### PR TITLE
fix: run all checks on PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to VDS
 on:
   push:
     branches: [ main ]
-    paths:
+    paths: # Main is locked in GitHub settings, don't bother runner on some checks passed in pull_request
       - 'Dockerfile'
       - 'docker-compose*'
       - '.github/workflows/deploy.yml'
@@ -11,15 +11,8 @@ on:
       - 'infra/**'
       - 'internal/**'
       - 'cmd/**'
-  pull_request:
-    paths:
-      - 'Dockerfile'
-      - 'docker-compose*'
-      - '.github/workflows/deploy.yml'
-      - 'prometheus.yml'
-      - 'infra/**'
-      - 'internal/**'
-      - 'cmd/**'
+  pull_request: # Run all checks despite changes so required checks are always satisfied
+                # There's no need to make this more complicated since the checks are fast (for now) and parallel
 
 permissions:
   contents: read


### PR DESCRIPTION
### Related Issues
Closes #29

### Summary
This change runs all PR checks despite changes. It's assumed that direct pushes to main are prohibited in the GitHub settings, and required checks such as linting, testing, and security scan are set up as well. This prevents any person from unchecked pushes to main, hence, preventing deploy.

### Verification
- [x] Verified project settings on Github
- [x] This change only expands check runs, so nothing can be broken

### Checklist
- [x] Code follows the style guidelines
- [ ] Unit tests added/updated
- [ ] Documentation updated
- [x] No sensitive data committed
