### PR TITLE
feat: strip out uuids into {id}

### DIFF
--- a/internal/http/middleware/metrics.go
+++ b/internal/http/middleware/metrics.go
@@ -3,10 +3,27 @@ package middleware
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+func AbstractMetricPath(rawPath string) string {
+	segments := strings.Split(rawPath, "/")
+	for i, segment := range segments {
+		if segment == "" {
+			continue
+		}
+
+		if _, err := uuid.Parse(segment); err == nil {
+			segments[i] = "{id}"
+		}
+	}
+
+	return strings.Join(segments, "/")
+}
 
 type Metrics struct {
 	HttpRequests *prometheus.CounterVec
@@ -48,7 +65,7 @@ func (w *StatusSpyWriter) WriteHeader(code int) {
 
 func (m *Metrics) Wrap(next http.Handler) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
+		abstractPath := AbstractMetricPath(r.URL.Path)
 
 		startTime := time.Now()
 		spy := &StatusSpyWriter{ResponseWriter: w, StatusCode: http.StatusOK}
@@ -56,10 +73,10 @@ func (m *Metrics) Wrap(next http.Handler) http.HandlerFunc {
 		next.ServeHTTP(spy, r)
 
 		duration := time.Since(startTime).Seconds()
-		status := spy.StatusCode
+		responseStatus := spy.StatusCode
 		method := r.Method
 
-		m.HttpRequests.WithLabelValues(path, method, strconv.Itoa(status)).Inc()
-		m.HttpDuration.WithLabelValues(path, method).Observe(duration)
+		m.HttpRequests.WithLabelValues(abstractPath, method, strconv.Itoa(responseStatus)).Inc()
+		m.HttpDuration.WithLabelValues(abstractPath, method).Observe(duration)
 	})
 }

--- a/internal/http/middleware/metrics.go
+++ b/internal/http/middleware/metrics.go
@@ -10,21 +10,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func AbstractMetricPath(rawPath string) string {
-	segments := strings.Split(rawPath, "/")
-	for i, segment := range segments {
-		if segment == "" {
-			continue
-		}
-
-		if _, err := uuid.Parse(segment); err == nil {
-			segments[i] = "{id}"
-		}
-	}
-
-	return strings.Join(segments, "/")
-}
-
 type Metrics struct {
 	HttpRequests *prometheus.CounterVec
 	HttpDuration *prometheus.HistogramVec
@@ -79,4 +64,19 @@ func (m *Metrics) Wrap(next http.Handler) http.HandlerFunc {
 		m.HttpRequests.WithLabelValues(abstractPath, method, strconv.Itoa(responseStatus)).Inc()
 		m.HttpDuration.WithLabelValues(abstractPath, method).Observe(duration)
 	})
+}
+
+func AbstractMetricPath(rawPath string) string {
+	segments := strings.Split(rawPath, "/")
+	for i, segment := range segments {
+		if segment == "" {
+			continue
+		}
+
+		if _, err := uuid.Parse(segment); err == nil {
+			segments[i] = "{id}"
+		}
+	}
+
+	return strings.Join(segments, "/")
 }

--- a/internal/http/middleware/metrics_test.go
+++ b/internal/http/middleware/metrics_test.go
@@ -12,64 +12,105 @@ import (
 	promTestutil "github.com/prometheus/client_golang/prometheus/testutil"
 )
 
-func TestMetrics_Collection(t *testing.T) {
+func TestAbstractMetricPath(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name         string
-		path         string
-		method       string
-		expectedCode string
+		rawPath      string
+		abstractPath string
+	}{
+		{name: "Empty", rawPath: "", abstractPath: ""},
+		{name: "Root", rawPath: "/", abstractPath: "/"},
+		{name: "Static segments preserved", rawPath: "/v1/register", abstractPath: "/v1/register"},
+		{name: "UUID v7 segment abstracted", rawPath: "/v1/boards/018e1000-0000-7000-8000-000000000001", abstractPath: "/v1/boards/{id}"},
+		{name: "Several UUID segments", rawPath: "/v1/a/550e8400-e29b-41d4-a716-446655440000/b/018e1000-0000-7000-8000-000000000001", abstractPath: "/v1/a/{id}/b/{id}"},
+		{name: "Opaque slug not UUID", rawPath: "/v1/boards/not-a-uuid", abstractPath: "/v1/boards/not-a-uuid"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			have := middleware.AbstractMetricPath(tt.rawPath)
+			if have != tt.abstractPath {
+				t.Errorf("AbstractMetricPath(%q) = %q, want %q", tt.rawPath, have, tt.abstractPath)
+			}
+		})
+	}
+}
+
+func TestMetrics_Collection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		requestPath   string
+		abstractPath  string
+		method        string
+		handlerStatus int
 	}{
 		{
-			name:         "Count successful register",
-			path:         "/v1/register",
-			method:       http.MethodPost,
-			expectedCode: "200",
+			name:          "register 200",
+			requestPath:   "/v1/register",
+			abstractPath:  "/v1/register",
+			method:        http.MethodPost,
+			handlerStatus: http.StatusOK,
 		},
 		{
-			name:         "Count failed health",
-			path:         "/v1/health",
-			method:       http.MethodGet,
-			expectedCode: "403",
+			name:          "health 403",
+			requestPath:   "/v1/health",
+			abstractPath:  "/v1/health",
+			method:        http.MethodGet,
+			handlerStatus: http.StatusForbidden,
+		},
+		{
+			name:          "board by id path label uses placeholder",
+			requestPath:   "/v1/boards/550e8400-e29b-41d4-a716-446655440000",
+			abstractPath:  "/v1/boards/{id}",
+			method:        http.MethodGet,
+			handlerStatus: http.StatusOK,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				code, _ := strconv.Atoi(tt.expectedCode)
-				w.WriteHeader(code)
+				w.WriteHeader(tt.handlerStatus)
 			})
 
 			reg := prometheus.NewRegistry()
 			mw := middleware.NewMetrics(reg)
 			wrapped := mw.Wrap(handler)
 
-			req, rr := testutil.NewJSONRequestAndRecorder(t, tt.method, tt.path, "")
+			req, rr := testutil.NewJSONRequestAndRecorder(t, tt.method, tt.requestPath, "")
 
 			wrapped.ServeHTTP(rr, req)
 
-			code := strconv.Itoa(rr.Code)
-			if code != tt.expectedCode {
-				t.Errorf("Middleware modified status code: expected %q, got %q", tt.expectedCode, code)
+			responseStatus := strconv.Itoa(rr.Code)
+			handlerStatusStr := strconv.Itoa(tt.handlerStatus)
+			if responseStatus != handlerStatusStr {
+				t.Errorf("recorder status %q, want %q (handler wrote %d)", responseStatus, handlerStatusStr, tt.handlerStatus)
 			}
 
-			count := promTestutil.ToFloat64(mw.HttpRequests.With(prometheus.Labels{
-				"path":   tt.path,
+			requestCount := promTestutil.ToFloat64(mw.HttpRequests.With(prometheus.Labels{
+				"path":   tt.abstractPath,
 				"method": tt.method,
-				"status": tt.expectedCode,
+				"status": handlerStatusStr,
 			}))
 
-			if count != 1 {
-				t.Errorf("Expected count = 1, got %f", count)
+			if requestCount != 1 {
+				t.Errorf("http_requests_total for path=%q method=%q status=%q: got %f, want 1",
+					tt.abstractPath,
+					tt.method,
+					handlerStatusStr,
+					requestCount,
+				)
 			}
 
-			histCount := promTestutil.CollectAndCount(mw.HttpDuration)
-			if histCount == 0 {
-				t.Errorf("Expected histogram to capture observation")
+			histogramSamples := promTestutil.CollectAndCount(mw.HttpDuration)
+			if histogramSamples == 0 {
+				t.Errorf("http_request_duration_seconds: no observations")
 			}
 		})
 	}


### PR DESCRIPTION
### Related Issues
Related to #105 

### Summary
This change makes sure the metrics middleware turns UUIDs into {id} placeholders so Prometheus won't have cardinality explosion (one DB key per item).

### Verification
- [x] Tests extended
- [x] Tests green 

### Checklist
- [x] Code follows the style guidelines
- [x] Unit tests added/updated
- [ ] Documentation updated
- [x] No sensitive data committed
