### PR TITLE
fix: pass t as argument to setup* during mocking

### DIFF
--- a/internal/http/handler/auth_test.go
+++ b/internal/http/handler/auth_test.go
@@ -15,11 +15,11 @@ import (
 )
 
 type authTestCase struct {
-	name         string
-	inputBody    any
-	setupMock    func(s *MockAuth)
-	expectedCode int
-	expectedBody any
+	name             string
+	inputBody        any
+	setupAuthService func(t *testing.T, s *MockAuthService)
+	expectedCode     int
+	expectedBody     any
 }
 
 func TestAuth_Register(t *testing.T) {
@@ -32,7 +32,7 @@ func TestAuth_Register(t *testing.T) {
 		{
 			name:      "Success",
 			inputBody: map[string]string{"email": email.String(), "password": password.String()},
-			setupMock: func(s *MockAuth) {
+			setupAuthService: func(t *testing.T, s *MockAuthService) {
 				s.RegisterFunc = func(ctx context.Context, e domain.Email, p domain.UserPassword) error {
 					if e != email {
 						t.Errorf("expected email %q, got %q", email, e)
@@ -49,7 +49,7 @@ func TestAuth_Register(t *testing.T) {
 		{
 			name:      "Internal error",
 			inputBody: map[string]string{"email": email.String(), "password": password.String()},
-			setupMock: func(s *MockAuth) {
+			setupAuthService: func(_ *testing.T, s *MockAuthService) {
 				s.RegisterFunc = func(ctx context.Context, email domain.Email, password domain.UserPassword) error {
 					return service.ErrInternal
 				}
@@ -103,7 +103,7 @@ func TestAuth_Register(t *testing.T) {
 		{
 			name:      "User already exists",
 			inputBody: map[string]string{"email": email.String(), "password": password.String()},
-			setupMock: func(s *MockAuth) {
+			setupAuthService: func(_ *testing.T, s *MockAuthService) {
 				s.RegisterFunc = func(ctx context.Context, email domain.Email, password domain.UserPassword) error {
 					return service.ErrUserAlreadyExists
 				}
@@ -121,7 +121,7 @@ func TestAuth_Register(t *testing.T) {
 		{
 			name:      "Unknown error",
 			inputBody: map[string]string{"email": email.String(), "password": password.String()},
-			setupMock: func(s *MockAuth) {
+			setupAuthService: func(_ *testing.T, s *MockAuthService) {
 				s.RegisterFunc = func(ctx context.Context, email domain.Email, password domain.UserPassword) error {
 					return errors.New("unknown error")
 				}
@@ -141,10 +141,10 @@ func TestAuth_Register(t *testing.T) {
 
 			req, rr := testutil.NewJSONRequestAndRecorder(t, http.MethodPost, "/register", tt.inputBody)
 
-			s := MockAuth{}
+			s := MockAuthService{}
 
-			if tt.setupMock != nil {
-				tt.setupMock(&s)
+			if tt.setupAuthService != nil {
+				tt.setupAuthService(t, &s)
 			}
 
 			logger := testutil.NewTestLogger(t)
@@ -168,7 +168,7 @@ func TestAuth_Login(t *testing.T) {
 		{
 			name:      "Success",
 			inputBody: map[string]string{"email": email.String(), "password": password.String()},
-			setupMock: func(s *MockAuth) {
+			setupAuthService: func(t *testing.T, s *MockAuthService) {
 				s.LoginFunc = func(ctx context.Context, e domain.Email, p domain.UserPassword) (string, error) {
 					if e != email {
 						t.Errorf("expected email %q, got %q", email, e)
@@ -185,7 +185,7 @@ func TestAuth_Login(t *testing.T) {
 		{
 			name:      "Invalid credentials",
 			inputBody: map[string]string{"email": email.String(), "password": password.String()},
-			setupMock: func(s *MockAuth) {
+			setupAuthService: func(_ *testing.T, s *MockAuthService) {
 				s.LoginFunc = func(ctx context.Context, email domain.Email, password domain.UserPassword) (string, error) {
 					return "", service.ErrInvalidCredentials
 				}
@@ -203,7 +203,7 @@ func TestAuth_Login(t *testing.T) {
 		{
 			name:      "User not found",
 			inputBody: map[string]string{"email": email.String(), "password": password.String()},
-			setupMock: func(s *MockAuth) {
+			setupAuthService: func(_ *testing.T, s *MockAuthService) {
 				s.LoginFunc = func(ctx context.Context, email domain.Email, password domain.UserPassword) (string, error) {
 					return "", service.ErrUserNotFound // Enumeration and timing attacks are known, this is fine
 				}
@@ -219,7 +219,7 @@ func TestAuth_Login(t *testing.T) {
 		{
 			name:      "Internal error",
 			inputBody: map[string]string{"email": email.String(), "password": password.String()},
-			setupMock: func(s *MockAuth) {
+			setupAuthService: func(_ *testing.T, s *MockAuthService) {
 				s.LoginFunc = func(ctx context.Context, email domain.Email, password domain.UserPassword) (string, error) {
 					return "", service.ErrInternal
 				}
@@ -304,10 +304,10 @@ func TestAuth_Login(t *testing.T) {
 			t.Parallel()
 			req, rr := testutil.NewJSONRequestAndRecorder(t, http.MethodPost, "/login", tt.inputBody)
 
-			s := &MockAuth{}
+			s := &MockAuthService{}
 
-			if tt.setupMock != nil {
-				tt.setupMock(s)
+			if tt.setupAuthService != nil {
+				tt.setupAuthService(t, s)
 			}
 
 			logger := testutil.NewTestLogger(t)
@@ -356,7 +356,7 @@ func TestAuth_WhoAmI(t *testing.T) {
 			req = req.WithContext(tt.context)
 
 			logger := testutil.NewTestLogger(t)
-			h := handler.NewAuth(logger, &MockAuth{}, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
+			h := handler.NewAuth(logger, &MockAuthService{}, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
 			h.WhoAmI(rr, req)
 
 			testutil.AssertStatusCode(t, rr, tt.expectedCode)

--- a/internal/http/handler/boards_test.go
+++ b/internal/http/handler/boards_test.go
@@ -18,13 +18,13 @@ import (
 )
 
 type boardsTestCase struct {
-	name         string
-	inputBody    any
-	context      context.Context
-	setupMock    func(s *MockBoards)
-	expectedCode int
-	expectedBody any
-	path         string
+	name              string
+	inputBody         any
+	context           context.Context
+	setupBoardService func(t *testing.T, s *MockBoardService)
+	expectedCode      int
+	expectedBody      any
+	path              string
 }
 
 const timeFormat = "2006-01-02T15:04:05.000Z07:00"
@@ -38,7 +38,7 @@ func TestBoards_Create(t *testing.T) {
 		{
 			name:      "Success",
 			inputBody: map[string]string{"name": validBoard.Name.String(), "description": validBoard.Description.String()},
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.CreateFunc = func(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
 					if ownerID != validBoard.OwnerID {
 						t.Errorf("expected ownerID %v, got %v", validBoard.OwnerID, ownerID)
@@ -84,7 +84,7 @@ func TestBoards_Create(t *testing.T) {
 		{
 			name:      "Internal error",
 			inputBody: map[string]string{"name": validBoard.Name.String(), "description": validBoard.Description.String()},
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.CreateFunc = func(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
 					return domain.Board{}, service.ErrInternal
 				}
@@ -95,7 +95,7 @@ func TestBoards_Create(t *testing.T) {
 		{
 			name:      "Unknown error",
 			inputBody: map[string]string{"name": validBoard.Name.String(), "description": validBoard.Description.String()},
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.CreateFunc = func(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
 					return domain.Board{}, errors.New("unknown error")
 				}
@@ -117,10 +117,10 @@ func TestBoards_Create(t *testing.T) {
 				req = req.WithContext(context.WithValue(req.Context(), httpschema.ContextKeyUserID, validBoard.OwnerID))
 			}
 
-			s := &MockBoards{}
+			s := &MockBoardService{}
 
-			if tt.setupMock != nil {
-				tt.setupMock(s)
+			if tt.setupBoardService != nil {
+				tt.setupBoardService(t, s)
 			}
 
 			logger := testutil.NewTestLogger(t)
@@ -144,7 +144,7 @@ func TestBoards_Get(t *testing.T) {
 		{
 			name:      "Success",
 			inputBody: "",
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.GetManyFunc = func(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error) {
 					if ownerID != validBoard.OwnerID {
 						t.Errorf("expected ownerID %v, got %v", validBoard.OwnerID, ownerID)
@@ -175,7 +175,7 @@ func TestBoards_Get(t *testing.T) {
 		{
 			name:      "Internal error",
 			inputBody: "",
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.GetManyFunc = func(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error) {
 					return nil, service.ErrInternal
 				}
@@ -186,7 +186,7 @@ func TestBoards_Get(t *testing.T) {
 		{
 			name:      "Unknown error",
 			inputBody: "",
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.GetManyFunc = func(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error) {
 					return nil, errors.New("unknown error")
 				}
@@ -208,10 +208,10 @@ func TestBoards_Get(t *testing.T) {
 				req = req.WithContext(context.WithValue(req.Context(), httpschema.ContextKeyUserID, validBoard.OwnerID))
 			}
 
-			s := &MockBoards{}
+			s := &MockBoardService{}
 
-			if tt.setupMock != nil {
-				tt.setupMock(s)
+			if tt.setupBoardService != nil {
+				tt.setupBoardService(t, s)
 			}
 
 			logger := testutil.NewTestLogger(t)
@@ -236,7 +236,7 @@ func TestBoards_GetByID(t *testing.T) {
 		{
 			name: "Success",
 			path: okPath,
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.GetFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
 					if ownerID != validBoard.OwnerID || boardID != validBoard.ID {
 						t.Errorf("unexpected ownerID %v boardID %v", ownerID, boardID)
@@ -263,7 +263,7 @@ func TestBoards_GetByID(t *testing.T) {
 		{
 			name: "Not found",
 			path: okPath,
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.GetFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, service.ErrBoardNotFound
 				}
@@ -274,7 +274,7 @@ func TestBoards_GetByID(t *testing.T) {
 		{
 			name: "Internal error",
 			path: okPath,
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.GetFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, service.ErrInternal
 				}
@@ -285,7 +285,7 @@ func TestBoards_GetByID(t *testing.T) {
 		{
 			name: "Unknown error",
 			path: okPath,
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.GetFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, errors.New("unknown")
 				}
@@ -316,9 +316,9 @@ func TestBoards_GetByID(t *testing.T) {
 
 			rr := httptest.NewRecorder()
 
-			s := &MockBoards{}
-			if tt.setupMock != nil {
-				tt.setupMock(s)
+			s := &MockBoardService{}
+			if tt.setupBoardService != nil {
+				tt.setupBoardService(t, s)
 			}
 
 			logger := testutil.NewTestLogger(t)
@@ -351,7 +351,7 @@ func TestBoards_UpdateByID(t *testing.T) {
 				"name":        updatedValidBoard.Name.String(),
 				"description": updatedValidBoard.Description.String(),
 			},
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 					if ownerID != validBoard.OwnerID || boardID != validBoard.ID {
 						t.Errorf("unexpected ownerID %v boardID %v", ownerID, boardID)
@@ -391,7 +391,7 @@ func TestBoards_UpdateByID(t *testing.T) {
 			inputBody: map[string]string{
 				"name": updatedNameOnlyBoard.Name.String(),
 			},
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 					if name == nil || *name != updatedNameOnlyBoard.Name {
 						t.Errorf("unexpected name %+v", name)
@@ -418,7 +418,7 @@ func TestBoards_UpdateByID(t *testing.T) {
 			inputBody: map[string]string{
 				"description": updatedDescriptionOnlyBoard.Description.String(),
 			},
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 					if name != nil {
 						t.Errorf("expected nil name, got %+v", name)
@@ -443,7 +443,7 @@ func TestBoards_UpdateByID(t *testing.T) {
 			name:      "Success (null fields mean skip)",
 			path:      okPath,
 			inputBody: map[string]any{"name": nil, "description": nil},
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 					if name != nil || description != nil {
 						t.Errorf("expected nil pointers, got name=%+v description=%+v", name, description)
@@ -468,7 +468,7 @@ func TestBoards_UpdateByID(t *testing.T) {
 				"name":        emptyDescriptionBoard.Name.String(),
 				"description": "",
 			},
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 					if name == nil || description == nil {
 						t.Errorf("expected non-nil pointers")
@@ -499,7 +499,7 @@ func TestBoards_UpdateByID(t *testing.T) {
 				"name":        validBoard.Name.String(),
 				"description": validBoard.Description.String(),
 			},
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 					return domain.Board{}, service.ErrBoardNotFound
 				}
@@ -514,7 +514,7 @@ func TestBoards_UpdateByID(t *testing.T) {
 				"name":        validBoard.Name.String(),
 				"description": validBoard.Description.String(),
 			},
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 					return domain.Board{}, service.ErrInternal
 				}
@@ -529,7 +529,7 @@ func TestBoards_UpdateByID(t *testing.T) {
 				"name":        validBoard.Name.String(),
 				"description": validBoard.Description.String(),
 			},
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 					return domain.Board{}, errors.New("unknown")
 				}
@@ -562,9 +562,9 @@ func TestBoards_UpdateByID(t *testing.T) {
 			}
 			req.SetPathValue("boardId", strings.TrimPrefix(tt.path, "/v1/boards/"))
 
-			s := &MockBoards{}
-			if tt.setupMock != nil {
-				tt.setupMock(s)
+			s := &MockBoardService{}
+			if tt.setupBoardService != nil {
+				tt.setupBoardService(t, s)
 			}
 
 			logger := testutil.NewTestLogger(t)
@@ -588,7 +588,7 @@ func TestBoards_Delete(t *testing.T) {
 		{
 			name: "Success",
 			path: okPath,
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.DeleteFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) error {
 					if ownerID != validBoard.OwnerID || boardID != validBoard.ID {
 						t.Errorf("unexpected ownerID %v boardID %v", ownerID, boardID)
@@ -608,7 +608,7 @@ func TestBoards_Delete(t *testing.T) {
 		{
 			name: "Not found",
 			path: okPath,
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.DeleteFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) error {
 					return service.ErrBoardNotFound
 				}
@@ -619,7 +619,7 @@ func TestBoards_Delete(t *testing.T) {
 		{
 			name: "Internal error",
 			path: okPath,
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.DeleteFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) error {
 					return service.ErrInternal
 				}
@@ -630,7 +630,7 @@ func TestBoards_Delete(t *testing.T) {
 		{
 			name: "Unknown error",
 			path: okPath,
-			setupMock: func(s *MockBoards) {
+			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.DeleteFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) error {
 					return errors.New("unknown")
 				}
@@ -661,9 +661,9 @@ func TestBoards_Delete(t *testing.T) {
 
 			rr := httptest.NewRecorder()
 
-			s := &MockBoards{}
-			if tt.setupMock != nil {
-				tt.setupMock(s)
+			s := &MockBoardService{}
+			if tt.setupBoardService != nil {
+				tt.setupBoardService(t, s)
 			}
 
 			logger := testutil.NewTestLogger(t)

--- a/internal/http/handler/columns_test.go
+++ b/internal/http/handler/columns_test.go
@@ -22,19 +22,19 @@ func TestColumns_Create(t *testing.T) {
 	validColumn := testutil.ValidColumn(validBoard.ID)
 
 	tests := []struct {
-		name         string
-		path         string
-		inputBody    any
-		context      context.Context
-		setupMock    func(s *MockColumns)
-		expectedCode int
-		expectedBody any
+		name               string
+		path               string
+		inputBody          any
+		context            context.Context
+		setupColumnService func(t *testing.T, s *MockColumnService)
+		expectedCode       int
+		expectedBody       any
 	}{
 		{
 			name:      "Success",
 			path:      "/v1/boards/" + validBoard.ID.String() + "/columns",
 			inputBody: map[string]string{"name": validColumn.Name.String()},
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
 					if callerID != validBoard.OwnerID {
 						t.Errorf("expected caller id %v, got %v", validBoard.OwnerID, callerID)
@@ -91,7 +91,7 @@ func TestColumns_Create(t *testing.T) {
 			name:      "Board not found",
 			path:      "/v1/boards/" + validBoard.ID.String() + "/columns",
 			inputBody: map[string]string{"name": "To Do"},
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
 					return domain.Column{}, service.ErrBoardNotFound
 				}
@@ -103,7 +103,7 @@ func TestColumns_Create(t *testing.T) {
 			name:      "Internal error",
 			path:      "/v1/boards/" + validBoard.ID.String() + "/columns",
 			inputBody: map[string]string{"name": "To Do"},
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
 					return domain.Column{}, service.ErrInternal
 				}
@@ -115,7 +115,7 @@ func TestColumns_Create(t *testing.T) {
 			name:      "Unexpected error",
 			path:      "/v1/boards/" + validBoard.ID.String() + "/columns",
 			inputBody: map[string]string{"name": "To Do"},
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
 					return domain.Column{}, errors.New("db exploded")
 				}
@@ -145,9 +145,9 @@ func TestColumns_Create(t *testing.T) {
 			req.SetPathValue("boardId", strings.TrimPrefix(strings.TrimSuffix(tt.path, "/columns"), "/v1/boards/"))
 
 			rr := httptest.NewRecorder()
-			mockColumns := &MockColumns{}
-			if tt.setupMock != nil {
-				tt.setupMock(mockColumns)
+			mockColumns := &MockColumnService{}
+			if tt.setupColumnService != nil {
+				tt.setupColumnService(t, mockColumns)
 			}
 
 			logger := testutil.NewTestLogger(t)
@@ -170,17 +170,17 @@ func TestColumns_List(t *testing.T) {
 	second.Position, _ = domain.NewColumnPosition(first.Position.Int64() + 1)
 
 	tests := []struct {
-		name         string
-		path         string
-		context      context.Context
-		setupMock    func(s *MockColumns)
-		expectedCode int
-		expectedBody any
+		name               string
+		path               string
+		context            context.Context
+		setupColumnService func(t *testing.T, s *MockColumnService)
+		expectedCode       int
+		expectedBody       any
 	}{
 		{
 			name: "Success",
 			path: "/v1/boards/" + validBoard.ID.String() + "/columns",
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.ListFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error) {
 					if callerID != validBoard.OwnerID {
 						t.Errorf("expected caller id %v, got %v", validBoard.OwnerID, callerID)
@@ -227,7 +227,7 @@ func TestColumns_List(t *testing.T) {
 		{
 			name: "Board not found",
 			path: "/v1/boards/" + validBoard.ID.String() + "/columns",
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.ListFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error) {
 					return nil, service.ErrBoardNotFound
 				}
@@ -238,7 +238,7 @@ func TestColumns_List(t *testing.T) {
 		{
 			name: "Internal error",
 			path: "/v1/boards/" + validBoard.ID.String() + "/columns",
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.ListFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error) {
 					return nil, service.ErrInternal
 				}
@@ -261,9 +261,9 @@ func TestColumns_List(t *testing.T) {
 			req.SetPathValue("boardId", strings.TrimPrefix(strings.TrimSuffix(tt.path, "/columns"), "/v1/boards/"))
 
 			rr := httptest.NewRecorder()
-			mockColumns := &MockColumns{}
-			if tt.setupMock != nil {
-				tt.setupMock(mockColumns)
+			mockColumns := &MockColumnService{}
+			if tt.setupColumnService != nil {
+				tt.setupColumnService(t, mockColumns)
 			}
 
 			logger := testutil.NewTestLogger(t)
@@ -293,24 +293,19 @@ func TestColumns_UpdateByID(t *testing.T) {
 	okPath := "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String()
 
 	tests := []struct {
-		name         string
-		path         string
-		inputBody    any
-		context      context.Context
-		setupMock    func(s *MockColumns)
-		expectedCode int
-		expectedBody any
+		name               string
+		path               string
+		inputBody          any
+		context            context.Context
+		setupColumnService func(t *testing.T, s *MockColumnService)
+		expectedCode       int
+		expectedBody       any
 	}{
 		{
 			name:      "Success (name update)",
 			path:      okPath,
 			inputBody: map[string]string{"name": updatedName.String()},
-			// FIXME: setupMock receives main t, and not one from a subtest.
-			// This is a critical bug across whole test suite that makes even failed subtests pass,
-			// and the main one will fail with errors which origin is unclear (which subtest failed?)
-			// All the setupMock blocks from app test suite must be rewritten to accept a subtest's t.
-			// Created https://github.com/mipselqq/goroutine/issues/148
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.UpdateByIDFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName) (domain.Column, error) {
 					if callerID != validBoard.OwnerID {
 						t.Errorf("expected caller id %v, got %v", validBoard.OwnerID, callerID)
@@ -341,7 +336,7 @@ func TestColumns_UpdateByID(t *testing.T) {
 			name:      "Success (empty body no-op)",
 			path:      okPath,
 			inputBody: map[string]any{},
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.UpdateByIDFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName) (domain.Column, error) {
 					if name != nil {
 						t.Errorf("expected nil name for no-op patch, got %+v", name)
@@ -399,7 +394,7 @@ func TestColumns_UpdateByID(t *testing.T) {
 			name:      "Column not found",
 			path:      okPath,
 			inputBody: map[string]string{"name": "Renamed"},
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.UpdateByIDFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName) (domain.Column, error) {
 					return domain.Column{}, service.ErrColumnNotFound
 				}
@@ -411,7 +406,7 @@ func TestColumns_UpdateByID(t *testing.T) {
 			name:      "Internal error",
 			path:      okPath,
 			inputBody: map[string]string{"name": "Renamed"},
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.UpdateByIDFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName) (domain.Column, error) {
 					return domain.Column{}, service.ErrInternal
 				}
@@ -447,9 +442,9 @@ func TestColumns_UpdateByID(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			mockColumns := &MockColumns{}
-			if tt.setupMock != nil {
-				tt.setupMock(mockColumns)
+			mockColumns := &MockColumnService{}
+			if tt.setupColumnService != nil {
+				tt.setupColumnService(t, mockColumns)
 			}
 
 			logger := testutil.NewTestLogger(t)
@@ -476,19 +471,19 @@ func TestColumns_Move(t *testing.T) {
 	okPath := "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String() + "/position"
 
 	tests := []struct {
-		name         string
-		path         string
-		inputBody    any
-		context      context.Context
-		setupMock    func(s *MockColumns)
-		expectedCode int
-		expectedBody any
+		name               string
+		path               string
+		inputBody          any
+		context            context.Context
+		setupColumnService func(t *testing.T, s *MockColumnService)
+		expectedCode       int
+		expectedBody       any
 	}{
 		{
 			name:      "Success",
 			path:      okPath,
 			inputBody: map[string]int64{"targetPosition": targetPosition.Int64()},
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.MoveFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, gotTargetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
 					if callerID != validBoard.OwnerID {
 						t.Errorf("expected caller id %v, got %v", validBoard.OwnerID, callerID)
@@ -550,7 +545,7 @@ func TestColumns_Move(t *testing.T) {
 			name:      "Index out of bounds",
 			path:      okPath,
 			inputBody: map[string]int64{"targetPosition": 10},
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.MoveFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, targetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
 					return domain.ColumnPosition{}, service.ErrIndexOutOfBounds
 				}
@@ -562,7 +557,7 @@ func TestColumns_Move(t *testing.T) {
 			name:      "Column not found",
 			path:      okPath,
 			inputBody: map[string]int64{"targetPosition": 1},
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.MoveFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, targetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
 					return domain.ColumnPosition{}, service.ErrColumnNotFound
 				}
@@ -574,7 +569,7 @@ func TestColumns_Move(t *testing.T) {
 			name:      "Internal error",
 			path:      okPath,
 			inputBody: map[string]int64{"targetPosition": 1},
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.MoveFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, targetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
 					return domain.ColumnPosition{}, service.ErrInternal
 				}
@@ -610,9 +605,9 @@ func TestColumns_Move(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			mockColumns := &MockColumns{}
-			if tt.setupMock != nil {
-				tt.setupMock(mockColumns)
+			mockColumns := &MockColumnService{}
+			if tt.setupColumnService != nil {
+				tt.setupColumnService(t, mockColumns)
 			}
 
 			logger := testutil.NewTestLogger(t)
@@ -634,17 +629,17 @@ func TestColumns_Delete(t *testing.T) {
 	okPath := "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String()
 
 	tests := []struct {
-		name         string
-		path         string
-		context      context.Context
-		setupMock    func(s *MockColumns)
-		expectedCode int
-		expectedBody any
+		name               string
+		path               string
+		context            context.Context
+		setupColumnService func(t *testing.T, s *MockColumnService)
+		expectedCode       int
+		expectedBody       any
 	}{
 		{
 			name: "Success",
 			path: okPath,
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.DeleteFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error {
 					if callerID != validBoard.OwnerID {
 						t.Errorf("expected caller id %v, got %v", validBoard.OwnerID, callerID)
@@ -683,7 +678,7 @@ func TestColumns_Delete(t *testing.T) {
 		{
 			name: "Column not found",
 			path: okPath,
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.DeleteFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error {
 					return service.ErrColumnNotFound
 				}
@@ -694,7 +689,7 @@ func TestColumns_Delete(t *testing.T) {
 		{
 			name: "Internal error",
 			path: okPath,
-			setupMock: func(s *MockColumns) {
+			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.DeleteFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error {
 					return service.ErrInternal
 				}
@@ -723,9 +718,9 @@ func TestColumns_Delete(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			mockColumns := &MockColumns{}
-			if tt.setupMock != nil {
-				tt.setupMock(mockColumns)
+			mockColumns := &MockColumnService{}
+			if tt.setupColumnService != nil {
+				tt.setupColumnService(t, mockColumns)
 			}
 
 			logger := testutil.NewTestLogger(t)

--- a/internal/http/handler/helpers_test.go
+++ b/internal/http/handler/helpers_test.go
@@ -8,7 +8,7 @@ import (
 	"goroutine/internal/testutil"
 )
 
-type MockAuth struct {
+type MockAuthService struct {
 	RegisterFunc func(ctx context.Context, email domain.Email, password domain.UserPassword) error
 	LoginFunc    func(ctx context.Context, email domain.Email, password domain.UserPassword) (string, error)
 }
@@ -19,17 +19,17 @@ func AssertFuncNotNil(funcName string, fn any) {
 	}
 }
 
-func (m *MockAuth) Register(ctx context.Context, email domain.Email, password domain.UserPassword) error {
+func (m *MockAuthService) Register(ctx context.Context, email domain.Email, password domain.UserPassword) error {
 	AssertFuncNotNil("AuthService.RegisterFunc", m.RegisterFunc)
 	return m.RegisterFunc(ctx, email, password)
 }
 
-func (m *MockAuth) Login(ctx context.Context, email domain.Email, password domain.UserPassword) (string, error) {
+func (m *MockAuthService) Login(ctx context.Context, email domain.Email, password domain.UserPassword) (string, error) {
 	AssertFuncNotNil("AuthService.LoginFunc", m.LoginFunc)
 	return m.LoginFunc(ctx, email, password)
 }
 
-type MockBoards struct {
+type MockBoardService struct {
 	CreateFunc     func(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error)
 	GetFunc        func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error)
 	GetManyFunc    func(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error)
@@ -37,7 +37,7 @@ type MockBoards struct {
 	DeleteFunc     func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) error
 }
 
-type MockColumns struct {
+type MockColumnService struct {
 	CreateFunc     func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error)
 	ListFunc       func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error)
 	UpdateByIDFunc func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName) (domain.Column, error)
@@ -45,52 +45,52 @@ type MockColumns struct {
 	DeleteFunc     func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error
 }
 
-func (m *MockBoards) Get(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
+func (m *MockBoardService) Get(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
 	AssertFuncNotNil("BoardsService.GetFunc", m.GetFunc)
 	return m.GetFunc(ctx, ownerID, boardID)
 }
 
-func (m *MockBoards) GetMany(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error) {
+func (m *MockBoardService) GetMany(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error) {
 	AssertFuncNotNil("BoardsService.GetManyFunc", m.GetManyFunc)
 	return m.GetManyFunc(ctx, ownerID)
 }
 
-func (m *MockBoards) Create(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
+func (m *MockBoardService) Create(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
 	AssertFuncNotNil("BoardsService.CreateFunc", m.CreateFunc)
 	return m.CreateFunc(ctx, ownerID, name, description)
 }
 
-func (m *MockBoards) UpdateByID(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
+func (m *MockBoardService) UpdateByID(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 	AssertFuncNotNil("BoardsService.UpdateByIDFunc", m.UpdateByIDFunc)
 	return m.UpdateByIDFunc(ctx, ownerID, boardID, name, description)
 }
 
-func (m *MockBoards) Delete(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) error {
+func (m *MockBoardService) Delete(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) error {
 	AssertFuncNotNil("BoardsService.DeleteFunc", m.DeleteFunc)
 	return m.DeleteFunc(ctx, ownerID, boardID)
 }
 
-func (m *MockColumns) Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
+func (m *MockColumnService) Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
 	AssertFuncNotNil("ColumnsService.CreateFunc", m.CreateFunc)
 	return m.CreateFunc(ctx, callerID, boardID, name)
 }
 
-func (m *MockColumns) List(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error) {
+func (m *MockColumnService) List(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error) {
 	AssertFuncNotNil("ColumnsService.ListFunc", m.ListFunc)
 	return m.ListFunc(ctx, callerID, boardID)
 }
 
-func (m *MockColumns) UpdateByID(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName) (domain.Column, error) {
+func (m *MockColumnService) UpdateByID(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName) (domain.Column, error) {
 	AssertFuncNotNil("ColumnsService.UpdateByIDFunc", m.UpdateByIDFunc)
 	return m.UpdateByIDFunc(ctx, callerID, boardID, columnID, name)
 }
 
-func (m *MockColumns) Move(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, targetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
+func (m *MockColumnService) Move(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, targetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
 	AssertFuncNotNil("ColumnsService.MoveFunc", m.MoveFunc)
 	return m.MoveFunc(ctx, callerID, boardID, columnID, targetPosition)
 }
 
-func (m *MockColumns) Delete(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error {
+func (m *MockColumnService) Delete(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error {
 	AssertFuncNotNil("ColumnsService.DeleteFunc", m.DeleteFunc)
 	return m.DeleteFunc(ctx, callerID, boardID, columnID)
 }

--- a/internal/http/middleware/auth_test.go
+++ b/internal/http/middleware/auth_test.go
@@ -19,13 +19,13 @@ func TestAuth(t *testing.T) {
 	mockStatusCode := http.StatusTeapot
 
 	tests := []struct {
-		name           string
-		headerName     string
-		headerValue    string
-		expectedStatus int
-		expectedUserID domain.UserID
-		expectedBody   any
-		setupMock      func(r *MockAuth)
+		name             string
+		headerName       string
+		headerValue      string
+		expectedStatus   int
+		expectedUserID   domain.UserID
+		expectedBody     any
+		setupAuthService func(r *MockAuthService)
 	}{
 		{
 			name:           "Valid token",
@@ -33,7 +33,7 @@ func TestAuth(t *testing.T) {
 			headerValue:    "Bearer valid.token.here",
 			expectedStatus: mockStatusCode,
 			expectedUserID: userID,
-			setupMock: func(r *MockAuth) {
+			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return userID, nil
 				}
@@ -44,7 +44,7 @@ func TestAuth(t *testing.T) {
 			headerName:     "Authorization",
 			headerValue:    "Bearer invalid.token.here",
 			expectedStatus: http.StatusUnauthorized,
-			setupMock: func(r *MockAuth) {
+			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, service.ErrInvalidToken
 				}
@@ -63,7 +63,7 @@ func TestAuth(t *testing.T) {
 			headerName:     "Authorization",
 			headerValue:    "Bearer expired.token.here",
 			expectedStatus: http.StatusUnauthorized,
-			setupMock: func(r *MockAuth) {
+			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, service.ErrTokenExpired
 				}
@@ -82,7 +82,7 @@ func TestAuth(t *testing.T) {
 			headerName:     "Authorization",
 			headerValue:    "Bearer invalid.signing.method.token.here",
 			expectedStatus: http.StatusUnauthorized,
-			setupMock: func(r *MockAuth) {
+			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, service.ErrInvalidSigningMethod
 				}
@@ -101,7 +101,7 @@ func TestAuth(t *testing.T) {
 			headerName:     "Authorization",
 			headerValue:    "",
 			expectedStatus: http.StatusUnauthorized,
-			setupMock: func(r *MockAuth) {
+			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, nil
 				}
@@ -120,7 +120,7 @@ func TestAuth(t *testing.T) {
 			headerName:     "Authorization",
 			headerValue:    "Bearer",
 			expectedStatus: http.StatusUnauthorized,
-			setupMock: func(r *MockAuth) {
+			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, nil
 				}
@@ -139,7 +139,7 @@ func TestAuth(t *testing.T) {
 			headerName:     "Authorization",
 			headerValue:    "Bearer ",
 			expectedStatus: http.StatusUnauthorized,
-			setupMock: func(r *MockAuth) {
+			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, nil
 				}
@@ -158,7 +158,7 @@ func TestAuth(t *testing.T) {
 			headerName:     "Authorization",
 			headerValue:    "Bearer token extra-part",
 			expectedStatus: http.StatusUnauthorized,
-			setupMock: func(r *MockAuth) {
+			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, nil
 				}
@@ -178,7 +178,7 @@ func TestAuth(t *testing.T) {
 			headerValue:    "   Bearer     valid.token.here   ",
 			expectedStatus: mockStatusCode,
 			expectedUserID: userID,
-			setupMock: func(r *MockAuth) {
+			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return userID, nil
 				}
@@ -190,7 +190,7 @@ func TestAuth(t *testing.T) {
 			headerValue:    "bEaReR vAlId.tOkEn.hErE",
 			expectedStatus: mockStatusCode,
 			expectedUserID: userID,
-			setupMock: func(r *MockAuth) {
+			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return userID, nil
 				}
@@ -201,7 +201,7 @@ func TestAuth(t *testing.T) {
 			headerName:     "Authorization",
 			headerValue:    "Basic some-token",
 			expectedStatus: http.StatusUnauthorized,
-			setupMock: func(r *MockAuth) {
+			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, nil
 				}
@@ -221,8 +221,8 @@ func TestAuth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			s := &MockAuth{}
-			tt.setupMock(s)
+			s := &MockAuthService{}
+			tt.setupAuthService(s)
 
 			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				id, ok := r.Context().Value(httpschema.ContextKeyUserID).(domain.UserID)

--- a/internal/http/middleware/helpers_test.go
+++ b/internal/http/middleware/helpers_test.go
@@ -6,10 +6,10 @@ import (
 	"goroutine/internal/domain"
 )
 
-type MockAuth struct {
+type MockAuthService struct {
 	VerifyTokenFunc func(ctx context.Context, token string) (domain.UserID, error)
 }
 
-func (m *MockAuth) VerifyToken(ctx context.Context, token string) (domain.UserID, error) {
+func (m *MockAuthService) VerifyToken(ctx context.Context, token string) (domain.UserID, error) {
 	return m.VerifyTokenFunc(ctx, token)
 }

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 type TestCase struct {
-	name        string
-	setupMock   func(r *MockUserRepository)
-	expectedErr error
+	name          string
+	setupUserRepo func(r *MockUserRepository)
+	expectedErr   error
 }
 
 func TestAuth_Register(t *testing.T) {
@@ -28,7 +28,7 @@ func TestAuth_Register(t *testing.T) {
 		{
 			name:        "Success",
 			expectedErr: nil,
-			setupMock: func(r *MockUserRepository) {
+			setupUserRepo: func(r *MockUserRepository) {
 				r.InsertFunc = func(ctx context.Context, email domain.Email, hash string) error {
 					if hash == testutil.ValidPassword().String() {
 						return errors.New("service saved plaintext password!")
@@ -40,7 +40,7 @@ func TestAuth_Register(t *testing.T) {
 		{
 			name:        "User already exists",
 			expectedErr: service.ErrUserAlreadyExists,
-			setupMock: func(r *MockUserRepository) {
+			setupUserRepo: func(r *MockUserRepository) {
 				r.InsertFunc = func(ctx context.Context, email domain.Email, hash string) error {
 					return repository.ErrUniqueViolation
 				}
@@ -49,7 +49,7 @@ func TestAuth_Register(t *testing.T) {
 		{
 			name:        "Internal repository error",
 			expectedErr: service.ErrInternal,
-			setupMock: func(r *MockUserRepository) {
+			setupUserRepo: func(r *MockUserRepository) {
 				r.InsertFunc = func(ctx context.Context, email domain.Email, hash string) error {
 					return repository.ErrInternal
 				}
@@ -58,7 +58,7 @@ func TestAuth_Register(t *testing.T) {
 		{
 			name:        "Unexpected repository error",
 			expectedErr: service.ErrInternal,
-			setupMock: func(r *MockUserRepository) {
+			setupUserRepo: func(r *MockUserRepository) {
 				r.InsertFunc = func(ctx context.Context, email domain.Email, hash string) error {
 					return errors.New("Super unknown error happened")
 				}
@@ -71,7 +71,7 @@ func TestAuth_Register(t *testing.T) {
 			t.Parallel()
 
 			r := &MockUserRepository{}
-			tt.setupMock(r)
+			tt.setupUserRepo(r)
 			s := service.NewAuth(r, testutil.ValidJWTOptions())
 
 			err := s.Register(context.Background(), testutil.ValidEmail(), testutil.ValidPassword())
@@ -89,7 +89,7 @@ func TestAuth_Login(t *testing.T) {
 	tests := []TestCase{
 		{
 			name: "Success",
-			setupMock: func(r *MockUserRepository) {
+			setupUserRepo: func(r *MockUserRepository) {
 				r.GetByEmailFunc = func(ctx context.Context, email domain.Email) (domain.UserID, string, error) {
 					return testutil.ValidUserID(), testutil.ValidPasswordHash(), nil
 				}
@@ -99,7 +99,7 @@ func TestAuth_Login(t *testing.T) {
 		{
 			name:        "User not found",
 			expectedErr: service.ErrUserNotFound,
-			setupMock: func(r *MockUserRepository) {
+			setupUserRepo: func(r *MockUserRepository) {
 				r.GetByEmailFunc = func(ctx context.Context, email domain.Email) (domain.UserID, string, error) {
 					return domain.UserID{}, "", repository.ErrRowNotFound
 				}
@@ -108,7 +108,7 @@ func TestAuth_Login(t *testing.T) {
 		{
 			name:        "Invalid password",
 			expectedErr: service.ErrInvalidCredentials,
-			setupMock: func(r *MockUserRepository) {
+			setupUserRepo: func(r *MockUserRepository) {
 				r.GetByEmailFunc = func(ctx context.Context, email domain.Email) (domain.UserID, string, error) {
 					return testutil.ValidUserID(), testutil.AnotherValidPasswordHash(), nil
 				}
@@ -117,7 +117,7 @@ func TestAuth_Login(t *testing.T) {
 		{
 			name:        "Internal repository error",
 			expectedErr: service.ErrInternal,
-			setupMock: func(r *MockUserRepository) {
+			setupUserRepo: func(r *MockUserRepository) {
 				r.GetByEmailFunc = func(ctx context.Context, email domain.Email) (domain.UserID, string, error) {
 					return domain.UserID{}, "", repository.ErrInternal
 				}
@@ -126,7 +126,7 @@ func TestAuth_Login(t *testing.T) {
 		{
 			name:        "Unexpected repository error",
 			expectedErr: service.ErrInternal,
-			setupMock: func(r *MockUserRepository) {
+			setupUserRepo: func(r *MockUserRepository) {
 				r.GetByEmailFunc = func(ctx context.Context, email domain.Email) (domain.UserID, string, error) {
 					return domain.UserID{}, "", errors.New("Super unknown error happened")
 				}
@@ -139,7 +139,7 @@ func TestAuth_Login(t *testing.T) {
 			t.Parallel()
 
 			r := &MockUserRepository{}
-			tt.setupMock(r)
+			tt.setupUserRepo(r)
 			jwtOpts := testutil.ValidJWTOptions()
 			s := service.NewAuth(r, jwtOpts)
 

--- a/internal/service/board_test.go
+++ b/internal/service/board_test.go
@@ -19,14 +19,14 @@ func TestBoard_Create(t *testing.T) {
 	validBoard := testutil.ValidBoard()
 
 	tests := []struct {
-		name        string
-		setupMock   func(r *MockBoardRepository)
-		expectedErr error
-		wantBoard   domain.Board
+		name           string
+		setupBoardRepo func(t *testing.T, r *MockBoardRepository)
+		expectedErr    error
+		wantBoard      domain.Board
 	}{
 		{
 			name: "Success",
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.CreateFunc = func(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
 					if ownerID != validBoard.OwnerID {
 						t.Errorf("expected ownerID %v, got %v", validBoard.OwnerID, ownerID)
@@ -45,7 +45,7 @@ func TestBoard_Create(t *testing.T) {
 		},
 		{
 			name: "Internal error",
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.CreateFunc = func(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
 					return domain.Board{}, repository.ErrInternal
 				}
@@ -54,7 +54,7 @@ func TestBoard_Create(t *testing.T) {
 		},
 		{
 			name: "Unexpected error",
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.CreateFunc = func(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
 					return domain.Board{}, errors.New("unexpected error")
 				}
@@ -68,7 +68,7 @@ func TestBoard_Create(t *testing.T) {
 			t.Parallel()
 
 			r := &MockBoardRepository{}
-			tt.setupMock(r)
+			tt.setupBoardRepo(t, r)
 			s := service.NewBoard(r, testutil.FixedTimeNow)
 
 			got, err := s.Create(context.Background(), validBoard.OwnerID, validBoard.Name, validBoard.Description)
@@ -89,14 +89,14 @@ func TestBoard_GetMany(t *testing.T) {
 	validBoard := testutil.ValidBoard()
 
 	tests := []struct {
-		name        string
-		setupMock   func(r *MockBoardRepository)
-		expectedErr error
-		wantBoards  []domain.Board
+		name           string
+		setupBoardRepo func(t *testing.T, r *MockBoardRepository)
+		expectedErr    error
+		wantBoards     []domain.Board
 	}{
 		{
 			name: "Success",
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetManyFunc = func(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error) {
 					if ownerID != validBoard.OwnerID {
 						t.Errorf("expected ownerID %v, got %v", validBoard.OwnerID, ownerID)
@@ -109,7 +109,7 @@ func TestBoard_GetMany(t *testing.T) {
 		},
 		{
 			name: "Internal error",
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetManyFunc = func(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error) {
 					return nil, repository.ErrInternal
 				}
@@ -118,7 +118,7 @@ func TestBoard_GetMany(t *testing.T) {
 		},
 		{
 			name: "Unexpected error",
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetManyFunc = func(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error) {
 					return nil, errors.New("unexpected error")
 				}
@@ -132,7 +132,7 @@ func TestBoard_GetMany(t *testing.T) {
 			t.Parallel()
 
 			r := &MockBoardRepository{}
-			tt.setupMock(r)
+			tt.setupBoardRepo(t, r)
 			s := service.NewBoard(r, testutil.FixedTimeNow)
 
 			got, err := s.GetMany(context.Background(), validBoard.OwnerID)
@@ -148,11 +148,11 @@ func TestBoard_GetMany(t *testing.T) {
 }
 
 type boardServiceGetTestCase struct {
-	name        string
-	callerID    domain.UserID
-	setupMock   func(r *MockBoardRepository)
-	expectedErr error
-	wantBoard   domain.Board
+	name           string
+	callerID       domain.UserID
+	setupBoardRepo func(t *testing.T, r *MockBoardRepository)
+	expectedErr    error
+	wantBoard      domain.Board
 }
 
 func TestBoard_Get(t *testing.T) {
@@ -165,7 +165,7 @@ func TestBoard_Get(t *testing.T) {
 		{
 			name:     "Success",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					if id != validBoard.ID {
 						t.Errorf("expected board id %v, got %v", validBoard.ID, id)
@@ -179,7 +179,7 @@ func TestBoard_Get(t *testing.T) {
 		{
 			name:     "Not found when not owner",
 			callerID: otherOwner,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
@@ -189,7 +189,7 @@ func TestBoard_Get(t *testing.T) {
 		{
 			name:     "Not found when row missing",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, repository.ErrRowNotFound
 				}
@@ -199,7 +199,7 @@ func TestBoard_Get(t *testing.T) {
 		{
 			name:     "Internal error from repository",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, repository.ErrInternal
 				}
@@ -209,7 +209,7 @@ func TestBoard_Get(t *testing.T) {
 		{
 			name:     "Unexpected error from repository",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, errors.New("db exploded")
 				}
@@ -223,7 +223,7 @@ func TestBoard_Get(t *testing.T) {
 			t.Parallel()
 
 			r := &MockBoardRepository{}
-			tt.setupMock(r)
+			tt.setupBoardRepo(t, r)
 			s := service.NewBoard(r, testutil.FixedTimeNow)
 
 			got, err := s.Get(context.Background(), tt.callerID, validBoard.ID)
@@ -257,7 +257,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 		callerID         domain.UserID
 		inputName        *domain.BoardName
 		inputDescription *domain.BoardDescription
-		setupMock        func(r *MockBoardRepository)
+		setupBoardRepo   func(t *testing.T, r *MockBoardRepository)
 		expectedErr      error
 		wantBoard        domain.Board
 	}{
@@ -266,7 +266,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 			callerID:         validBoard.OwnerID,
 			inputName:        &updatedName,
 			inputDescription: &updatedDescription,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.UpdateByIDFunc = func(ctx context.Context, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription, updatedAt time.Time) (domain.Board, error) {
 					if boardID != validBoard.ID {
 						t.Errorf("unexpected boardID %v", boardID)
@@ -297,7 +297,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 			name:      "Success update only name",
 			callerID:  validBoard.OwnerID,
 			inputName: &updatedNameOnly,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.UpdateByIDFunc = func(ctx context.Context, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription, updatedAt time.Time) (domain.Board, error) {
 					if updatedAt != updatedNameOnlyBoard.UpdatedAt {
 						t.Errorf("unexpected updatedAt %v", updatedAt)
@@ -321,7 +321,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 			name:             "Success update only description",
 			callerID:         validBoard.OwnerID,
 			inputDescription: &updatedDescriptionOnly,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.UpdateByIDFunc = func(ctx context.Context, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription, updatedAt time.Time) (domain.Board, error) {
 					if updatedAt != updatedDescriptionOnlyBoard.UpdatedAt {
 						t.Errorf("unexpected updatedAt %v", updatedAt)
@@ -344,7 +344,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 		{
 			name:     "Success update no fields",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
@@ -355,7 +355,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 		{
 			name:     "Not found when wrong owner",
 			callerID: otherOwner,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
@@ -365,7 +365,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 		{
 			name:     "Not found when row missing",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, repository.ErrRowNotFound
 				}
@@ -376,7 +376,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 			name:      "Internal error",
 			callerID:  validBoard.OwnerID,
 			inputName: &updatedName,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
@@ -390,7 +390,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 			name:      "Unexpected error",
 			callerID:  validBoard.OwnerID,
 			inputName: &updatedName,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
@@ -403,7 +403,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 		{
 			name:     "Unexpected get by id error",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, errors.New("db exploded")
 				}
@@ -417,7 +417,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 			t.Parallel()
 
 			r := &MockBoardRepository{}
-			tt.setupMock(r)
+			tt.setupBoardRepo(t, r)
 			s := service.NewBoard(r, testutil.FixedTime5mFromNow)
 
 			got, err := s.UpdateByID(context.Background(), tt.callerID, validBoard.ID, tt.inputName, tt.inputDescription)
@@ -439,15 +439,15 @@ func TestBoard_Delete(t *testing.T) {
 	otherOwner := domain.NewUserID()
 
 	tests := []struct {
-		name        string
-		callerID    domain.UserID
-		setupMock   func(r *MockBoardRepository)
-		expectedErr error
+		name           string
+		callerID       domain.UserID
+		setupBoardRepo func(t *testing.T, r *MockBoardRepository)
+		expectedErr    error
 	}{
 		{
 			name:     "Success",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					if id != validBoard.ID {
 						t.Errorf("unexpected boardID %v", id)
@@ -466,7 +466,7 @@ func TestBoard_Delete(t *testing.T) {
 		{
 			name:     "Not found when wrong owner",
 			callerID: otherOwner,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
@@ -476,7 +476,7 @@ func TestBoard_Delete(t *testing.T) {
 		{
 			name:     "Not found when row missing",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, repository.ErrRowNotFound
 				}
@@ -486,7 +486,7 @@ func TestBoard_Delete(t *testing.T) {
 		{
 			name:     "Internal error from repository",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, repository.ErrInternal
 				}
@@ -496,7 +496,7 @@ func TestBoard_Delete(t *testing.T) {
 		{
 			name:     "Unexpected error from repository",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, errors.New("db exploded")
 				}
@@ -506,7 +506,7 @@ func TestBoard_Delete(t *testing.T) {
 		{
 			name:     "Delete returns not found",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
@@ -519,7 +519,7 @@ func TestBoard_Delete(t *testing.T) {
 		{
 			name:     "Delete returns internal",
 			callerID: validBoard.OwnerID,
-			setupMock: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
@@ -536,7 +536,7 @@ func TestBoard_Delete(t *testing.T) {
 			t.Parallel()
 
 			r := &MockBoardRepository{}
-			tt.setupMock(r)
+			tt.setupBoardRepo(t, r)
 			s := service.NewBoard(r, testutil.FixedTimeNow)
 
 			err := s.Delete(context.Background(), tt.callerID, validBoard.ID)

--- a/internal/service/column_test.go
+++ b/internal/service/column_test.go
@@ -35,17 +35,17 @@ func TestColumn_Create(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		callerID    domain.UserID
-		setupBoards func(r *MockBoardRepository)
-		setupColumn func(r *MockColumnRepository)
-		expectedErr error
-		wantColumn  domain.Column
+		name            string
+		callerID        domain.UserID
+		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
+		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
+		expectedErr     error
+		wantColumn      domain.Column
 	}{
 		{
 			name:     "Success",
 			callerID: validBoard.OwnerID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					if id != validBoard.ID {
 						t.Errorf("expected board id %v, got %v", validBoard.ID, id)
@@ -53,7 +53,7 @@ func TestColumn_Create(t *testing.T) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.CreateFunc = func(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, createdAt, updatedAt time.Time) (domain.Column, error) {
 					if boardID != validBoard.ID {
 						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
@@ -72,12 +72,12 @@ func TestColumn_Create(t *testing.T) {
 		{
 			name:     "Board not found",
 			callerID: validBoard.OwnerID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, repository.ErrRowNotFound
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.CreateFunc = func(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, createdAt, updatedAt time.Time) (domain.Column, error) {
 					t.Fatalf("should not be called")
 					return domain.Column{}, nil
@@ -88,12 +88,12 @@ func TestColumn_Create(t *testing.T) {
 		{
 			name:     "Caller has no access",
 			callerID: domain.NewUserID(),
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.CreateFunc = func(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, createdAt, updatedAt time.Time) (domain.Column, error) {
 					t.Fatalf("should not be called")
 					return domain.Column{}, nil
@@ -104,12 +104,12 @@ func TestColumn_Create(t *testing.T) {
 		{
 			name:     "Create internal error",
 			callerID: validBoard.OwnerID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.CreateFunc = func(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, createdAt, updatedAt time.Time) (domain.Column, error) {
 					return domain.Column{}, errors.New("insert failed")
 				}
@@ -124,8 +124,8 @@ func TestColumn_Create(t *testing.T) {
 
 			boardRepo := &MockBoardRepository{}
 			columnRepo := &MockColumnRepository{}
-			tt.setupBoards(boardRepo)
-			tt.setupColumn(columnRepo)
+			tt.setupBoardRepo(t, boardRepo)
+			tt.setupColumnRepo(t, columnRepo)
 
 			s := service.NewColumn(columnRepo, boardRepo, testutil.FixedTimeNow)
 			got, err := s.Create(context.Background(), tt.callerID, validBoard.ID, validName)
@@ -149,22 +149,22 @@ func TestColumn_List(t *testing.T) {
 	second.Position, _ = domain.NewColumnPosition(first.Position.Int64() + 1)
 
 	tests := []struct {
-		name        string
-		callerID    domain.UserID
-		setupBoards func(r *MockBoardRepository)
-		setupColumn func(r *MockColumnRepository)
-		expectedErr error
-		wantColumns []domain.Column
+		name            string
+		callerID        domain.UserID
+		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
+		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
+		expectedErr     error
+		wantColumns     []domain.Column
 	}{
 		{
 			name:     "Success",
 			callerID: validBoard.OwnerID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.ListByBoardIDFunc = func(ctx context.Context, boardID domain.BoardID) ([]domain.Column, error) {
 					if boardID != validBoard.ID {
 						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
@@ -177,12 +177,12 @@ func TestColumn_List(t *testing.T) {
 		{
 			name:     "Board not found",
 			callerID: validBoard.OwnerID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, repository.ErrRowNotFound
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.ListByBoardIDFunc = func(ctx context.Context, boardID domain.BoardID) ([]domain.Column, error) {
 					t.Fatalf("should not be called")
 					return nil, nil
@@ -193,12 +193,12 @@ func TestColumn_List(t *testing.T) {
 		{
 			name:     "No access",
 			callerID: domain.NewUserID(),
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.ListByBoardIDFunc = func(ctx context.Context, boardID domain.BoardID) ([]domain.Column, error) {
 					t.Fatalf("should not be called")
 					return nil, nil
@@ -209,12 +209,12 @@ func TestColumn_List(t *testing.T) {
 		{
 			name:     "Repository error",
 			callerID: validBoard.OwnerID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.ListByBoardIDFunc = func(ctx context.Context, boardID domain.BoardID) ([]domain.Column, error) {
 					return nil, errors.New("db failed")
 				}
@@ -229,8 +229,8 @@ func TestColumn_List(t *testing.T) {
 
 			boardRepo := &MockBoardRepository{}
 			columnRepo := &MockColumnRepository{}
-			tt.setupBoards(boardRepo)
-			tt.setupColumn(columnRepo)
+			tt.setupBoardRepo(t, boardRepo)
+			tt.setupColumnRepo(t, columnRepo)
 
 			s := service.NewColumn(columnRepo, boardRepo, testutil.FixedTimeNow)
 			got, err := s.List(context.Background(), tt.callerID, validBoard.ID)
@@ -259,26 +259,26 @@ func TestColumn_UpdateByID(t *testing.T) {
 	updatedColumn.UpdatedAt = testutil.FixedTimeNow()
 
 	tests := []struct {
-		name        string
-		callerID    domain.UserID
-		columnID    domain.ColumnID
-		patchName   *domain.ColumnName
-		setupBoards func(r *MockBoardRepository)
-		setupColumn func(r *MockColumnRepository)
-		expectedErr error
-		wantColumn  domain.Column
+		name            string
+		callerID        domain.UserID
+		columnID        domain.ColumnID
+		patchName       *domain.ColumnName
+		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
+		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
+		expectedErr     error
+		wantColumn      domain.Column
 	}{
 		{
 			name:      "Success",
 			callerID:  validBoard.OwnerID,
 			columnID:  validColumn.ID,
 			patchName: &updatedName,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					if columnID != validColumn.ID {
 						t.Errorf("expected column id %v, got %v", validColumn.ID, columnID)
@@ -307,12 +307,12 @@ func TestColumn_UpdateByID(t *testing.T) {
 			name:     "Success no-op patch",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					return validColumn, nil
 				}
@@ -327,12 +327,12 @@ func TestColumn_UpdateByID(t *testing.T) {
 			name:     "Board not found",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, repository.ErrRowNotFound
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					t.Fatalf("should not be called")
 					return domain.Column{}, nil
@@ -348,12 +348,12 @@ func TestColumn_UpdateByID(t *testing.T) {
 			name:     "Caller has no access",
 			callerID: domain.NewUserID(),
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					t.Fatalf("should not be called")
 					return domain.Column{}, nil
@@ -369,12 +369,12 @@ func TestColumn_UpdateByID(t *testing.T) {
 			name:     "Column does not belong to board",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					otherBoardColumn := validColumn
 					otherBoardColumn.BoardID = domain.NewBoardID()
@@ -391,12 +391,12 @@ func TestColumn_UpdateByID(t *testing.T) {
 			name:     "Column not found",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					return domain.Column{}, repository.ErrRowNotFound
 				}
@@ -412,12 +412,12 @@ func TestColumn_UpdateByID(t *testing.T) {
 			callerID:  validBoard.OwnerID,
 			columnID:  validColumn.ID,
 			patchName: &updatedName,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					return validColumn, nil
 				}
@@ -435,8 +435,8 @@ func TestColumn_UpdateByID(t *testing.T) {
 
 			boardRepo := &MockBoardRepository{}
 			columnRepo := &MockColumnRepository{}
-			tt.setupBoards(boardRepo)
-			tt.setupColumn(columnRepo)
+			tt.setupBoardRepo(t, boardRepo)
+			tt.setupColumnRepo(t, columnRepo)
 
 			s := service.NewColumn(columnRepo, boardRepo, testutil.FixedTimeNow)
 			got, err := s.UpdateByID(context.Background(), tt.callerID, validBoard.ID, tt.columnID, tt.patchName)
@@ -462,24 +462,24 @@ func TestColumn_Move(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		callerID     domain.UserID
-		columnID     domain.ColumnID
-		setupBoards  func(r *MockBoardRepository)
-		setupColumn  func(r *MockColumnRepository)
-		expectedErr  error
-		wantPosition domain.ColumnPosition
+		name            string
+		callerID        domain.UserID
+		columnID        domain.ColumnID
+		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
+		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
+		expectedErr     error
+		wantPosition    domain.ColumnPosition
 	}{
 		{
 			name:     "Success",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					if columnID != validColumn.ID {
 						t.Errorf("expected column id %v, got %v", validColumn.ID, columnID)
@@ -505,12 +505,12 @@ func TestColumn_Move(t *testing.T) {
 			name:     "Board not found",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, repository.ErrRowNotFound
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					t.Fatalf("should not be called")
 					return domain.Column{}, nil
@@ -526,12 +526,12 @@ func TestColumn_Move(t *testing.T) {
 			name:     "Caller has no access",
 			callerID: domain.NewUserID(),
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					t.Fatalf("should not be called")
 					return domain.Column{}, nil
@@ -547,12 +547,12 @@ func TestColumn_Move(t *testing.T) {
 			name:     "Column belongs to another board",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					otherBoardColumn := validColumn
 					otherBoardColumn.BoardID = domain.NewBoardID()
@@ -569,12 +569,12 @@ func TestColumn_Move(t *testing.T) {
 			name:     "Column not found",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					return domain.Column{}, repository.ErrRowNotFound
 				}
@@ -589,12 +589,12 @@ func TestColumn_Move(t *testing.T) {
 			name:     "Index out of bounds",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					return validColumn, nil
 				}
@@ -608,12 +608,12 @@ func TestColumn_Move(t *testing.T) {
 			name:     "Move row not found",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					return validColumn, nil
 				}
@@ -627,12 +627,12 @@ func TestColumn_Move(t *testing.T) {
 			name:     "Move internal error",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					return validColumn, nil
 				}
@@ -650,8 +650,8 @@ func TestColumn_Move(t *testing.T) {
 
 			boardRepo := &MockBoardRepository{}
 			columnRepo := &MockColumnRepository{}
-			tt.setupBoards(boardRepo)
-			tt.setupColumn(columnRepo)
+			tt.setupBoardRepo(t, boardRepo)
+			tt.setupColumnRepo(t, columnRepo)
 
 			s := service.NewColumn(columnRepo, boardRepo, testutil.FixedTimeNow)
 			got, err := s.Move(context.Background(), tt.callerID, validBoard.ID, tt.columnID, targetPosition)
@@ -673,18 +673,18 @@ func TestColumn_Delete(t *testing.T) {
 	validColumn := testutil.ValidColumn(validBoard.ID)
 
 	tests := []struct {
-		name        string
-		callerID    domain.UserID
-		columnID    domain.ColumnID
-		setupBoards func(r *MockBoardRepository)
-		setupColumn func(r *MockColumnRepository)
-		expectedErr error
+		name            string
+		callerID        domain.UserID
+		columnID        domain.ColumnID
+		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
+		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
+		expectedErr     error
 	}{
 		{
 			name:     "Success",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					if id != validBoard.ID {
 						t.Errorf("expected board id %v, got %v", validBoard.ID, id)
@@ -692,7 +692,7 @@ func TestColumn_Delete(t *testing.T) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
 					if boardID != validBoard.ID {
 						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
@@ -708,12 +708,12 @@ func TestColumn_Delete(t *testing.T) {
 			name:     "Board not found",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return domain.Board{}, repository.ErrRowNotFound
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
 					t.Fatalf("should not be called")
 					return nil
@@ -725,12 +725,12 @@ func TestColumn_Delete(t *testing.T) {
 			name:     "Caller has no access",
 			callerID: domain.NewUserID(),
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
 					t.Fatalf("should not be called")
 					return nil
@@ -742,12 +742,12 @@ func TestColumn_Delete(t *testing.T) {
 			name:     "Column not found",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
 					return repository.ErrRowNotFound
 				}
@@ -758,12 +758,12 @@ func TestColumn_Delete(t *testing.T) {
 			name:     "Delete internal error",
 			callerID: validBoard.OwnerID,
 			columnID: validColumn.ID,
-			setupBoards: func(r *MockBoardRepository) {
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					return validBoard, nil
 				}
 			},
-			setupColumn: func(r *MockColumnRepository) {
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
 					return errors.New("delete failed")
 				}
@@ -778,8 +778,8 @@ func TestColumn_Delete(t *testing.T) {
 
 			boardRepo := &MockBoardRepository{}
 			columnRepo := &MockColumnRepository{}
-			tt.setupBoards(boardRepo)
-			tt.setupColumn(columnRepo)
+			tt.setupBoardRepo(t, boardRepo)
+			tt.setupColumnRepo(t, columnRepo)
 
 			s := service.NewColumn(columnRepo, boardRepo, testutil.FixedTimeNow)
 			err := s.Delete(context.Background(), tt.callerID, validBoard.ID, tt.columnID)


### PR DESCRIPTION
### Related Issues
Closes #148 

### Summary
- Fix bugs where setup* will use outer testing.T instead of subtest's one
- Rename mocks and setup functions along the way for clarity

### Verification
- [x] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [x] Unit tests added/updated
- [ ] Documentation updated
- [x] No sensitive data committed
