### PR TITLE
security: protect metrics endpoint

### DIFF
--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -54,7 +54,7 @@ func SetupDatabaseFromEnv(logger *slog.Logger, migrationsDir string) (*pgxpool.P
 	return pool, nil
 }
 
-func RunBackgroundServer(logger *slog.Logger, name string, addr string, handler http.Handler) *http.Server {
+func RunBackgroundServer(logger *slog.Logger, name, addr string, handler http.Handler) *http.Server {
 	srv := &http.Server{
 		Addr:    addr,
 		Handler: handler,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,6 +8,7 @@ pre-commit:
     swag:
       glob: "internal/handler/*.go"
       run: make swag && git diff --exit-code docs/ || (echo "Swagger documentation regenerated. Please stage the changes in docs/ and try again." && exit 1)
+
     lint:
       glob: "*.go"
       run: make lint

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -26,7 +26,7 @@ func TestAuth_HappyPath(t *testing.T) {
 
 	application := app.New(logger, pool, &cfg)
 
-	ts := httptest.NewServer(application.AdminRouter)
+	ts := httptest.NewServer(application.Router)
 	defer ts.Close()
 	client := ts.Client()
 


### PR DESCRIPTION
### Related Issues
Closes #31 

### Summary
This change runs 2 servers: one for the app for users, one for administration endpoints (only /metrics for now) on a separate port that is hidden by the ufw firewall during server setup using Ansible. This way, the endpoints become enclosed in the internal network.

### Verification
- [ ] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [ ] Unit tests added/updated
- [ ] Documentation updated
- [x] No sensitive data committed
