### PR TITLE
fix: report errors in all fields lazily

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -291,7 +291,7 @@ const docTemplate = `{
 var SwaggerInfo = &swag.Spec{
 	Version:          "",
 	Host:             "",
-	BasePath:         "/",
+	BasePath:         "/v1/",
 	Schemes:          []string{},
 	Title:            "Goroutine kanban API",
 	Description:      "A nice kanban board with a beautiful heart ✨",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5,7 +5,7 @@
         "title": "Goroutine kanban API",
         "contact": {}
     },
-    "basePath": "/",
+    "basePath": "/v1/",
     "paths": {
         "/v1/health": {
             "get": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,4 @@
-basePath: /
+basePath: /v1/
 definitions:
   handler.loginBody:
     properties:

--- a/internal/http/handler/auth.go
+++ b/internal/http/handler/auth.go
@@ -60,21 +60,11 @@ func (h *Auth) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	email, errs := domain.NewEmail(body.Email)
-	if len(errs) > 0 {
-		h.responder.BadRequest(
-			w, "VALIDATION_ERROR",
-			[]httpschema.Detail{{Field: "email", Issues: errs}},
-		)
-		return
-	}
-
-	password, errs := domain.NewPassword(body.Password)
-	if len(errs) > 0 {
-		h.responder.BadRequest(
-			w, "VALIDATION_ERROR",
-			[]httpschema.Detail{{Field: "password", Issues: errs}},
-		)
+	details := []httpschema.Detail{}
+	email := validateCredential("email", body.Email, domain.NewEmail, &details)
+	password := validateCredential("password", body.Password, domain.NewPassword, &details)
+	if len(details) > 0 {
+		h.responder.BadRequest(w, "VALIDATION_ERROR", details)
 		return
 	}
 
@@ -137,22 +127,11 @@ func (h *Auth) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: merge email and password into user to remove this mess
-	email, errs := domain.NewEmail(body.Email)
-	if len(errs) > 0 {
-		h.responder.BadRequest(
-			w, "VALIDATION_ERROR",
-			[]httpschema.Detail{{Field: "email", Issues: errs}},
-		)
-		return
-	}
-
-	password, errs := domain.NewPassword(body.Password)
-	if len(errs) > 0 {
-		h.responder.BadRequest(
-			w, "VALIDATION_ERROR",
-			[]httpschema.Detail{{Field: "password", Issues: errs}},
-		)
+	details := []httpschema.Detail{}
+	email := validateCredential("email", body.Email, domain.NewEmail, &details)
+	password := validateCredential("password", body.Password, domain.NewPassword, &details)
+	if len(details) > 0 {
+		h.responder.BadRequest(w, "VALIDATION_ERROR", details)
 		return
 	}
 
@@ -172,6 +151,14 @@ func (h *Auth) Login(w http.ResponseWriter, r *http.Request) {
 
 	h.logger.Info("Successfuly logged in user", slog.String("email", body.Email))
 	httpschema.RespondJSON(w, h.logger, http.StatusOK, loginResponse{Token: token})
+}
+
+func validateCredential[T any](field, val string, constructor func(string) (T, []string), details *[]httpschema.Detail) T {
+	res, errs := constructor(val)
+	if len(errs) > 0 {
+		*details = append(*details, httpschema.Detail{Field: field, Issues: errs})
+	}
+	return res
 }
 
 type whoAmIResponse struct {

--- a/internal/http/handler/auth_test.go
+++ b/internal/http/handler/auth_test.go
@@ -79,6 +79,12 @@ func TestAuth_Register(t *testing.T) {
 			expectedBody: fmt.Sprintf(`{"code":"VALIDATION_ERROR","message":"Some fields are invalid","timestamp":%q,"details":[{"field":"email","issues":["Invalid email"]}]}`, fixedTime),
 		},
 		{
+			name:         "Empty email and password",
+			inputBody:    fmt.Sprintf(`{"email": %q, "password": %q}`, "", ""),
+			expectedCode: http.StatusBadRequest,
+			expectedBody: fmt.Sprintf(`{"code":"VALIDATION_ERROR","message":"Some fields are invalid","timestamp":%q,"details":[{"field":"email","issues":["Invalid email"]},{"field":"password","issues":["Password is too short"]}]}`, fixedTime),
+		},
+		{
 			name:         "Empty password",
 			inputBody:    fmt.Sprintf(`{"email": %q, "password": %q}`, email, ""),
 			expectedCode: http.StatusBadRequest,
@@ -211,6 +217,12 @@ func TestAuth_Login(t *testing.T) {
 			inputBody:    fmt.Sprintf(`{"email": %q, "password": %q}`, "invalid-email", password),
 			expectedCode: http.StatusBadRequest,
 			expectedBody: fmt.Sprintf(`{"code":"VALIDATION_ERROR","message":"Some fields are invalid","timestamp":%q,"details":[{"field":"email","issues":["Invalid email"]}]}`, fixedTime),
+		},
+		{
+			name:         "Empty email and password",
+			inputBody:    fmt.Sprintf(`{"email": %q, "password": %q}`, "", ""),
+			expectedCode: http.StatusBadRequest,
+			expectedBody: fmt.Sprintf(`{"code":"VALIDATION_ERROR","message":"Some fields are invalid","timestamp":%q,"details":[{"field":"email","issues":["Invalid email"]},{"field":"password","issues":["Password is too short"]}]}`, fixedTime),
 		},
 		{
 			name:         "Empty password",


### PR DESCRIPTION
### Summary
- If both email and password are invalid, respond with two issue details instead of the first one
- Slightly more reusable validation code

### Verification
- [x] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [x] Unit tests added/updated
- [ ] Documentation updated
- [x] No sensitive data committed
