### PR TITLE
feat: columns API delete

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -434,6 +434,69 @@ const docTemplate = `{
             }
         },
         "/v1/boards/{boardId}/columns/{columnId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Permanently delete a column from board for the current user and shift positions to close the gap.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "columns"
+                ],
+                "summary": "Delete a column by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Column ID",
+                        "name": "columnId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "COLUMN_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            },
             "patch": {
                 "security": [
                     {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -426,6 +426,69 @@
             }
         },
         "/v1/boards/{boardId}/columns/{columnId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Permanently delete a column from board for the current user and shift positions to close the gap.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "columns"
+                ],
+                "summary": "Delete a column by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Column ID",
+                        "name": "columnId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "COLUMN_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            },
             "patch": {
                 "security": [
                     {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -427,6 +427,48 @@ paths:
       tags:
       - columns
   /v1/boards/{boardId}/columns/{columnId}:
+    delete:
+      consumes:
+      - application/json
+      description: Permanently delete a column from board for the current user and
+        shift positions to close the gap.
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardId
+        required: true
+        type: string
+      - description: Column ID
+        in: path
+        name: columnId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: VALIDATION_ERROR
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "401":
+          description: 'Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER'
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "404":
+          description: COLUMN_NOT_FOUND
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/httpschema.Error'
+      security:
+      - BearerAuth: []
+      summary: Delete a column by id
+      tags:
+      - columns
     patch:
       consumes:
       - application/json

--- a/internal/http/handler/columns.go
+++ b/internal/http/handler/columns.go
@@ -16,6 +16,7 @@ type ColumnsService interface {
 	Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error)
 	List(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error)
 	UpdateByID(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName) (domain.Column, error)
+	Delete(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error
 }
 
 type Columns struct {
@@ -218,6 +219,54 @@ func (h *Columns) UpdateByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httpschema.RespondJSON(w, h.logger, http.StatusOK, NewColumnResponse(&column))
+}
+
+// Delete godoc
+// @Summary Delete a column by id
+// @Description Permanently delete a column from board for the current user and shift positions to close the gap.
+// @Tags columns
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param boardId path string true "Board ID"
+// @Param columnId path string true "Column ID"
+// @Success 204 "No Content"
+// @Failure 400 {object} httpschema.DetailedError "VALIDATION_ERROR"
+// @Failure 401 {object} httpschema.DetailedError "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER"
+// @Failure 404 {object} httpschema.DetailedError "COLUMN_NOT_FOUND"
+// @Failure 500 {object} httpschema.Error "Internal server error"
+// @Router /v1/boards/{boardId}/columns/{columnId} [delete]
+func (h *Columns) Delete(w http.ResponseWriter, r *http.Request) {
+	rawBoardID := r.PathValue("boardId")
+	boardID, err := domain.ParseBoardID(rawBoardID)
+	if err != nil {
+		h.responder.ValidationError(w, []httpschema.Detail{{Field: "boardId", Issues: []string{"Invalid board id"}}})
+		return
+	}
+
+	rawColumnID := r.PathValue("columnId")
+	columnID, err := domain.ParseColumnID(rawColumnID)
+	if err != nil {
+		h.responder.ValidationError(w, []httpschema.Detail{{Field: "columnId", Issues: []string{"Invalid column id"}}})
+		return
+	}
+
+	userID, ok := h.extractUserIDOrHandleMissing(w, r)
+	if !ok {
+		return
+	}
+
+	err = h.service.Delete(r.Context(), userID, boardID, columnID)
+	if err != nil {
+		if errors.Is(err, service.ErrColumnNotFound) {
+			h.responder.ColumnNotFound(w, []httpschema.Detail{{Field: "columnId", Issues: []string{"Column not found"}}})
+			return
+		}
+		h.responder.InternalError(w, r, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Columns) extractUserIDOrHandleMissing(w http.ResponseWriter, r *http.Request) (domain.UserID, bool) {

--- a/internal/http/handler/columns_test.go
+++ b/internal/http/handler/columns_test.go
@@ -53,7 +53,7 @@ func TestColumns_Create(t *testing.T) {
 				"id":        validColumn.ID.String(),
 				"boardId":   validColumn.BoardID.String(),
 				"name":      validColumn.Name.String(),
-				"position":  float64(validColumn.Position.Int64()),
+				"position":  validColumn.Position.Int64(),
 				"createdAt": validColumn.CreatedAt.Format(timeFormat),
 				"updatedAt": validColumn.UpdatedAt.Format(timeFormat),
 			},
@@ -197,7 +197,7 @@ func TestColumns_List(t *testing.T) {
 					"id":        first.ID.String(),
 					"boardId":   first.BoardID.String(),
 					"name":      first.Name.String(),
-					"position":  float64(first.Position.Int64()),
+					"position":  first.Position.Int64(),
 					"createdAt": first.CreatedAt.Format(timeFormat),
 					"updatedAt": first.UpdatedAt.Format(timeFormat),
 				},
@@ -205,7 +205,7 @@ func TestColumns_List(t *testing.T) {
 					"id":        second.ID.String(),
 					"boardId":   second.BoardID.String(),
 					"name":      second.Name.String(),
-					"position":  float64(second.Position.Int64()),
+					"position":  second.Position.Int64(),
 					"createdAt": second.CreatedAt.Format(timeFormat),
 					"updatedAt": second.UpdatedAt.Format(timeFormat),
 				},
@@ -332,7 +332,7 @@ func TestColumns_UpdateByID(t *testing.T) {
 				"id":        updatedColumn.ID.String(),
 				"boardId":   updatedColumn.BoardID.String(),
 				"name":      updatedColumn.Name.String(),
-				"position":  float64(updatedColumn.Position.Int64()),
+				"position":  updatedColumn.Position.Int64(),
 				"createdAt": updatedColumn.CreatedAt.Format(timeFormat),
 				"updatedAt": updatedColumn.UpdatedAt.Format(timeFormat),
 			},
@@ -354,7 +354,7 @@ func TestColumns_UpdateByID(t *testing.T) {
 				"id":        validColumn.ID.String(),
 				"boardId":   validColumn.BoardID.String(),
 				"name":      validColumn.Name.String(),
-				"position":  float64(validColumn.Position.Int64()),
+				"position":  validColumn.Position.Int64(),
 				"createdAt": validColumn.CreatedAt.Format(timeFormat),
 				"updatedAt": validColumn.UpdatedAt.Format(timeFormat),
 			},
@@ -458,6 +458,121 @@ func TestColumns_UpdateByID(t *testing.T) {
 
 			testutil.AssertStatusCode(t, rr, tt.expectedCode)
 			testutil.AssertContentType(t, rr, "application/json")
+			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+		})
+	}
+}
+
+func TestColumns_Delete(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumn := testutil.ValidColumn(validBoard.ID)
+	okPath := "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String()
+
+	tests := []struct {
+		name         string
+		path         string
+		context      context.Context
+		setupMock    func(s *MockColumns)
+		expectedCode int
+		expectedBody any
+	}{
+		{
+			name: "Success",
+			path: okPath,
+			setupMock: func(s *MockColumns) {
+				s.DeleteFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error {
+					if callerID != validBoard.OwnerID {
+						t.Errorf("expected caller id %v, got %v", validBoard.OwnerID, callerID)
+					}
+					if boardID != validBoard.ID {
+						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+					}
+					if columnID != validColumn.ID {
+						t.Errorf("expected column id %v, got %v", validColumn.ID, columnID)
+					}
+					return nil
+				}
+			},
+			expectedCode: http.StatusNoContent,
+			expectedBody: nil,
+		},
+		{
+			name:         "Invalid board id",
+			path:         "/v1/boards/not-a-uuid/columns/" + validColumn.ID.String(),
+			expectedCode: http.StatusBadRequest,
+			expectedBody: validationErrorBody("boardId", []string{"Invalid board id"}),
+		},
+		{
+			name:         "Invalid column id",
+			path:         "/v1/boards/" + validBoard.ID.String() + "/columns/not-a-uuid",
+			expectedCode: http.StatusBadRequest,
+			expectedBody: validationErrorBody("columnId", []string{"Invalid column id"}),
+		},
+		{
+			name:         "Missing context user",
+			path:         okPath,
+			context:      context.Background(),
+			expectedCode: http.StatusUnauthorized,
+			expectedBody: unauthorizedTokenBody(),
+		},
+		{
+			name: "Column not found",
+			path: okPath,
+			setupMock: func(s *MockColumns) {
+				s.DeleteFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error {
+					return service.ErrColumnNotFound
+				}
+			},
+			expectedCode: http.StatusNotFound,
+			expectedBody: columnNotFoundErrorBody(),
+		},
+		{
+			name: "Internal error",
+			path: okPath,
+			setupMock: func(s *MockColumns) {
+				s.DeleteFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error {
+					return service.ErrInternal
+				}
+			},
+			expectedCode: http.StatusInternalServerError,
+			expectedBody: internalErrorBody(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodDelete, tt.path, http.NoBody)
+			if tt.context != nil {
+				req = req.WithContext(tt.context)
+			} else {
+				req = req.WithContext(context.WithValue(req.Context(), httpschema.ContextKeyUserID, validBoard.OwnerID))
+			}
+
+			boardAndColumn := strings.TrimPrefix(tt.path, "/v1/boards/")
+			parts := strings.Split(boardAndColumn, "/columns/")
+			if len(parts) == 2 {
+				req.SetPathValue("boardId", parts[0])
+				req.SetPathValue("columnId", parts[1])
+			}
+
+			rr := httptest.NewRecorder()
+			mockColumns := &MockColumns{}
+			if tt.setupMock != nil {
+				tt.setupMock(mockColumns)
+			}
+
+			logger := testutil.NewTestLogger(t)
+			h := handler.NewColumns(logger, mockColumns, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
+			h.Delete(rr, req)
+
+			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			if tt.expectedCode != http.StatusNoContent {
+				testutil.AssertContentType(t, rr, "application/json")
+			}
 			testutil.AssertResponseBody(t, rr, tt.expectedBody)
 		})
 	}

--- a/internal/http/handler/helpers_test.go
+++ b/internal/http/handler/helpers_test.go
@@ -41,6 +41,7 @@ type MockColumns struct {
 	CreateFunc     func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error)
 	ListFunc       func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error)
 	UpdateByIDFunc func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName) (domain.Column, error)
+	DeleteFunc     func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error
 }
 
 func (m *MockBoards) Get(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
@@ -81,6 +82,11 @@ func (m *MockColumns) List(ctx context.Context, callerID domain.UserID, boardID 
 func (m *MockColumns) UpdateByID(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName) (domain.Column, error) {
 	AssertFuncNotNil("ColumnsService.UpdateByIDFunc", m.UpdateByIDFunc)
 	return m.UpdateByIDFunc(ctx, callerID, boardID, columnID, name)
+}
+
+func (m *MockColumns) Delete(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error {
+	AssertFuncNotNil("ColumnsService.DeleteFunc", m.DeleteFunc)
+	return m.DeleteFunc(ctx, callerID, boardID, columnID)
 }
 
 func columnNotFoundErrorBody() map[string]any {

--- a/internal/http/route.go
+++ b/internal/http/route.go
@@ -29,6 +29,7 @@ func NewRouter(h *handler.Handlers, m *middleware.Middlewares) http.Handler {
 	mux.Handle("POST /v1/boards/{boardId}/columns", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Columns.Create))))
 	mux.Handle("GET /v1/boards/{boardId}/columns", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Columns.List))))
 	mux.Handle("PATCH /v1/boards/{boardId}/columns/{columnId}", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Columns.UpdateByID))))
+	mux.Handle("DELETE /v1/boards/{boardId}/columns/{columnId}", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Columns.Delete))))
 	mux.Handle("GET "+swaggerBasePath, NewSwaggerHandler(swaggerBasePath, loginPath))
 
 	return m.RequestID.Wrap(m.CORS.Wrap(mux))

--- a/internal/http/route_test.go
+++ b/internal/http/route_test.go
@@ -91,6 +91,10 @@ func TestNewRouter_Full(t *testing.T) {
 			metrics: true, cors: true, requestID: true,
 		},
 		{
+			entry:   entry{"Delete column endpoint", http.MethodDelete, "/v1/boards/" + UUIDv7() + "/columns/" + UUIDv7()},
+			metrics: true, cors: true, requestID: true,
+		},
+		{
 			entry:   entry{"Swagger endpoint", http.MethodGet, "/v1/swagger/index.html"},
 			metrics: false, cors: true, requestID: true,
 		},

--- a/internal/repository/column.go
+++ b/internal/repository/column.go
@@ -163,5 +163,36 @@ func (r *PgColumn) UpdateByID(
 }
 
 func (r *PgColumn) Delete(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
-	panic("TODO: implement PgColumn.Delete with position shift")
+	const query = `
+		WITH board_lock AS (
+			SELECT id
+			FROM boards
+			WHERE id = $1
+			FOR UPDATE
+		), deleted AS (
+			DELETE FROM columns
+			WHERE board_id = (SELECT id FROM board_lock)
+			  AND id = $2
+			RETURNING position
+		), shifted AS (
+			UPDATE columns
+			SET position = position - 1
+			WHERE board_id = (SELECT id FROM board_lock)
+			  AND position > (SELECT position FROM deleted)
+		)
+		SELECT 1
+		FROM deleted
+	`
+
+	var ok int
+	err := r.pool.QueryRow(ctx, query, boardID, columnID).Scan(&ok)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrRowNotFound
+		}
+
+		return fmt.Errorf("column repo: delete: %v: %w", err, ErrInternal)
+	}
+
+	return nil
 }

--- a/internal/repository/column.go
+++ b/internal/repository/column.go
@@ -163,6 +163,37 @@ func (r *PgColumn) UpdateByID(
 }
 
 func (r *PgColumn) Delete(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
+	const (
+		lockBoardQuery = `
+		SELECT 1
+		FROM boards
+		WHERE id = @board_id
+		FOR UPDATE`
+
+		deleteColumnQuery = `
+		DELETE FROM columns
+		WHERE board_id = @board_id
+		  AND id = @column_id
+		RETURNING position`
+
+		positionOffsetQuery = `
+		SELECT COALESCE(MAX(position), 0) + 1
+		FROM columns
+		WHERE board_id = @board_id`
+
+		bumpTrailingColumnsQuery = `
+		UPDATE columns
+		SET position = position + @position_offset
+		WHERE board_id = @board_id
+		  AND position > @deleted_position`
+
+		compactTrailingColumnsQuery = `
+		UPDATE columns
+		SET position = position - @position_offset - 1
+		WHERE board_id = @board_id
+		  AND position > @position_offset`
+	)
+
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("column repo: delete begin tx: %v: %w", err, ErrInternal)
@@ -171,14 +202,10 @@ func (r *PgColumn) Delete(ctx context.Context, boardID domain.BoardID, columnID 
 		_ = tx.Rollback(ctx)
 	}()
 
-	const lockBoardQuery = `
-		SELECT 1
-		FROM boards
-		WHERE id = $1
-		FOR UPDATE`
-
 	var locked int
-	err = tx.QueryRow(ctx, lockBoardQuery, boardID).Scan(&locked)
+	err = tx.QueryRow(ctx, lockBoardQuery, pgx.NamedArgs{
+		"board_id": boardID,
+	}).Scan(&locked)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ErrRowNotFound
@@ -186,14 +213,11 @@ func (r *PgColumn) Delete(ctx context.Context, boardID domain.BoardID, columnID 
 		return fmt.Errorf("column repo: delete lock board: %v: %w", err, ErrInternal)
 	}
 
-	const deleteColumnQuery = `
-		DELETE FROM columns
-		WHERE board_id = $1
-		  AND id = $2
-		RETURNING position`
-
 	var deletedPosition int64
-	err = tx.QueryRow(ctx, deleteColumnQuery, boardID, columnID).Scan(&deletedPosition)
+	err = tx.QueryRow(ctx, deleteColumnQuery, pgx.NamedArgs{
+		"board_id":  boardID,
+		"column_id": columnID,
+	}).Scan(&deletedPosition)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ErrRowNotFound
@@ -201,36 +225,27 @@ func (r *PgColumn) Delete(ctx context.Context, boardID domain.BoardID, columnID 
 		return fmt.Errorf("column repo: delete column: %v: %w", err, ErrInternal)
 	}
 
-	const positionOffsetQuery = `
-		SELECT COALESCE(MAX(position), 0) + 1
-		FROM columns
-		WHERE board_id = $1`
-
 	var positionOffset int64
-	err = tx.QueryRow(ctx, positionOffsetQuery, boardID).Scan(&positionOffset)
+	err = tx.QueryRow(ctx, positionOffsetQuery, pgx.NamedArgs{
+		"board_id": boardID,
+	}).Scan(&positionOffset)
 	if err != nil {
 		return fmt.Errorf("column repo: delete position offset: %v: %w", err, ErrInternal)
 	}
 
-	// Shift in two steps to avoid transient UNIQUE(board_id, position) conflicts
-	const bumpTrailingColumnsQuery = `
-		UPDATE columns
-		SET position = position + $2
-		WHERE board_id = $1
-		  AND position > $3`
-
-	_, err = tx.Exec(ctx, bumpTrailingColumnsQuery, boardID, positionOffset, deletedPosition)
+	_, err = tx.Exec(ctx, bumpTrailingColumnsQuery, pgx.NamedArgs{
+		"board_id":         boardID,
+		"position_offset":  positionOffset,
+		"deleted_position": deletedPosition,
+	})
 	if err != nil {
 		return fmt.Errorf("column repo: delete bump trailing columns: %v: %w", err, ErrInternal)
 	}
 
-	const compactTrailingColumnsQuery = `
-		UPDATE columns
-		SET position = position - $2 - 1
-		WHERE board_id = $1
-		  AND position > $2`
-
-	_, err = tx.Exec(ctx, compactTrailingColumnsQuery, boardID, positionOffset)
+	_, err = tx.Exec(ctx, compactTrailingColumnsQuery, pgx.NamedArgs{
+		"board_id":        boardID,
+		"position_offset": positionOffset,
+	})
 	if err != nil {
 		return fmt.Errorf("column repo: delete compact trailing columns: %v: %w", err, ErrInternal)
 	}

--- a/internal/repository/column.go
+++ b/internal/repository/column.go
@@ -161,3 +161,7 @@ func (r *PgColumn) UpdateByID(
 
 	return column, nil
 }
+
+func (r *PgColumn) Delete(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
+	panic("TODO: implement PgColumn.Delete with position shift")
+}

--- a/internal/repository/column.go
+++ b/internal/repository/column.go
@@ -163,35 +163,81 @@ func (r *PgColumn) UpdateByID(
 }
 
 func (r *PgColumn) Delete(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
-	const query = `
-		WITH board_lock AS (
-			SELECT id
-			FROM boards
-			WHERE id = $1
-			FOR UPDATE
-		), deleted AS (
-			DELETE FROM columns
-			WHERE board_id = (SELECT id FROM board_lock)
-			  AND id = $2
-			RETURNING position
-		), shifted AS (
-			UPDATE columns
-			SET position = position - 1
-			WHERE board_id = (SELECT id FROM board_lock)
-			  AND position > (SELECT position FROM deleted)
-		)
-		SELECT 1
-		FROM deleted
-	`
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("column repo: delete begin tx: %v: %w", err, ErrInternal)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
 
-	var ok int
-	err := r.pool.QueryRow(ctx, query, boardID, columnID).Scan(&ok)
+	const lockBoardQuery = `
+		SELECT 1
+		FROM boards
+		WHERE id = $1
+		FOR UPDATE`
+
+	var locked int
+	err = tx.QueryRow(ctx, lockBoardQuery, boardID).Scan(&locked)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ErrRowNotFound
 		}
+		return fmt.Errorf("column repo: delete lock board: %v: %w", err, ErrInternal)
+	}
 
-		return fmt.Errorf("column repo: delete: %v: %w", err, ErrInternal)
+	const deleteColumnQuery = `
+		DELETE FROM columns
+		WHERE board_id = $1
+		  AND id = $2
+		RETURNING position`
+
+	var deletedPosition int64
+	err = tx.QueryRow(ctx, deleteColumnQuery, boardID, columnID).Scan(&deletedPosition)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrRowNotFound
+		}
+		return fmt.Errorf("column repo: delete column: %v: %w", err, ErrInternal)
+	}
+
+	const positionOffsetQuery = `
+		SELECT COALESCE(MAX(position), 0) + 1
+		FROM columns
+		WHERE board_id = $1`
+
+	var positionOffset int64
+	err = tx.QueryRow(ctx, positionOffsetQuery, boardID).Scan(&positionOffset)
+	if err != nil {
+		return fmt.Errorf("column repo: delete position offset: %v: %w", err, ErrInternal)
+	}
+
+	// Shift in two steps to avoid transient UNIQUE(board_id, position) conflicts
+	const bumpTrailingColumnsQuery = `
+		UPDATE columns
+		SET position = position + $2
+		WHERE board_id = $1
+		  AND position > $3`
+
+	_, err = tx.Exec(ctx, bumpTrailingColumnsQuery, boardID, positionOffset, deletedPosition)
+	if err != nil {
+		return fmt.Errorf("column repo: delete bump trailing columns: %v: %w", err, ErrInternal)
+	}
+
+	const compactTrailingColumnsQuery = `
+		UPDATE columns
+		SET position = position - $2 - 1
+		WHERE board_id = $1
+		  AND position > $2`
+
+	_, err = tx.Exec(ctx, compactTrailingColumnsQuery, boardID, positionOffset)
+	if err != nil {
+		return fmt.Errorf("column repo: delete compact trailing columns: %v: %w", err, ErrInternal)
+	}
+
+	err = tx.Commit(ctx)
+	if err != nil {
+		return fmt.Errorf("column repo: delete commit: %v: %w", err, ErrInternal)
 	}
 
 	return nil

--- a/internal/repository/column.go
+++ b/internal/repository/column.go
@@ -176,6 +176,9 @@ func (r *PgColumn) Delete(ctx context.Context, boardID domain.BoardID, columnID 
 		  AND id = @column_id
 		RETURNING position`
 
+		// Workaround:
+		// UNIQUE(board_id, position) may be violated during simple offsetting since crawling order is not guaranteed
+		// So we shift all the columns out of working scope and then move them back in the correct order
 		positionOffsetQuery = `
 		SELECT COALESCE(MAX(position), 0) + 1
 		FROM columns

--- a/internal/repository/column_test.go
+++ b/internal/repository/column_test.go
@@ -319,6 +319,7 @@ func TestColumnRepository_Delete(t *testing.T) {
 		name3, _ := domain.NewColumnName("Done")
 		now := testutil.FixedTimeNow()
 
+		// TODO: use separate code for creating columns to decouple test suite
 		first, err := r.Create(context.Background(), board.ID, name1, now, now)
 		if err != nil {
 			t.Fatalf("Create first: %v", err)

--- a/internal/repository/column_test.go
+++ b/internal/repository/column_test.go
@@ -296,3 +296,111 @@ func TestColumnRepository_UpdateByID(t *testing.T) {
 		}
 	})
 }
+
+func TestColumnRepository_Delete(t *testing.T) {
+	pool := testutil.SetupTestDB(t, "../../migrations")
+	defer pool.Close()
+
+	r := repository.NewPgColumn(pool)
+
+	t.Run("Success shift positions", func(t *testing.T) {
+		testutil.TruncateTable(t, pool, "columns")
+		testutil.TruncateTable(t, pool, "boards")
+		testutil.TruncateTable(t, pool, "users")
+
+		userID := testutil.ValidUserID()
+		CreateUser(t, pool, userID, "column-delete-shift@example.com")
+
+		board := testutil.ValidBoard()
+		InsertBoard(t, pool, &board)
+
+		name1, _ := domain.NewColumnName("Todo")
+		name2, _ := domain.NewColumnName("In Progress")
+		name3, _ := domain.NewColumnName("Done")
+		now := testutil.FixedTimeNow()
+
+		first, err := r.Create(context.Background(), board.ID, name1, now, now)
+		if err != nil {
+			t.Fatalf("Create first: %v", err)
+		}
+		second, err := r.Create(context.Background(), board.ID, name2, now, now)
+		if err != nil {
+			t.Fatalf("Create second: %v", err)
+		}
+		third, err := r.Create(context.Background(), board.ID, name3, now, now)
+		if err != nil {
+			t.Fatalf("Create third: %v", err)
+		}
+
+		err = r.Delete(context.Background(), board.ID, second.ID)
+		if err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+
+		got, err := r.ListByBoardID(context.Background(), board.ID)
+		if err != nil {
+			t.Fatalf("ListByBoardID() error = %v", err)
+		}
+
+		if len(got) != 2 {
+			t.Fatalf("expected 2 columns after delete, got %d", len(got))
+		}
+		if got[0].ID != first.ID {
+			t.Errorf("expected first column id %q, got %q", first.ID, got[0].ID)
+		}
+		if got[0].Position.Int64() != 1 {
+			t.Errorf("expected first position 1, got %d", got[0].Position.Int64())
+		}
+		if got[1].ID != third.ID {
+			t.Errorf("expected second column id %q, got %q", third.ID, got[1].ID)
+		}
+		if got[1].Position.Int64() != 2 {
+			t.Errorf("expected second position 2 after shift, got %d", got[1].Position.Int64())
+		}
+
+		_, err = r.GetByID(context.Background(), second.ID)
+		if !errors.Is(err, repository.ErrRowNotFound) {
+			t.Errorf("GetByID deleted column error = %v, want ErrRowNotFound", err)
+		}
+	})
+
+	t.Run("Not found by column id", func(t *testing.T) {
+		testutil.TruncateTable(t, pool, "columns")
+		testutil.TruncateTable(t, pool, "boards")
+		testutil.TruncateTable(t, pool, "users")
+
+		userID := testutil.ValidUserID()
+		CreateUser(t, pool, userID, "column-delete-missing-col@example.com")
+
+		board := testutil.ValidBoard()
+		InsertBoard(t, pool, &board)
+
+		err := r.Delete(context.Background(), board.ID, domain.NewColumnID())
+		if !errors.Is(err, repository.ErrRowNotFound) {
+			t.Errorf("Delete() error = %v, want ErrRowNotFound", err)
+		}
+	})
+
+	t.Run("Not found by board id", func(t *testing.T) {
+		testutil.TruncateTable(t, pool, "columns")
+		testutil.TruncateTable(t, pool, "boards")
+		testutil.TruncateTable(t, pool, "users")
+
+		userID := testutil.ValidUserID()
+		CreateUser(t, pool, userID, "column-delete-missing-board@example.com")
+
+		board := testutil.ValidBoard()
+		InsertBoard(t, pool, &board)
+
+		name, _ := domain.NewColumnName("Todo")
+		created, err := r.Create(context.Background(), board.ID, name, testutil.FixedTimeNow(), testutil.FixedTimeNow())
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+
+		err = r.Delete(context.Background(), domain.NewBoardID(), created.ID)
+		if !errors.Is(err, repository.ErrRowNotFound) {
+			t.Errorf("Delete() error = %v, want ErrRowNotFound", err)
+		}
+	})
+}

--- a/internal/service/column.go
+++ b/internal/service/column.go
@@ -21,6 +21,7 @@ type ColumnRepository interface {
 	ListByBoardID(ctx context.Context, boardID domain.BoardID) ([]domain.Column, error)
 	GetByID(ctx context.Context, columnID domain.ColumnID) (domain.Column, error)
 	UpdateByID(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName, updatedAt time.Time) (domain.Column, error)
+	Delete(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error
 }
 
 type ColumnBoardRepository interface {
@@ -125,4 +126,32 @@ func (s *Column) UpdateByID(
 	}
 
 	return updated, nil
+}
+
+func (s *Column) Delete(
+	ctx context.Context,
+	callerID domain.UserID,
+	boardID domain.BoardID,
+	columnID domain.ColumnID,
+) error {
+	board, err := s.boardRepository.GetByID(ctx, boardID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return ErrColumnNotFound
+		}
+		return fmt.Errorf("column service: delete get board: %v: %w", err, ErrInternal)
+	}
+	if board.OwnerID != callerID {
+		return ErrColumnNotFound
+	}
+
+	err = s.columnRepository.Delete(ctx, boardID, columnID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return ErrColumnNotFound
+		}
+		return fmt.Errorf("column service: delete: %v: %w", err, ErrInternal)
+	}
+
+	return nil
 }

--- a/internal/service/column_test.go
+++ b/internal/service/column_test.go
@@ -450,3 +450,128 @@ func TestColumn_UpdateByID(t *testing.T) {
 		})
 	}
 }
+
+func TestColumn_Delete(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumn := testutil.ValidColumn(validBoard.ID)
+
+	tests := []struct {
+		name        string
+		callerID    domain.UserID
+		columnID    domain.ColumnID
+		setupBoards func(r *MockBoardRepository)
+		setupColumn func(r *MockColumnRepository)
+		expectedErr error
+	}{
+		{
+			name:     "Success",
+			callerID: validBoard.OwnerID,
+			columnID: validColumn.ID,
+			setupBoards: func(r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					if id != validBoard.ID {
+						t.Errorf("expected board id %v, got %v", validBoard.ID, id)
+					}
+					return validBoard, nil
+				}
+			},
+			setupColumn: func(r *MockColumnRepository) {
+				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
+					if boardID != validBoard.ID {
+						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+					}
+					if columnID != validColumn.ID {
+						t.Errorf("expected column id %v, got %v", validColumn.ID, columnID)
+					}
+					return nil
+				}
+			},
+		},
+		{
+			name:     "Board not found",
+			callerID: validBoard.OwnerID,
+			columnID: validColumn.ID,
+			setupBoards: func(r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return domain.Board{}, repository.ErrRowNotFound
+				}
+			},
+			setupColumn: func(r *MockColumnRepository) {
+				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
+					t.Fatalf("should not be called")
+					return nil
+				}
+			},
+			expectedErr: service.ErrColumnNotFound,
+		},
+		{
+			name:     "Caller has no access",
+			callerID: domain.NewUserID(),
+			columnID: validColumn.ID,
+			setupBoards: func(r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumn: func(r *MockColumnRepository) {
+				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
+					t.Fatalf("should not be called")
+					return nil
+				}
+			},
+			expectedErr: service.ErrColumnNotFound,
+		},
+		{
+			name:     "Column not found",
+			callerID: validBoard.OwnerID,
+			columnID: validColumn.ID,
+			setupBoards: func(r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumn: func(r *MockColumnRepository) {
+				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
+					return repository.ErrRowNotFound
+				}
+			},
+			expectedErr: service.ErrColumnNotFound,
+		},
+		{
+			name:     "Delete internal error",
+			callerID: validBoard.OwnerID,
+			columnID: validColumn.ID,
+			setupBoards: func(r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumn: func(r *MockColumnRepository) {
+				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
+					return errors.New("delete failed")
+				}
+			},
+			expectedErr: service.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			boardRepo := &MockBoardRepository{}
+			columnRepo := &MockColumnRepository{}
+			tt.setupBoards(boardRepo)
+			tt.setupColumn(columnRepo)
+
+			s := service.NewColumn(columnRepo, boardRepo, testutil.FixedTimeNow)
+			err := s.Delete(context.Background(), tt.callerID, validBoard.ID, tt.columnID)
+
+			if !errors.Is(err, tt.expectedErr) {
+				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			}
+		})
+	}
+}

--- a/internal/service/helpers_test.go
+++ b/internal/service/helpers_test.go
@@ -42,6 +42,7 @@ type MockColumnRepository struct {
 	ListByBoardIDFunc func(ctx context.Context, boardID domain.BoardID) ([]domain.Column, error)
 	GetByIDFunc       func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error)
 	UpdateByIDFunc    func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName, updatedAt time.Time) (domain.Column, error)
+	DeleteFunc        func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error
 }
 
 func (m *MockBoardRepository) Create(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
@@ -99,4 +100,9 @@ func (m *MockColumnRepository) UpdateByID(
 ) (domain.Column, error) {
 	AssertFuncNotNil("ColumnRepository.UpdateByIDFunc", m.UpdateByIDFunc)
 	return m.UpdateByIDFunc(ctx, boardID, columnID, name, updatedAt)
+}
+
+func (m *MockColumnRepository) Delete(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
+	AssertFuncNotNil("ColumnRepository.DeleteFunc", m.DeleteFunc)
+	return m.DeleteFunc(ctx, boardID, columnID)
 }

--- a/tests/column_test.go
+++ b/tests/column_test.go
@@ -153,6 +153,67 @@ func TestColumn_HappyPath(t *testing.T) {
 		if diff := cmp.Diff(updatedNameColumn, listedAfterUpdate[0]); diff != "" {
 			t.Errorf("List item after update mismatch (-want +got):\n%s", diff)
 		}
+
+		// 6. Create the second column so we can later delete it from the middle of the ordered list
+		createSecondResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
+			"name": "In Progress",
+		})
+		defer func() {
+			_ = createSecondResp.Body.Close()
+		}()
+		if createSecondResp.StatusCode != http.StatusCreated {
+			t.Fatalf("Expected second create status %d, got %d", http.StatusCreated, createSecondResp.StatusCode)
+		}
+
+		secondColumn := parseColumn(t, createSecondResp)
+		if secondColumn.Position != 2 {
+			t.Errorf("Expected second column position %d, got %d", 2, secondColumn.Position)
+		}
+
+		// 7. Create the third column so delete can verify position compaction for trailing items
+		createThirdResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
+			"name": "Done",
+		})
+		defer func() {
+			_ = createThirdResp.Body.Close()
+		}()
+		if createThirdResp.StatusCode != http.StatusCreated {
+			t.Fatalf("Expected third create status %d, got %d", http.StatusCreated, createThirdResp.StatusCode)
+		}
+
+		thirdColumn := parseColumn(t, createThirdResp)
+		if thirdColumn.Position != 3 {
+			t.Errorf("Expected third column position %d, got %d", 3, thirdColumn.Position)
+		}
+
+		// 8. Delete the middle column and expect the request to succeed
+		deleteResp := ac.Do(t, http.MethodDelete, "/v1/boards/"+board.ID+"/columns/"+secondColumn.ID, nil)
+		defer func() {
+			_ = deleteResp.Body.Close()
+		}()
+		if deleteResp.StatusCode != http.StatusNoContent {
+			t.Fatalf("Expected delete status %d, got %d", http.StatusNoContent, deleteResp.StatusCode)
+		}
+
+		// 9. List columns again and verify delete preserved the first column and compacted positions
+		listAfterDeleteResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns", nil)
+		defer func() {
+			_ = listAfterDeleteResp.Body.Close()
+		}()
+		if listAfterDeleteResp.StatusCode != http.StatusOK {
+			t.Fatalf("Expected list status %d after delete, got %d", http.StatusOK, listAfterDeleteResp.StatusCode)
+		}
+
+		listedAfterDelete := parseColumnsList(t, listAfterDeleteResp)
+		if len(listedAfterDelete) != 2 {
+			t.Fatalf("Expected 2 columns after delete, got %d", len(listedAfterDelete))
+		}
+		if listedAfterDelete[0].ID != updatedNameColumn.ID || listedAfterDelete[0].Name != updatedNameColumn.Name || listedAfterDelete[0].Position != 1 {
+			t.Errorf("Expected updated first column to stay at position 1, got id=%s name=%q position=%d", listedAfterDelete[0].ID, listedAfterDelete[0].Name, listedAfterDelete[0].Position)
+		}
+		if listedAfterDelete[1].ID != thirdColumn.ID || listedAfterDelete[1].Position != 2 {
+			t.Errorf("Expected third column to shift to position 2, got id=%s position=%d", listedAfterDelete[1].ID, listedAfterDelete[1].Position)
+		}
 	})
 }
 
@@ -172,86 +233,4 @@ func parseColumnsList(t *testing.T, resp *http.Response) []columnJSON {
 		t.Fatalf("decode columns list: %v", err)
 	}
 	return c
-}
-
-func TestColumn_Delete_ShiftsPositions(t *testing.T) {
-	httpClient, ts, pool := Prelude(t)
-
-	testutil.TruncateTable(t, pool, "columns")
-	testutil.TruncateTable(t, pool, "boards")
-	testutil.TruncateTable(t, pool, "users")
-
-	// 1. Register (already done via ac client)
-	ac := CreateUserAndAuthenticateClient(t, httpClient, ts.URL)
-
-	// 2. Create a board for the column ordering scenario
-	createBoardResp := ac.Do(t, http.MethodPost, "/v1/boards", map[string]string{
-		"name":        testutil.ValidBoardName().String(),
-		"description": testutil.ValidBoardDescription().String(),
-	})
-	defer func() {
-		_ = createBoardResp.Body.Close()
-	}()
-	if createBoardResp.StatusCode != http.StatusCreated {
-		t.Fatalf("create board status = %d, want %d", createBoardResp.StatusCode, http.StatusCreated)
-	}
-	board := parseBoard(t, createBoardResp)
-
-	// 3. Create the first column and keep its response for position checks
-	createFirstResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{"name": "Todo"})
-	defer func() {
-		_ = createFirstResp.Body.Close()
-	}()
-	if createFirstResp.StatusCode != http.StatusCreated {
-		t.Fatalf("create first column status = %d, want %d", createFirstResp.StatusCode, http.StatusCreated)
-	}
-	first := parseColumn(t, createFirstResp)
-
-	// 4. Create the second column that will be deleted later
-	createSecondResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{"name": "In Progress"})
-	defer func() {
-		_ = createSecondResp.Body.Close()
-	}()
-	if createSecondResp.StatusCode != http.StatusCreated {
-		t.Fatalf("create second column status = %d, want %d", createSecondResp.StatusCode, http.StatusCreated)
-	}
-	second := parseColumn(t, createSecondResp)
-
-	// 5. Create the third column so we can verify position shifting after delete
-	createThirdResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{"name": "Done"})
-	defer func() {
-		_ = createThirdResp.Body.Close()
-	}()
-	if createThirdResp.StatusCode != http.StatusCreated {
-		t.Fatalf("create third column status = %d, want %d", createThirdResp.StatusCode, http.StatusCreated)
-	}
-	third := parseColumn(t, createThirdResp)
-
-	// 6. Delete the middle column and expect the request to succeed
-	deleteResp := ac.Do(t, http.MethodDelete, "/v1/boards/"+board.ID+"/columns/"+second.ID, nil)
-	defer func() {
-		_ = deleteResp.Body.Close()
-	}()
-	if deleteResp.StatusCode != http.StatusNoContent {
-		t.Fatalf("delete column status = %d, want %d", deleteResp.StatusCode, http.StatusNoContent)
-	}
-
-	// 7. List columns again and verify the remaining columns have compacted positions
-	listResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns", nil)
-	defer func() {
-		_ = listResp.Body.Close()
-	}()
-	if listResp.StatusCode != http.StatusOK {
-		t.Fatalf("list columns status = %d, want %d", listResp.StatusCode, http.StatusOK)
-	}
-	columns := parseColumnsList(t, listResp)
-	if len(columns) != 2 {
-		t.Fatalf("expected 2 columns after delete, got %d", len(columns))
-	}
-	if columns[0].ID != first.ID || columns[0].Position != 1 {
-		t.Errorf("expected first column to stay position 1, got id=%s position=%d", columns[0].ID, columns[0].Position)
-	}
-	if columns[1].ID != third.ID || columns[1].Position != 2 {
-		t.Errorf("expected third column to shift to position 2, got id=%s position=%d", columns[1].ID, columns[1].Position)
-	}
 }

--- a/tests/column_test.go
+++ b/tests/column_test.go
@@ -173,3 +173,85 @@ func parseColumnsList(t *testing.T, resp *http.Response) []columnJSON {
 	}
 	return c
 }
+
+func TestColumn_Delete_ShiftsPositions(t *testing.T) {
+	httpClient, ts, pool := Prelude(t)
+
+	testutil.TruncateTable(t, pool, "columns")
+	testutil.TruncateTable(t, pool, "boards")
+	testutil.TruncateTable(t, pool, "users")
+
+	// 1. Register (already done via ac client)
+	ac := CreateUserAndAuthenticateClient(t, httpClient, ts.URL)
+
+	// 2. Create a board for the column ordering scenario
+	createBoardResp := ac.Do(t, http.MethodPost, "/v1/boards", map[string]string{
+		"name":        testutil.ValidBoardName().String(),
+		"description": testutil.ValidBoardDescription().String(),
+	})
+	defer func() {
+		_ = createBoardResp.Body.Close()
+	}()
+	if createBoardResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create board status = %d, want %d", createBoardResp.StatusCode, http.StatusCreated)
+	}
+	board := parseBoard(t, createBoardResp)
+
+	// 3. Create the first column and keep its response for position checks
+	createFirstResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{"name": "Todo"})
+	defer func() {
+		_ = createFirstResp.Body.Close()
+	}()
+	if createFirstResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create first column status = %d, want %d", createFirstResp.StatusCode, http.StatusCreated)
+	}
+	first := parseColumn(t, createFirstResp)
+
+	// 4. Create the second column that will be deleted later
+	createSecondResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{"name": "In Progress"})
+	defer func() {
+		_ = createSecondResp.Body.Close()
+	}()
+	if createSecondResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create second column status = %d, want %d", createSecondResp.StatusCode, http.StatusCreated)
+	}
+	second := parseColumn(t, createSecondResp)
+
+	// 5. Create the third column so we can verify position shifting after delete
+	createThirdResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{"name": "Done"})
+	defer func() {
+		_ = createThirdResp.Body.Close()
+	}()
+	if createThirdResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create third column status = %d, want %d", createThirdResp.StatusCode, http.StatusCreated)
+	}
+	third := parseColumn(t, createThirdResp)
+
+	// 6. Delete the middle column and expect the request to succeed
+	deleteResp := ac.Do(t, http.MethodDelete, "/v1/boards/"+board.ID+"/columns/"+second.ID, nil)
+	defer func() {
+		_ = deleteResp.Body.Close()
+	}()
+	if deleteResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete column status = %d, want %d", deleteResp.StatusCode, http.StatusNoContent)
+	}
+
+	// 7. List columns again and verify the remaining columns have compacted positions
+	listResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns", nil)
+	defer func() {
+		_ = listResp.Body.Close()
+	}()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("list columns status = %d, want %d", listResp.StatusCode, http.StatusOK)
+	}
+	columns := parseColumnsList(t, listResp)
+	if len(columns) != 2 {
+		t.Fatalf("expected 2 columns after delete, got %d", len(columns))
+	}
+	if columns[0].ID != first.ID || columns[0].Position != 1 {
+		t.Errorf("expected first column to stay position 1, got id=%s position=%d", columns[0].ID, columns[0].Position)
+	}
+	if columns[1].ID != third.ID || columns[1].Position != 2 {
+		t.Errorf("expected third column to shift to position 2, got id=%s position=%d", columns[1].ID, columns[1].Position)
+	}
+}


### PR DESCRIPTION
### Related Issues
Refers to #144

### Summary
- Allow user to delete their columns
- Automatic cascade reposition to fill in position gap after deletion

### Technical Details (optional)
Cascade reposition is fine, since we won't have that much columns

### Verification
- [x] Tests extended
- [x] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [x] Unit tests added/updated
- [x] Documentation updated
- [x] No sensitive data committed