### PR TITLE
fix: swagger double /v1 prefix

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,7 +20,7 @@ var version = "no version bundled by linker"
 
 // @title Goroutine kanban API
 // @description A nice kanban board with a beautiful heart ✨
-// @BasePath /v1/
+// @BasePath /
 func main() {
 	if os.Getenv("ENV") != "prod" {
 		_ = godotenv.Load(".env.dev")

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -291,7 +291,7 @@ const docTemplate = `{
 var SwaggerInfo = &swag.Spec{
 	Version:          "",
 	Host:             "",
-	BasePath:         "/v1/",
+	BasePath:         "/",
 	Schemes:          []string{},
 	Title:            "Goroutine kanban API",
 	Description:      "A nice kanban board with a beautiful heart ✨",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5,7 +5,7 @@
         "title": "Goroutine kanban API",
         "contact": {}
     },
-    "basePath": "/v1/",
+    "basePath": "/",
     "paths": {
         "/v1/health": {
             "get": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,4 @@
-basePath: /v1/
+basePath: /
 definitions:
   handler.loginBody:
     properties:


### PR DESCRIPTION
### Related Issues
Fixes #126 

### Summary
#126 worked somehow, but today it started setting `/v1/v1/` for any API paths, so I fixed it by removing v1/ from `@BasePath` annotation.

### Verification
- [x] Swagger is able to send API requests both locally and on staging with no errors

### Checklist
- [x] Code follows the style guidelines
- [ ] Unit tests added/updated
- [x] Documentation updated
- [x] No sensitive data committed