### PR TITLE
feat: columns api create

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -304,6 +304,76 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/boards/{boardId}/columns": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new column in board for the current user. Column is appended to the end.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "columns"
+                ],
+                "summary": "Create a new column",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Column details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.createColumnBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.columnResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "BOARD_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/health": {
             "get": {
                 "description": "Check if the server is alive",
@@ -490,6 +560,35 @@ const docTemplate = `{
                 }
             }
         },
+        "handler.columnResponse": {
+            "type": "object",
+            "properties": {
+                "boardId": {
+                    "type": "string",
+                    "example": "019cc971-e5be-7df9-ae8a-c6e3f29c86a1"
+                },
+                "createdAt": {
+                    "type": "string",
+                    "example": "2026-03-07T20:56:50.000+03:00"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "019cc971-e5be-7df9-ae8a-c6e3f29c86a2"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "In Progress"
+                },
+                "position": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "example": "2026-03-07T20:56:50.000+03:00"
+                }
+            }
+        },
         "handler.createBoardBody": {
             "type": "object",
             "properties": {
@@ -500,6 +599,15 @@ const docTemplate = `{
                 "name": {
                     "type": "string",
                     "example": "My Board Name"
+                }
+            }
+        },
+        "handler.createColumnBody": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "example": "To Do"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -296,6 +296,76 @@
                 }
             }
         },
+        "/v1/boards/{boardId}/columns": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new column in board for the current user. Column is appended to the end.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "columns"
+                ],
+                "summary": "Create a new column",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Column details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.createColumnBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.columnResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "BOARD_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/health": {
             "get": {
                 "description": "Check if the server is alive",
@@ -482,6 +552,35 @@
                 }
             }
         },
+        "handler.columnResponse": {
+            "type": "object",
+            "properties": {
+                "boardId": {
+                    "type": "string",
+                    "example": "019cc971-e5be-7df9-ae8a-c6e3f29c86a1"
+                },
+                "createdAt": {
+                    "type": "string",
+                    "example": "2026-03-07T20:56:50.000+03:00"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "019cc971-e5be-7df9-ae8a-c6e3f29c86a2"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "In Progress"
+                },
+                "position": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "example": "2026-03-07T20:56:50.000+03:00"
+                }
+            }
+        },
         "handler.createBoardBody": {
             "type": "object",
             "properties": {
@@ -492,6 +591,15 @@
                 "name": {
                     "type": "string",
                     "example": "My Board Name"
+                }
+            }
+        },
+        "handler.createColumnBody": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "example": "To Do"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -21,6 +21,27 @@ definitions:
         example: "2026-03-07T20:56:50.000+03:00"
         type: string
     type: object
+  handler.columnResponse:
+    properties:
+      boardId:
+        example: 019cc971-e5be-7df9-ae8a-c6e3f29c86a1
+        type: string
+      createdAt:
+        example: "2026-03-07T20:56:50.000+03:00"
+        type: string
+      id:
+        example: 019cc971-e5be-7df9-ae8a-c6e3f29c86a2
+        type: string
+      name:
+        example: In Progress
+        type: string
+      position:
+        example: 1
+        type: integer
+      updatedAt:
+        example: "2026-03-07T20:56:50.000+03:00"
+        type: string
+    type: object
   handler.createBoardBody:
     properties:
       description:
@@ -28,6 +49,12 @@ definitions:
         type: string
       name:
         example: My Board Name
+        type: string
+    type: object
+  handler.createColumnBody:
+    properties:
+      name:
+        example: To Do
         type: string
     type: object
   handler.loginBody:
@@ -308,6 +335,52 @@ paths:
       summary: UpdateByID a board by id
       tags:
       - boards
+  /v1/boards/{boardId}/columns:
+    post:
+      consumes:
+      - application/json
+      description: Create a new column in board for the current user. Column is appended
+        to the end.
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardId
+        required: true
+        type: string
+      - description: Column details
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handler.createColumnBody'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/handler.columnResponse'
+        "400":
+          description: VALIDATION_ERROR
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "401":
+          description: 'Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER'
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "404":
+          description: BOARD_NOT_FOUND
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/httpschema.Error'
+      security:
+      - BearerAuth: []
+      summary: Create a new column
+      tags:
+      - columns
   /v1/health:
     get:
       description: Check if the server is alive

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -28,6 +28,7 @@ type App struct {
 func New(logger *slog.Logger, pool *pgxpool.Pool, cfg *config.AppConfig, reg prometheus.Registerer) *App {
 	userRepo := repository.NewPgUser(pool)
 	boardsRepo := repository.NewPgBoard(pool)
+	columnsRepo := repository.NewPgColumn(pool)
 
 	authService := service.NewAuth(userRepo, service.JWTOptions{
 		JWTSecret:     cfg.JWTSecret,
@@ -35,12 +36,14 @@ func New(logger *slog.Logger, pool *pgxpool.Pool, cfg *config.AppConfig, reg pro
 		SigningMethod: jwt.SigningMethodHS256,
 	})
 	boardsService := service.NewBoard(service.BoardRepository(boardsRepo), service.TimeNow)
+	columnsService := service.NewColumn(service.ColumnRepository(columnsRepo), service.ColumnBoardRepository(boardsRepo), service.TimeNow)
 
 	responder := httpschema.MustNewErrorResponder(logger, service.TimeNowRFC3339Millis)
 
 	authHandler := handler.NewAuth(logger, authService, responder)
 	healthHandler := handler.NewHealth(logger)
 	boardsHandler := handler.NewBoards(logger, boardsService, responder)
+	columnsHandler := handler.NewColumns(logger, columnsService, responder)
 
 	metricsMiddleware := middleware.NewMetrics(reg)
 	corsMiddleware := middleware.NewCORS(logger, cfg.AllowedOrigins)
@@ -49,7 +52,7 @@ func New(logger *slog.Logger, pool *pgxpool.Pool, cfg *config.AppConfig, reg pro
 		return fmt.Sprintf("req-%s", uuid.Must(uuid.NewV7()))
 	})
 
-	handlers := &handler.Handlers{Auth: authHandler, Health: healthHandler, Boards: boardsHandler}
+	handlers := &handler.Handlers{Auth: authHandler, Health: healthHandler, Boards: boardsHandler, Columns: columnsHandler}
 	middlewares := &middleware.Middlewares{
 		Metrics:   metricsMiddleware,
 		CORS:      corsMiddleware,

--- a/internal/domain/column.go
+++ b/internal/domain/column.go
@@ -108,21 +108,12 @@ func (p *ColumnPosition) Scan(value any) error {
 		return nil
 	}
 
-	var parsed int64
-	switch v := value.(type) {
-	case int64:
-		parsed = v
-	case int32:
-		parsed = int64(v)
-	case int:
-		parsed = int64(v)
-	case float64:
-		parsed = int64(v)
-	default:
+	v, ok := value.(int64)
+	if !ok {
 		return fmt.Errorf("unexpected type for ColumnPosition: %T", value)
 	}
 
-	position, err := NewColumnPosition(parsed)
+	position, err := NewColumnPosition(v)
 	if err != nil {
 		return fmt.Errorf("column position: %w: %v", ErrDataCorrupted, err)
 	}

--- a/internal/domain/column.go
+++ b/internal/domain/column.go
@@ -1,0 +1,157 @@
+package domain
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	ErrColumnNameTooShort  = "Name is too short"
+	ErrColumnNameTooLong   = "Name is too long"
+	ErrColumnPositionValue = "Position is invalid"
+)
+
+type Column struct {
+	ID        ColumnID
+	BoardID   BoardID
+	Name      ColumnName
+	Position  ColumnPosition
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type ColumnName struct {
+	value string
+}
+
+func NewColumnName(name string) (ColumnName, error) {
+	trimmedName := strings.TrimSpace(name)
+	var issues []string
+	if trimmedName == "" {
+		issues = append(issues, ErrColumnNameTooShort)
+	}
+	if len(trimmedName) > 128 {
+		issues = append(issues, ErrColumnNameTooLong)
+	}
+	if len(issues) > 0 {
+		return ColumnName{}, &ErrValidation{Issues: issues}
+	}
+
+	return ColumnName{value: trimmedName}, nil
+}
+
+func (n ColumnName) IsEmpty() bool {
+	return n.value == ""
+}
+
+func (n ColumnName) String() string {
+	return n.value
+}
+
+func (n ColumnName) Value() (driver.Value, error) {
+	return n.value, nil
+}
+
+func (n *ColumnName) Scan(value any) error {
+	if value == nil {
+		n.value = ""
+		return nil
+	}
+	s, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("unexpected type for ColumnName: %T", value)
+	}
+	cn, err := NewColumnName(s)
+	if err != nil {
+		return fmt.Errorf("column name: %w: %v", ErrDataCorrupted, err)
+	}
+	*n = cn
+	return nil
+}
+
+type ColumnPosition struct {
+	value int32
+}
+
+func NewColumnPosition(position int64) (ColumnPosition, error) {
+	if position <= 0 || position > math.MaxInt32 {
+		return ColumnPosition{}, &ErrValidation{Issues: []string{ErrColumnPositionValue}}
+	}
+
+	return ColumnPosition{value: int32(position)}, nil
+}
+
+func ParseColumnPosition(position string) (ColumnPosition, error) {
+	v, err := strconv.ParseInt(position, 10, 64)
+	if err != nil {
+		return ColumnPosition{}, &ErrValidation{Issues: []string{ErrColumnPositionValue}}
+	}
+
+	return NewColumnPosition(v)
+}
+
+func (p ColumnPosition) Int64() int64 {
+	return int64(p.value)
+}
+
+func (p ColumnPosition) Value() (driver.Value, error) {
+	return p.value, nil
+}
+
+func (p *ColumnPosition) Scan(value any) error {
+	if value == nil {
+		p.value = 0
+		return nil
+	}
+
+	var parsed int64
+	switch v := value.(type) {
+	case int64:
+		parsed = v
+	case int32:
+		parsed = int64(v)
+	case int:
+		parsed = int64(v)
+	case float64:
+		parsed = int64(v)
+	default:
+		return fmt.Errorf("unexpected type for ColumnPosition: %T", value)
+	}
+
+	position, err := NewColumnPosition(parsed)
+	if err != nil {
+		return fmt.Errorf("column position: %w: %v", ErrDataCorrupted, err)
+	}
+
+	*p = position
+	return nil
+}
+
+func (c Column) String() string {
+	return fmt.Sprintf(
+		"id:        %s\nboardId:   %s\nname:      %q\nposition:  %d\ncreatedAt: %s\nupdatedAt: %s",
+		c.ID.String(),
+		c.BoardID.String(),
+		c.Name.String(),
+		c.Position.Int64(),
+		c.CreatedAt.UTC().Format(time.RFC3339Nano),
+		c.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	)
+}
+
+type (
+	columnTag struct{}
+	ColumnID  = UUID[columnTag]
+)
+
+func NewColumnID() ColumnID {
+	return NewID[columnTag]()
+}
+
+func ParseColumnID(s string) (ColumnID, error) {
+	return ParseID[columnTag](s)
+}

--- a/internal/domain/column_test.go
+++ b/internal/domain/column_test.go
@@ -53,6 +53,37 @@ func TestColumnName(t *testing.T) {
 	}
 }
 
+func TestParseColumnPosition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "Valid", input: "1"},
+		{name: "Zero", input: "0", wantErr: true},
+		{name: "Negative", input: "-1", wantErr: true},
+		{name: "Greater than int32", input: "2147483648", wantErr: true},
+		{name: "Greater than int64", input: "9223372036854775808", wantErr: true},
+		{name: "Not a number", input: "abc", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := domain.ParseColumnPosition(tt.input)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("did not expect error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestColumnPosition(t *testing.T) {
 	t.Parallel()
 
@@ -141,11 +172,10 @@ func TestColumnPosition_Scan(t *testing.T) {
 		wantErr bool
 		errIs   error
 	}{
-		{name: "Valid int32", input: int32(1)},
-		{name: "Valid int64", input: int64(2)},
+		{name: "Valid int64", input: int64(1)},
 		{name: "Zero", input: int64(0), wantErr: true, errIs: domain.ErrDataCorrupted},
-		{name: "Overflow", input: int64(math.MaxInt32 + 1), wantErr: true, errIs: domain.ErrDataCorrupted},
 		{name: "Nil", input: nil},
+		{name: "Int32 is rejected", input: int32(2), wantErr: true},
 		{name: "Bad type", input: "abc", wantErr: true},
 	}
 

--- a/internal/domain/column_test.go
+++ b/internal/domain/column_test.go
@@ -1,0 +1,172 @@
+package domain_test
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	"goroutine/internal/domain"
+)
+
+func TestColumnName(t *testing.T) {
+	t.Parallel()
+
+	borderlineLongName := strings.Repeat("a", 128)
+	tests := []struct {
+		name           string
+		input          string
+		expectedIssues []string
+		expectedValue  string
+	}{
+		{name: "Valid", input: "In Progress", expectedValue: "In Progress"},
+		{name: "Long valid", input: borderlineLongName, expectedValue: borderlineLongName},
+		{name: "Too long but valid when trimmed", input: "   " + borderlineLongName + "   ", expectedValue: borderlineLongName},
+		{name: "Too long", input: borderlineLongName + "a", expectedIssues: []string{domain.ErrColumnNameTooLong}},
+		{name: "Empty", input: "", expectedIssues: []string{domain.ErrColumnNameTooShort}},
+		{name: "Whitespace", input: "   ", expectedIssues: []string{domain.ErrColumnNameTooShort}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			name, err := domain.NewColumnName(tt.input)
+			var actualIssues []string
+			if err != nil {
+				var ve *domain.ErrValidation
+				if errors.As(err, &ve) {
+					actualIssues = ve.Issues
+				} else {
+					actualIssues = []string{err.Error()}
+				}
+			}
+
+			if !reflect.DeepEqual(actualIssues, tt.expectedIssues) {
+				t.Errorf("expected issues %v, got %v", tt.expectedIssues, actualIssues)
+			}
+			if name.String() != tt.expectedValue {
+				t.Errorf("expected value %q, got %q", tt.expectedValue, name.String())
+			}
+		})
+	}
+}
+
+func TestColumnPosition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		input          int64
+		expectedIssues []string
+		expectedValue  int64
+	}{
+		{name: "Valid", input: 1, expectedValue: 1},
+		{name: "Valid max int32", input: math.MaxInt32, expectedValue: math.MaxInt32},
+		{name: "Zero", input: 0, expectedIssues: []string{domain.ErrColumnPositionValue}},
+		{name: "Negative", input: -10, expectedIssues: []string{domain.ErrColumnPositionValue}},
+		{name: "Overflow", input: math.MaxInt32 + 1, expectedIssues: []string{domain.ErrColumnPositionValue}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			position, err := domain.NewColumnPosition(tt.input)
+			var actualIssues []string
+			if err != nil {
+				var ve *domain.ErrValidation
+				if errors.As(err, &ve) {
+					actualIssues = ve.Issues
+				} else {
+					actualIssues = []string{err.Error()}
+				}
+			}
+
+			if !reflect.DeepEqual(actualIssues, tt.expectedIssues) {
+				t.Errorf("expected issues %v, got %v", tt.expectedIssues, actualIssues)
+			}
+			if tt.expectedIssues == nil && position.Int64() != tt.expectedValue {
+				t.Errorf("expected value %d, got %d", tt.expectedValue, position.Int64())
+			}
+		})
+	}
+}
+
+func TestColumnName_Scan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   any
+		wantErr bool
+		errIs   error
+	}{
+		{name: "Valid", input: "Todo"},
+		{name: "Too long", input: strings.Repeat("a", 129), wantErr: true, errIs: domain.ErrDataCorrupted},
+		{name: "Empty", input: "", wantErr: true, errIs: domain.ErrDataCorrupted},
+		{name: "Nil", input: nil},
+		{name: "Bad type", input: 1, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var name domain.ColumnName
+			err := name.Scan(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				} else if tt.errIs != nil && !errors.Is(err, tt.errIs) {
+					t.Errorf("expected error %v, got %v", tt.errIs, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("did not expect error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestColumnPosition_Scan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   any
+		wantErr bool
+		errIs   error
+	}{
+		{name: "Valid int32", input: int32(1)},
+		{name: "Valid int64", input: int64(2)},
+		{name: "Zero", input: int64(0), wantErr: true, errIs: domain.ErrDataCorrupted},
+		{name: "Overflow", input: int64(math.MaxInt32 + 1), wantErr: true, errIs: domain.ErrDataCorrupted},
+		{name: "Nil", input: nil},
+		{name: "Bad type", input: "abc", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var position domain.ColumnPosition
+			err := position.Scan(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				} else if tt.errIs != nil && !errors.Is(err, tt.errIs) {
+					t.Errorf("expected error %v, got %v", tt.errIs, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("did not expect error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/http/handler/columns.go
+++ b/internal/http/handler/columns.go
@@ -1,0 +1,125 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"goroutine/internal/domain"
+	"goroutine/internal/http/httpschema"
+	"goroutine/internal/service"
+)
+
+type ColumnsService interface {
+	Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error)
+}
+
+type Columns struct {
+	logger    *slog.Logger
+	service   ColumnsService
+	responder *httpschema.ErrorResponder
+}
+
+func NewColumns(logger *slog.Logger, svc ColumnsService, responder *httpschema.ErrorResponder) *Columns {
+	return &Columns{logger: logger, service: svc, responder: responder}
+}
+
+type createColumnBody struct {
+	Name string `json:"name" example:"To Do"`
+}
+
+type columnResponse struct {
+	ID        string `json:"id" example:"019cc971-e5be-7df9-ae8a-c6e3f29c86a2"`
+	BoardID   string `json:"boardId" example:"019cc971-e5be-7df9-ae8a-c6e3f29c86a1"`
+	Name      string `json:"name" example:"In Progress"`
+	Position  int64  `json:"position" example:"1"`
+	CreatedAt string `json:"createdAt" example:"2026-03-07T20:56:50.000+03:00"`
+	UpdatedAt string `json:"updatedAt" example:"2026-03-07T20:56:50.000+03:00"`
+}
+
+func NewColumnResponse(column *domain.Column) columnResponse {
+	return columnResponse{
+		ID:        column.ID.String(),
+		BoardID:   column.BoardID.String(),
+		Name:      column.Name.String(),
+		Position:  column.Position.Int64(),
+		CreatedAt: service.FormatRFC3339Millis(column.CreatedAt),
+		UpdatedAt: service.FormatRFC3339Millis(column.UpdatedAt),
+	}
+}
+
+// Create godoc
+// @Summary Create a new column
+// @Description Create a new column in board for the current user. Column is appended to the end.
+// @Tags columns
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param boardId path string true "Board ID"
+// @Param body body createColumnBody true "Column details"
+// @Success 201 {object} columnResponse
+// @Failure 400 {object} httpschema.DetailedError "VALIDATION_ERROR"
+// @Failure 401 {object} httpschema.DetailedError "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER"
+// @Failure 404 {object} httpschema.DetailedError "BOARD_NOT_FOUND"
+// @Failure 500 {object} httpschema.Error "Internal server error"
+// @Router /v1/boards/{boardId}/columns [post]
+func (h *Columns) Create(w http.ResponseWriter, r *http.Request) {
+	rawBoardID := r.PathValue("boardId")
+	boardID, err := domain.ParseBoardID(rawBoardID)
+	if err != nil {
+		h.responder.ValidationError(w, []httpschema.Detail{{Field: "boardId", Issues: []string{"Invalid board id"}}})
+		return
+	}
+
+	var body createColumnBody
+	if err = json.NewDecoder(r.Body).Decode(&body); err != nil {
+		h.responder.ValidationError(w, []httpschema.Detail{{Field: "body", Issues: []string{"Invalid JSON body"}}})
+		return
+	}
+
+	details := []httpschema.Detail{}
+	name := httpschema.ValidateField("name", body.Name, domain.NewColumnName, &details)
+	if len(details) > 0 {
+		h.responder.ValidationError(w, details)
+		return
+	}
+
+	userID, ok := h.extractUserIDOrHandleMissing(w, r)
+	if !ok {
+		return
+	}
+
+	column, err := h.service.Create(r.Context(), userID, boardID, name)
+	if err != nil {
+		if errors.Is(err, service.ErrBoardNotFound) {
+			h.responder.BoardNotFound(w, []httpschema.Detail{{Field: "boardId", Issues: []string{"Board not found"}}})
+			return
+		}
+		h.responder.InternalError(w, r, err)
+		return
+	}
+
+	httpschema.RespondJSON(w, h.logger, http.StatusCreated, NewColumnResponse(&column))
+}
+
+func (h *Columns) extractUserIDOrHandleMissing(w http.ResponseWriter, r *http.Request) (domain.UserID, bool) {
+	valid := true
+
+	userID, ok := r.Context().Value(httpschema.ContextKeyUserID).(domain.UserID)
+	if !ok {
+		valid = false
+	}
+	if userID.IsEmpty() {
+		valid = false
+	}
+
+	if !valid {
+		h.logger.ErrorContext(r.Context(), "BUG: valid UserID not found in context. Middleware should have handled this.")
+		h.responder.InvalidToken(w, []httpschema.Detail{{Field: "Authorization", Issues: []string{"Invalid token"}}})
+		return domain.UserID{}, false
+	}
+
+	return userID, true
+}

--- a/internal/http/handler/columns_test.go
+++ b/internal/http/handler/columns_test.go
@@ -1,0 +1,171 @@
+package handler_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"goroutine/internal/domain"
+	"goroutine/internal/http/handler"
+	"goroutine/internal/http/httpschema"
+	"goroutine/internal/service"
+	"goroutine/internal/testutil"
+)
+
+func TestColumns_Create(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumnName, _ := domain.NewColumnName("To Do")
+	validPosition, _ := domain.NewColumnPosition(1)
+	validColumn := domain.Column{
+		ID:        domain.NewColumnID(),
+		BoardID:   validBoard.ID,
+		Name:      validColumnName,
+		Position:  validPosition,
+		CreatedAt: testutil.FixedTimeNow(),
+		UpdatedAt: testutil.FixedTimeNow(),
+	}
+
+	tests := []struct {
+		name         string
+		path         string
+		inputBody    any
+		context      context.Context
+		setupMock    func(s *MockColumns)
+		expectedCode int
+		expectedBody any
+	}{
+		{
+			name:      "Success",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns",
+			inputBody: map[string]string{"name": validColumn.Name.String()},
+			setupMock: func(s *MockColumns) {
+				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
+					if callerID != validBoard.OwnerID {
+						t.Errorf("expected caller id %v, got %v", validBoard.OwnerID, callerID)
+					}
+					if boardID != validBoard.ID {
+						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+					}
+					if name != validColumn.Name {
+						t.Errorf("expected name %v, got %v", validColumn.Name, name)
+					}
+					return validColumn, nil
+				}
+			},
+			expectedCode: http.StatusCreated,
+			expectedBody: map[string]any{
+				"id":        validColumn.ID.String(),
+				"boardId":   validColumn.BoardID.String(),
+				"name":      validColumn.Name.String(),
+				"position":  float64(validColumn.Position.Int64()),
+				"createdAt": validColumn.CreatedAt.Format(timeFormat),
+				"updatedAt": validColumn.UpdatedAt.Format(timeFormat),
+			},
+		},
+		{
+			name:         "Invalid board id",
+			path:         "/v1/boards/not-a-uuid/columns",
+			inputBody:    map[string]string{"name": "To Do"},
+			expectedCode: http.StatusBadRequest,
+			expectedBody: validationErrorBody("boardId", []string{"Invalid board id"}),
+		},
+		{
+			name:         "Invalid JSON",
+			path:         "/v1/boards/" + validBoard.ID.String() + "/columns",
+			inputBody:    "{\"name\":\"broken\"",
+			expectedCode: http.StatusBadRequest,
+			expectedBody: invalidJsonBody(),
+		},
+		{
+			name:         "Invalid name",
+			path:         "/v1/boards/" + validBoard.ID.String() + "/columns",
+			inputBody:    map[string]string{"name": "   "},
+			expectedCode: http.StatusBadRequest,
+			expectedBody: validationErrorBody("name", []string{"Name is too short"}),
+		},
+		{
+			name:         "Missing context user",
+			path:         "/v1/boards/" + validBoard.ID.String() + "/columns",
+			inputBody:    map[string]string{"name": "To Do"},
+			context:      context.Background(),
+			expectedCode: http.StatusUnauthorized,
+			expectedBody: unauthorizedTokenBody(),
+		},
+		{
+			name:      "Board not found",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns",
+			inputBody: map[string]string{"name": "To Do"},
+			setupMock: func(s *MockColumns) {
+				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
+					return domain.Column{}, service.ErrBoardNotFound
+				}
+			},
+			expectedCode: http.StatusNotFound,
+			expectedBody: boardNotFoundErrorBody(),
+		},
+		{
+			name:      "Internal error",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns",
+			inputBody: map[string]string{"name": "To Do"},
+			setupMock: func(s *MockColumns) {
+				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
+					return domain.Column{}, service.ErrInternal
+				}
+			},
+			expectedCode: http.StatusInternalServerError,
+			expectedBody: internalErrorBody(),
+		},
+		{
+			name:      "Unexpected error",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns",
+			inputBody: map[string]string{"name": "To Do"},
+			setupMock: func(s *MockColumns) {
+				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
+					return domain.Column{}, errors.New("db exploded")
+				}
+			},
+			expectedCode: http.StatusInternalServerError,
+			expectedBody: internalErrorBody(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var req *http.Request
+			if raw, ok := tt.inputBody.(string); ok {
+				req = httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(raw))
+				req.Header.Set("Content-Type", "application/json")
+			} else {
+				req, _ = testutil.NewJSONRequestAndRecorder(t, http.MethodPost, tt.path, tt.inputBody)
+			}
+
+			if tt.context != nil {
+				req = req.WithContext(tt.context)
+			} else {
+				req = req.WithContext(context.WithValue(req.Context(), httpschema.ContextKeyUserID, validBoard.OwnerID))
+			}
+			req.SetPathValue("boardId", strings.TrimPrefix(strings.TrimSuffix(tt.path, "/columns"), "/v1/boards/"))
+
+			rr := httptest.NewRecorder()
+			mockColumns := &MockColumns{}
+			if tt.setupMock != nil {
+				tt.setupMock(mockColumns)
+			}
+
+			logger := testutil.NewTestLogger(t)
+			h := handler.NewColumns(logger, mockColumns, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
+			h.Create(rr, req)
+
+			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			testutil.AssertContentType(t, rr, "application/json")
+			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+		})
+	}
+}

--- a/internal/http/handler/columns_test.go
+++ b/internal/http/handler/columns_test.go
@@ -19,16 +19,7 @@ func TestColumns_Create(t *testing.T) {
 	t.Parallel()
 
 	validBoard := testutil.ValidBoard()
-	validColumnName, _ := domain.NewColumnName("To Do")
-	validPosition, _ := domain.NewColumnPosition(1)
-	validColumn := domain.Column{
-		ID:        domain.NewColumnID(),
-		BoardID:   validBoard.ID,
-		Name:      validColumnName,
-		Position:  validPosition,
-		CreatedAt: testutil.FixedTimeNow(),
-		UpdatedAt: testutil.FixedTimeNow(),
-	}
+	validColumn := testutil.ValidColumn(validBoard.ID)
 
 	tests := []struct {
 		name         string

--- a/internal/http/handler/handlers.go
+++ b/internal/http/handler/handlers.go
@@ -1,15 +1,17 @@
 package handler
 
 type Handlers struct {
-	Auth   *Auth
-	Health *Health
-	Boards *Boards
+	Auth    *Auth
+	Health  *Health
+	Boards  *Boards
+	Columns *Columns
 }
 
-func NewHandlers(auth *Auth, health *Health, boards *Boards) *Handlers {
+func NewHandlers(auth *Auth, health *Health, boards *Boards, columns *Columns) *Handlers {
 	return &Handlers{
-		Auth:   auth,
-		Health: health,
-		Boards: boards,
+		Auth:    auth,
+		Health:  health,
+		Boards:  boards,
+		Columns: columns,
 	}
 }

--- a/internal/http/handler/helpers_test.go
+++ b/internal/http/handler/helpers_test.go
@@ -37,6 +37,10 @@ type MockBoards struct {
 	DeleteFunc     func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) error
 }
 
+type MockColumns struct {
+	CreateFunc func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error)
+}
+
 func (m *MockBoards) Get(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
 	AssertFuncNotNil("BoardsService.GetFunc", m.GetFunc)
 	return m.GetFunc(ctx, ownerID, boardID)
@@ -60,6 +64,11 @@ func (m *MockBoards) UpdateByID(ctx context.Context, ownerID domain.UserID, boar
 func (m *MockBoards) Delete(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) error {
 	AssertFuncNotNil("BoardsService.DeleteFunc", m.DeleteFunc)
 	return m.DeleteFunc(ctx, ownerID, boardID)
+}
+
+func (m *MockColumns) Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
+	AssertFuncNotNil("ColumnsService.CreateFunc", m.CreateFunc)
+	return m.CreateFunc(ctx, callerID, boardID, name)
 }
 
 func invalidJsonBody() map[string]any {
@@ -86,6 +95,17 @@ func notFoundErrorBody() map[string]any {
 		"code":      "NOT_FOUND",
 		"message":   "Resource not found",
 		"timestamp": testutil.FixedTimeNowStr(),
+	}
+}
+
+func boardNotFoundErrorBody() map[string]any {
+	return map[string]any{
+		"code":      "BOARD_NOT_FOUND",
+		"message":   "Board not found",
+		"timestamp": testutil.FixedTimeNowStr(),
+		"details": []any{
+			map[string]any{"field": "boardId", "issues": []string{"Board not found"}},
+		},
 	}
 }
 

--- a/internal/http/httpschema/code_map.go
+++ b/internal/http/httpschema/code_map.go
@@ -5,6 +5,7 @@ var codeMap = map[string]string{
 	"VALIDATION_ERROR":      "Some fields are invalid",
 	"INTERNAL_SERVER_ERROR": "Internal server error",
 	"NOT_FOUND":             "Resource not found",
+	"BOARD_NOT_FOUND":       "Board not found",
 	"INVALID_AUTH_HEADER":   "Invalid authorization header",
 	"USER_NOT_FOUND":        "User not found",
 	"INVALID_TOKEN":         "Invalid token",

--- a/internal/http/httpschema/error_responder.go
+++ b/internal/http/httpschema/error_responder.go
@@ -29,6 +29,10 @@ func (r *ErrorResponder) NotFound(w http.ResponseWriter, details []Detail) {
 	r.DetailedError(w, http.StatusNotFound, "NOT_FOUND", details)
 }
 
+func (r *ErrorResponder) BoardNotFound(w http.ResponseWriter, details []Detail) {
+	r.DetailedError(w, http.StatusNotFound, "BOARD_NOT_FOUND", details)
+}
+
 func (r *ErrorResponder) UserNotFound(w http.ResponseWriter, details []Detail) {
 	r.DetailedError(w, http.StatusUnauthorized, "USER_NOT_FOUND", details)
 }

--- a/internal/http/route.go
+++ b/internal/http/route.go
@@ -26,6 +26,7 @@ func NewRouter(h *handler.Handlers, m *middleware.Middlewares) http.Handler {
 	mux.Handle("PATCH /v1/boards/{boardId}", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Boards.UpdateByID))))
 	mux.Handle("DELETE /v1/boards/{boardId}", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Boards.Delete))))
 	mux.Handle("GET /v1/boards", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Boards.GetMany))))
+	mux.Handle("POST /v1/boards/{boardId}/columns", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Columns.Create))))
 	mux.Handle("GET "+swaggerBasePath, NewSwaggerHandler(swaggerBasePath, loginPath))
 
 	return m.RequestID.Wrap(m.CORS.Wrap(mux))

--- a/internal/repository/column.go
+++ b/internal/repository/column.go
@@ -1,0 +1,66 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"goroutine/internal/domain"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type PgColumn struct {
+	pool *pgxpool.Pool
+}
+
+func NewPgColumn(pool *pgxpool.Pool) *PgColumn {
+	return &PgColumn{pool: pool}
+}
+
+func (r *PgColumn) Create(
+	ctx context.Context,
+	boardID domain.BoardID,
+	name domain.ColumnName,
+	createdAt time.Time,
+	updatedAt time.Time,
+) (domain.Column, error) {
+	const query = `
+		WITH board_lock AS (
+			SELECT id
+			FROM boards
+			WHERE id = $1
+			FOR UPDATE
+		), next_pos AS (
+			SELECT COALESCE(MAX(position), 0) + 1 AS position
+			FROM columns
+			WHERE board_id = $1
+		), inserted AS (
+			INSERT INTO columns (board_id, name, position, created_at, updated_at)
+			SELECT $1, $2, next_pos.position, $3, $4
+			FROM board_lock, next_pos
+			RETURNING id, board_id, name, position, created_at, updated_at
+		)
+		SELECT id, board_id, name, position, created_at, updated_at
+		FROM inserted`
+
+	var column domain.Column
+	err := r.pool.QueryRow(ctx, query, boardID, name, createdAt, updatedAt).Scan(
+		&column.ID,
+		&column.BoardID,
+		&column.Name,
+		&column.Position,
+		&column.CreatedAt,
+		&column.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.Column{}, ErrRowNotFound
+		}
+		return domain.Column{}, fmt.Errorf("column repo: create: %v: %w", err, ErrInternal)
+	}
+
+	return column, nil
+}

--- a/internal/repository/column_test.go
+++ b/internal/repository/column_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"goroutine/internal/domain"
+	"goroutine/internal/repository"
+	"goroutine/internal/testutil"
+)
+
+func TestColumnRepository_Create(t *testing.T) {
+	pool := testutil.SetupTestDB(t, "../../migrations")
+	defer pool.Close()
+
+	r := repository.NewPgColumn(pool)
+
+	t.Run("Success", func(t *testing.T) {
+		testutil.TruncateTable(t, pool, "columns")
+		testutil.TruncateTable(t, pool, "boards")
+		testutil.TruncateTable(t, pool, "users")
+
+		userID := testutil.ValidUserID()
+		CreateUser(t, pool, userID, "column-create@example.com")
+
+		board := testutil.ValidBoard()
+		board.OwnerID = userID
+		InsertBoard(t, pool, &board)
+
+		name, err := domain.NewColumnName("In Progress")
+		if err != nil {
+			t.Fatalf("NewColumnName: %v", err)
+		}
+		now := testutil.FixedTimeNow()
+
+		column, err := r.Create(context.Background(), board.ID, name, now, now)
+		if err != nil {
+			t.Fatalf("Create() error = %v", err)
+		}
+
+		if column.ID.IsEmpty() {
+			t.Error("expected generated column id")
+		}
+		if column.BoardID != board.ID {
+			t.Errorf("expected boardID %q, got %q", board.ID, column.BoardID)
+		}
+		if column.Name != name {
+			t.Errorf("expected name %q, got %q", name, column.Name)
+		}
+		if column.Position.Int64() != 1 {
+			t.Errorf("expected position 1, got %d", column.Position.Int64())
+		}
+		if !column.CreatedAt.Equal(now) {
+			t.Errorf("expected createdAt %v, got %v", now, column.CreatedAt)
+		}
+		if !column.UpdatedAt.Equal(now) {
+			t.Errorf("expected updatedAt %v, got %v", now, column.UpdatedAt)
+		}
+	})
+}
+
+func TestColumnRepository_Create_AppendsPosition(t *testing.T) {
+	pool := testutil.SetupTestDB(t, "../../migrations")
+	defer pool.Close()
+
+	r := repository.NewPgColumn(pool)
+
+	testutil.TruncateTable(t, pool, "columns")
+	testutil.TruncateTable(t, pool, "boards")
+	testutil.TruncateTable(t, pool, "users")
+
+	userID := testutil.ValidUserID()
+	CreateUser(t, pool, userID, "column-max@example.com")
+
+	board := testutil.ValidBoard()
+	board.OwnerID = userID
+	InsertBoard(t, pool, &board)
+
+	nameA, _ := domain.NewColumnName("Todo")
+	nameB, _ := domain.NewColumnName("Done")
+	now := testutil.FixedTimeNow()
+
+	first, err := r.Create(context.Background(), board.ID, nameA, now, now)
+	if err != nil {
+		t.Fatalf("Create first: %v", err)
+	}
+	second, err := r.Create(context.Background(), board.ID, nameB, now, now)
+	if err != nil {
+		t.Fatalf("Create second: %v", err)
+	}
+
+	if first.Position.Int64() != 1 {
+		t.Errorf("first position expected 1, got %d", first.Position.Int64())
+	}
+	if second.Position.Int64() != 2 {
+		t.Errorf("second position expected 2, got %d", second.Position.Int64())
+	}
+}

--- a/internal/service/column.go
+++ b/internal/service/column.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"goroutine/internal/domain"
+	"goroutine/internal/repository"
+)
+
+type ColumnRepository interface {
+	Create(
+		ctx context.Context,
+		boardID domain.BoardID,
+		name domain.ColumnName,
+		createdAt time.Time,
+		updatedAt time.Time,
+	) (domain.Column, error)
+}
+
+type ColumnBoardRepository interface {
+	GetByID(ctx context.Context, id domain.BoardID) (domain.Board, error)
+}
+
+type Column struct {
+	columnRepository ColumnRepository
+	boardRepository  ColumnBoardRepository
+	timeFunc         func() time.Time
+}
+
+func NewColumn(columnRepo ColumnRepository, boardRepo ColumnBoardRepository, timeFunc TimeFunc) *Column {
+	if timeFunc == nil {
+		panic("BUG: timeFunc is nil")
+	}
+
+	return &Column{columnRepository: columnRepo, boardRepository: boardRepo, timeFunc: timeFunc}
+}
+
+func (s *Column) Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
+	board, err := s.boardRepository.GetByID(ctx, boardID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return domain.Column{}, ErrBoardNotFound
+		}
+		return domain.Column{}, fmt.Errorf("column service: create get board: %v: %w", err, ErrInternal)
+	}
+	if board.OwnerID != callerID {
+		return domain.Column{}, ErrBoardNotFound
+	}
+
+	now := s.timeFunc()
+	column, err := s.columnRepository.Create(ctx, boardID, name, now, now)
+	if err != nil {
+		return domain.Column{}, fmt.Errorf("column service: create: %v: %w", err, ErrInternal)
+	}
+
+	return column, nil
+}

--- a/internal/service/column_test.go
+++ b/internal/service/column_test.go
@@ -1,0 +1,141 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"goroutine/internal/domain"
+	"goroutine/internal/repository"
+	"goroutine/internal/service"
+	"goroutine/internal/testutil"
+)
+
+func TestColumn_Create(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validName, err := domain.NewColumnName("In Progress")
+	if err != nil {
+		t.Fatalf("NewColumnName: %v", err)
+	}
+	validPosition, err := domain.NewColumnPosition(3)
+	if err != nil {
+		t.Fatalf("NewColumnPosition: %v", err)
+	}
+	validColumn := domain.Column{
+		ID:        domain.NewColumnID(),
+		BoardID:   validBoard.ID,
+		Name:      validName,
+		Position:  validPosition,
+		CreatedAt: testutil.FixedTimeNow(),
+		UpdatedAt: testutil.FixedTimeNow(),
+	}
+
+	tests := []struct {
+		name        string
+		callerID    domain.UserID
+		setupBoards func(r *MockBoardRepository)
+		setupColumn func(r *MockColumnRepository)
+		expectedErr error
+		wantColumn  domain.Column
+	}{
+		{
+			name:     "Success",
+			callerID: validBoard.OwnerID,
+			setupBoards: func(r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					if id != validBoard.ID {
+						t.Errorf("expected board id %v, got %v", validBoard.ID, id)
+					}
+					return validBoard, nil
+				}
+			},
+			setupColumn: func(r *MockColumnRepository) {
+				r.CreateFunc = func(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, createdAt, updatedAt time.Time) (domain.Column, error) {
+					if boardID != validBoard.ID {
+						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+					}
+					if name != validName {
+						t.Errorf("expected name %v, got %v", validName, name)
+					}
+					if !createdAt.Equal(testutil.FixedTimeNow()) || !updatedAt.Equal(testutil.FixedTimeNow()) {
+						t.Errorf("expected service timestamp %v, got created=%v updated=%v", testutil.FixedTimeNow(), createdAt, updatedAt)
+					}
+					return validColumn, nil
+				}
+			},
+			wantColumn: validColumn,
+		},
+		{
+			name:     "Board not found",
+			callerID: validBoard.OwnerID,
+			setupBoards: func(r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return domain.Board{}, repository.ErrRowNotFound
+				}
+			},
+			setupColumn: func(r *MockColumnRepository) {
+				r.CreateFunc = func(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, createdAt, updatedAt time.Time) (domain.Column, error) {
+					t.Fatalf("should not be called")
+					return domain.Column{}, nil
+				}
+			},
+			expectedErr: service.ErrBoardNotFound,
+		},
+		{
+			name:     "Caller has no access",
+			callerID: domain.NewUserID(),
+			setupBoards: func(r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumn: func(r *MockColumnRepository) {
+				r.CreateFunc = func(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, createdAt, updatedAt time.Time) (domain.Column, error) {
+					t.Fatalf("should not be called")
+					return domain.Column{}, nil
+				}
+			},
+			expectedErr: service.ErrBoardNotFound,
+		},
+		{
+			name:     "Create internal error",
+			callerID: validBoard.OwnerID,
+			setupBoards: func(r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumn: func(r *MockColumnRepository) {
+				r.CreateFunc = func(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, createdAt, updatedAt time.Time) (domain.Column, error) {
+					return domain.Column{}, errors.New("insert failed")
+				}
+			},
+			expectedErr: service.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			boardRepo := &MockBoardRepository{}
+			columnRepo := &MockColumnRepository{}
+			tt.setupBoards(boardRepo)
+			tt.setupColumn(columnRepo)
+
+			s := service.NewColumn(columnRepo, boardRepo, testutil.FixedTimeNow)
+			got, err := s.Create(context.Background(), tt.callerID, validBoard.ID, validName)
+
+			if !errors.Is(err, tt.expectedErr) {
+				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			}
+			if tt.expectedErr == nil && !reflect.DeepEqual(tt.wantColumn, got) {
+				t.Errorf("Create() column = %#v, want %#v", got, tt.wantColumn)
+			}
+		})
+	}
+}

--- a/internal/service/helpers_test.go
+++ b/internal/service/helpers_test.go
@@ -37,6 +37,10 @@ type MockBoardRepository struct {
 	DeleteFunc     func(ctx context.Context, boardID domain.BoardID) error
 }
 
+type MockColumnRepository struct {
+	CreateFunc func(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, createdAt time.Time, updatedAt time.Time) (domain.Column, error)
+}
+
 func (m *MockBoardRepository) Create(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
 	AssertFuncNotNil("BoardRepository.CreateFunc", m.CreateFunc)
 	return m.CreateFunc(ctx, ownerID, name, description)
@@ -60,4 +64,15 @@ func (m *MockBoardRepository) UpdateByID(ctx context.Context, boardID domain.Boa
 func (m *MockBoardRepository) Delete(ctx context.Context, boardID domain.BoardID) error {
 	AssertFuncNotNil("BoardRepository.DeleteFunc", m.DeleteFunc)
 	return m.DeleteFunc(ctx, boardID)
+}
+
+func (m *MockColumnRepository) Create(
+	ctx context.Context,
+	boardID domain.BoardID,
+	name domain.ColumnName,
+	createdAt time.Time,
+	updatedAt time.Time,
+) (domain.Column, error) {
+	AssertFuncNotNil("ColumnRepository.CreateFunc", m.CreateFunc)
+	return m.CreateFunc(ctx, boardID, name, createdAt, updatedAt)
 }

--- a/internal/testutil/data.go
+++ b/internal/testutil/data.go
@@ -59,6 +59,19 @@ func ValidBoardDescription() domain.BoardDescription {
 	return must(domain.NewBoardDescription, "Test Board Description")
 }
 
+func ValidColumnName() domain.ColumnName {
+	return must(domain.NewColumnName, "To Do")
+}
+
+func ValidColumnPosition() domain.ColumnPosition {
+	position, err := domain.NewColumnPosition(1)
+	if err != nil {
+		panic(fmt.Errorf("testutil: BUG: value is no longer valid: %w", err))
+	}
+
+	return position
+}
+
 func ValidJWTSecret() secrecy.SecretString {
 	return secrecy.SecretString("secret")
 }
@@ -108,5 +121,20 @@ func UpdateValidBoard(t *testing.T, base *domain.Board, name, description string
 		Description: domainDescription,
 		CreatedAt:   base.CreatedAt,
 		UpdatedAt:   updatedAt,
+	}
+}
+
+func ValidColumn(boardID domain.BoardID) domain.Column {
+	name := ValidColumnName()
+	position := ValidColumnPosition()
+	pseudoNow := FixedTimeNow()
+
+	return domain.Column{
+		ID:        domain.NewColumnID(),
+		BoardID:   boardID,
+		Name:      name,
+		Position:  position,
+		CreatedAt: pseudoNow,
+		UpdatedAt: pseudoNow,
 	}
 }

--- a/migrations/20260414120000_create_columns_table.sql
+++ b/migrations/20260414120000_create_columns_table.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+CREATE TABLE columns (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    board_id UUID NOT NULL REFERENCES boards(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    position INT NOT NULL CHECK (position > 0),
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    UNIQUE (board_id, position)
+);
+
+-- +goose Down
+DROP TABLE columns;

--- a/tests/column_test.go
+++ b/tests/column_test.go
@@ -1,0 +1,118 @@
+//go:build e2e
+
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"goroutine/internal/domain"
+	"goroutine/internal/testutil"
+)
+
+type columnJSON struct {
+	ID        string `json:"id"`
+	BoardID   string `json:"boardId"`
+	Name      string `json:"name"`
+	Position  int64  `json:"position"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+func TestColumn_Create(t *testing.T) {
+	httpClient, ts, pool := Prelude(t)
+
+	testutil.TruncateTable(t, pool, "columns")
+	testutil.TruncateTable(t, pool, "boards")
+	testutil.TruncateTable(t, pool, "users")
+
+	ac := CreateUserAndAuthenticateClient(t, httpClient, ts.URL)
+
+	boardName := testutil.ValidBoardName().String()
+	boardDescription := testutil.ValidBoardDescription().String()
+
+	createBoardResp := ac.Do(t, http.MethodPost, "/v1/boards", map[string]string{
+		"name":        boardName,
+		"description": boardDescription,
+	})
+	defer func() { _ = createBoardResp.Body.Close() }()
+	if createBoardResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create board status = %d, want %d", createBoardResp.StatusCode, http.StatusCreated)
+	}
+
+	board := parseBoard(t, createBoardResp)
+
+	createColumnResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{"name": "To Do"})
+	defer func() { _ = createColumnResp.Body.Close() }()
+	if createColumnResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create first column status = %d, want %d", createColumnResp.StatusCode, http.StatusCreated)
+	}
+	firstColumn := parseColumn(t, createColumnResp)
+	if firstColumn.BoardID != board.ID {
+		t.Errorf("first column boardId = %q, want %q", firstColumn.BoardID, board.ID)
+	}
+	if firstColumn.Position != 1 {
+		t.Errorf("first column position = %d, want 1", firstColumn.Position)
+	}
+	if _, err := domain.ParseColumnID(firstColumn.ID); err != nil {
+		t.Errorf("first column id invalid: %v", err)
+	}
+	if _, err := time.Parse(timeFormat, firstColumn.CreatedAt); err != nil {
+		t.Errorf("first column createdAt invalid: %v", err)
+	}
+	if _, err := time.Parse(timeFormat, firstColumn.UpdatedAt); err != nil {
+		t.Errorf("first column updatedAt invalid: %v", err)
+	}
+
+	createSecondColumnResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{"name": "In Progress"})
+	defer func() { _ = createSecondColumnResp.Body.Close() }()
+	if createSecondColumnResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create second column status = %d, want %d", createSecondColumnResp.StatusCode, http.StatusCreated)
+	}
+	secondColumn := parseColumn(t, createSecondColumnResp)
+	if secondColumn.Position != 2 {
+		t.Errorf("second column position = %d, want 2", secondColumn.Position)
+	}
+
+	invalidColumnResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{"name": "   "})
+	defer func() { _ = invalidColumnResp.Body.Close() }()
+	if invalidColumnResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid column status = %d, want %d", invalidColumnResp.StatusCode, http.StatusBadRequest)
+	}
+	var validationErr struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(invalidColumnResp.Body).Decode(&validationErr); err != nil {
+		t.Fatalf("decode validation error: %v", err)
+	}
+	if validationErr.Code != "VALIDATION_ERROR" {
+		t.Errorf("validation error code = %q, want %q", validationErr.Code, "VALIDATION_ERROR")
+	}
+
+	missingBoardID := domain.NewBoardID().String()
+	missingBoardResp := ac.Do(t, http.MethodPost, "/v1/boards/"+missingBoardID+"/columns", map[string]string{"name": "Done"})
+	defer func() { _ = missingBoardResp.Body.Close() }()
+	if missingBoardResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing board status = %d, want %d", missingBoardResp.StatusCode, http.StatusNotFound)
+	}
+	var notFoundErr struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(missingBoardResp.Body).Decode(&notFoundErr); err != nil {
+		t.Fatalf("decode missing board error: %v", err)
+	}
+	if notFoundErr.Code != "BOARD_NOT_FOUND" {
+		t.Errorf("missing board code = %q, want %q", notFoundErr.Code, "BOARD_NOT_FOUND")
+	}
+}
+
+func parseColumn(t *testing.T, resp *http.Response) columnJSON {
+	t.Helper()
+	var c columnJSON
+	if err := json.NewDecoder(resp.Body).Decode(&c); err != nil {
+		t.Fatalf("decode column: %v", err)
+	}
+	return c
+}


### PR DESCRIPTION
### Related Issues
Refers to #144 

### Summary
Implement columns create endpoint:
- Domain: `Column` with full members validation
- Migration: table `columns`
- Repository: creation with automatic position calculation
- Service: creation with ownership checks
- Handler: request/response as per contract

### Technical Details
This change is generated by AI under supervision according to existing hand-written boards API

### Verification
- [ ] Tests are green

### Checklist
- [ ] Code follows the style guidelines
- [ ] Unit tests added/updated
- [ ] Documentation updated
- [ ] No sensitive data committed
