### PR TITLE
fix: remove ssh override files in Ansible

### DIFF
--- a/ansible/server-setup-ubuntu.yml
+++ b/ansible/server-setup-ubuntu.yml
@@ -104,6 +104,20 @@
         state: started
         enabled: yes
 
+    # For logging during deployment
+    - name: Check for SSH overrides in sshd_config.d
+      find:
+        paths: /etc/ssh/sshd_config.d
+        patterns: "*.conf"
+      register: sshd_overrides
+
+    - name: Remove SSH configuration overrides
+      file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ sshd_overrides.files }}"
+      notify: Restart SSH
+
     - name: SSH Hardening
       lineinfile:
         dest: /etc/ssh/sshd_config


### PR DESCRIPTION
### Related Issues
Closes #63

### Summary
This change removes shh config overrides supplied by hoster, avoiding unexpected behavior.

### Verification
- [x] I ran ubuntu-setup playbook manually and it banned password login

### Checklist
- [x] Code follows the style guidelines
- [ ] Unit tests added/updated
- [ ] Documentation updated
- [x] No sensitive data committed
