### PR TITLE
refactor: use unified test error messages

### DIFF
--- a/DEVELOPER_GUIDELINES.md
+++ b/DEVELOPER_GUIDELINES.md
@@ -105,6 +105,23 @@ For most features, touch layers in this order:
 - Use scenario-oriented test names (`Success`, `Invalid JSON`, `User not found`).
 - Use `internal/testutil` for integration/e2e setup (`SetupTestDB`, `TruncateTable`).
 
+### 6.1 Test failure message naming
+
+- Use only two assertion/failure styles in tests:
+  - **Short form** when the context is already obvious from the subtest name or the assertion itself: `got ..., want ...`.
+  - **Long form** when the failing operation must be named explicitly, especially for unexpected errors, helper functions, or tests with multiple meaningful calls: `SomeCall() error = %v` or `SomeCall() = ..., want ...`.
+- Prefer `got` before `want`.
+- Do not write free-form prose like `unexpected error`, `Failed to decode ...`, `Create second board: ...`, or mixed forms like `QueryRow(Scan board row) error = %v`.
+- Write direct contrasts instead:
+  - Bad: `t.Fatalf("unexpected error: %v", err)`  
+    Good: `t.Fatalf("Create() error = %v", err)`
+  - Bad: `t.Fatalf("Failed to decode board: %v", err)`  
+    Good: `t.Fatalf("Board Decode() error = %v", err)`
+  - Bad: `t.Errorf("expected %q, got %q", want, got)`  
+    Good: `t.Errorf("got %q, want %q", got, want)`
+  - Bad: `t.Errorf("unexpected boardID %v", boardID)`  
+    Good: `t.Errorf("got boardID %v, want %v", boardID, wantBoardID)`
+
 ## 7) Migrations
 
 - Apply schema changes only via files in `migrations/`.

--- a/cmd/ping/main_test.go
+++ b/cmd/ping/main_test.go
@@ -12,7 +12,7 @@ func TestRun(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path != "/v1/health" {
-				t.Errorf("expected path /v1/health, got %q", r.URL.Path)
+				t.Errorf("got path %q, want /v1/health", r.URL.Path)
 			}
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -21,7 +21,7 @@ func TestRun(t *testing.T) {
 		u, _ := url.Parse(ts.URL)
 		err := run(u.Hostname(), u.Port(), 1*time.Second)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("run() error = %v", err)
 		}
 	})
 
@@ -34,7 +34,7 @@ func TestRun(t *testing.T) {
 		u, _ := url.Parse(ts.URL)
 		err := run(u.Hostname(), u.Port(), 1*time.Second)
 		if err == nil {
-			t.Fatal("expected error, got nil")
+			t.Fatal("got nil error, want non-nil")
 		}
 	})
 
@@ -48,14 +48,14 @@ func TestRun(t *testing.T) {
 		u, _ := url.Parse(ts.URL)
 		err := run(u.Hostname(), u.Port(), 10*time.Millisecond)
 		if err == nil {
-			t.Fatal("expected timeout error, got nil")
+			t.Fatal("got nil error, want non-nil")
 		}
 	})
 
 	t.Run("unreachable host", func(t *testing.T) {
 		err := run("127.0.0.1", "0", 1*time.Second)
 		if err == nil {
-			t.Fatal("expected error for unreachable host, got nil")
+			t.Fatal("got nil error, want non-nil")
 		}
 	})
 }

--- a/internal/config/app_test.go
+++ b/internal/config/app_test.go
@@ -48,7 +48,7 @@ func TestNewAppConfigFromEnv(t *testing.T) {
 
 		diff := cmp.Diff(defaultAppConfig, cfg)
 		if diff != "" {
-			t.Errorf("app used unexpected values instead of defaults (-want +got):\n%s", diff)
+			t.Errorf("NewAppConfigFromEnv() diff (-want +got):\n%s", diff)
 		}
 	})
 
@@ -56,7 +56,7 @@ func TestNewAppConfigFromEnv(t *testing.T) {
 		setCustomAppEnvVars(t)
 
 		cfg := config.NewAppConfigFromEnv(testutil.NewDiscardLogger())
-		expectedCfg := config.AppConfig{
+		wantCfg := config.AppConfig{
 			Port:           "3000",
 			AdminPort:      "9092",
 			Host:           "127.0.0.1",
@@ -67,9 +67,9 @@ func TestNewAppConfigFromEnv(t *testing.T) {
 			JWTExp:         time.Hour,
 			AllowedOrigins: config.ParseAllowedOrigins("http://example.com,http://test.com"),
 		}
-		diff := cmp.Diff(expectedCfg, cfg)
+		diff := cmp.Diff(wantCfg, cfg)
 		if diff != "" {
-			t.Errorf("app config used unexpected values instead of env vars (-want +got):\n%s", diff)
+			t.Errorf("NewAppConfigFromEnv() diff (-want +got):\n%s", diff)
 		}
 	})
 
@@ -80,7 +80,7 @@ func TestNewAppConfigFromEnv(t *testing.T) {
 
 		for _, envVar := range appEnvVars {
 			if !strings.Contains(buf.String(), envVar) {
-				t.Errorf("expected warn on unset %q", envVar)
+				t.Errorf("got log output %q, want mention of %q", buf.String(), envVar)
 			}
 		}
 	})
@@ -92,7 +92,7 @@ func TestNewAppConfigFromEnv(t *testing.T) {
 		_ = config.NewAppConfigFromEnv(logger)
 
 		if buf.String() != "" {
-			t.Errorf("expected no warnings on all variables are set, got %q", buf.String())
+			t.Errorf("got warnings %q, want none", buf.String())
 		}
 	})
 }
@@ -100,11 +100,11 @@ func TestNewAppConfigFromEnv(t *testing.T) {
 func TestAppConfig_LogValue(t *testing.T) {
 	v := defaultAppConfig.LogValue()
 	if v.Kind() != slog.KindGroup {
-		t.Fatalf("expected Group kind, got %v", v.Kind())
+		t.Fatalf("got kind %v, want Group", v.Kind())
 	}
 
 	attrs := v.Group()
-	expectedAttrs := map[string]string{
+	wantAttrs := map[string]string{
 		"port":            "8080",
 		"admin_port":      "9091",
 		"host":            "0.0.0.0",
@@ -116,5 +116,5 @@ func TestAppConfig_LogValue(t *testing.T) {
 		"allowed_origins": "[http://127.0.0.1:8080 http://localhost:8080]",
 	}
 
-	testutil.FailOnInvalidLogValue(t, attrs, expectedAttrs)
+	testutil.FailOnInvalidLogValue(t, attrs, wantAttrs)
 }

--- a/internal/config/database_test.go
+++ b/internal/config/database_test.go
@@ -38,7 +38,7 @@ func TestNewPGConfigFromEnv(t *testing.T) {
 
 		diff := cmp.Diff(defaultPgConfig, cfg)
 		if diff != "" {
-			t.Errorf("pg config used unexpected values instead of defaults (-want +got):\n%s", diff)
+			t.Errorf("NewPGConfigFromEnv() diff (-want +got):\n%s", diff)
 		}
 	})
 
@@ -46,16 +46,16 @@ func TestNewPGConfigFromEnv(t *testing.T) {
 		setCustomPgEnvVars(t)
 
 		cfg := config.NewPGConfigFromEnv(testutil.NewDiscardLogger())
-		expectedCfg := config.PgConfig{
+		wantCfg := config.PgConfig{
 			User:     "custom_user",
 			Password: secrecy.SecretString("custom_pass"),
 			Host:     "custom_host",
 			Port:     "5433",
 			DB:       "custom_db",
 		}
-		diff := cmp.Diff(expectedCfg, cfg)
+		diff := cmp.Diff(wantCfg, cfg)
 		if diff != "" {
-			t.Errorf("pg config used unexpected values instead of env vars (-want +got):\n%s", diff)
+			t.Errorf("NewPGConfigFromEnv() diff (-want +got):\n%s", diff)
 		}
 	})
 
@@ -67,7 +67,7 @@ func TestNewPGConfigFromEnv(t *testing.T) {
 
 		for _, envVar := range pgEnvVars {
 			if !strings.Contains(buf.String(), envVar) {
-				t.Errorf("expected warn on unset %q", envVar)
+				t.Errorf("got log output %q, want mention of %q", buf.String(), envVar)
 			}
 		}
 	})
@@ -79,25 +79,25 @@ func TestNewPGConfigFromEnv(t *testing.T) {
 		_ = config.NewPGConfigFromEnv(logger)
 
 		if buf.String() != "" {
-			t.Errorf("expected no warnings, got %q", buf.String())
+			t.Errorf("got warnings %q, want none", buf.String())
 		}
 	})
 }
 
 func TestPgConfig_BuildDSN(t *testing.T) {
-	expected := "postgres://user:password@127.0.0.1:5432/todo_db"
-	if got := defaultPgConfig.BuildDSN(); got != expected {
-		t.Errorf("expected %q, got %q", expected, got)
+	want := "postgres://user:password@127.0.0.1:5432/todo_db"
+	if got := defaultPgConfig.BuildDSN(); got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 
 func TestPgConfig_LogValue(t *testing.T) {
 	v := defaultPgConfig.LogValue()
 	if v.Kind() != slog.KindGroup {
-		t.Fatalf("expected Group kind, got %v", v.Kind())
+		t.Fatalf("got kind %v, want Group", v.Kind())
 	}
 
-	expectedAttrs := map[string]string{
+	wantAttrs := map[string]string{
 		"user":     "user",
 		"password": "(8 chars)",
 		"host":     "127.0.0.1",
@@ -105,5 +105,5 @@ func TestPgConfig_LogValue(t *testing.T) {
 		"db":       "todo_db",
 	}
 
-	testutil.FailOnInvalidLogValue(t, v.Group(), expectedAttrs)
+	testutil.FailOnInvalidLogValue(t, v.Group(), wantAttrs)
 }

--- a/internal/domain/board_test.go
+++ b/internal/domain/board_test.go
@@ -15,52 +15,52 @@ func TestName(t *testing.T) {
 	borderlineLongName := strings.Repeat("a", 128)
 
 	nameTests := []struct {
-		name           string
-		input          string
-		expectedIssues []string
-		expectedValue  string
+		name       string
+		input      string
+		wantIssues []string
+		wantValue  string
 	}{
 		{
-			name:           "Valid name",
-			input:          "My Todo Name",
-			expectedIssues: nil,
-			expectedValue:  "My Todo Name",
+			name:       "Valid name",
+			input:      "My Todo Name",
+			wantIssues: nil,
+			wantValue:  "My Todo Name",
 		},
 		{
-			name:           "Long valid name",
-			input:          borderlineLongName,
-			expectedIssues: nil,
-			expectedValue:  borderlineLongName,
+			name:       "Long valid name",
+			input:      borderlineLongName,
+			wantIssues: nil,
+			wantValue:  borderlineLongName,
 		},
 		{
-			name:           "Too long but valid when trimmed",
-			input:          "      " + borderlineLongName + "     ",
-			expectedIssues: nil,
-			expectedValue:  borderlineLongName,
+			name:       "Too long but valid when trimmed",
+			input:      "      " + borderlineLongName + "     ",
+			wantIssues: nil,
+			wantValue:  borderlineLongName,
 		},
 		{
-			name:           "Too long name",
-			input:          borderlineLongName + "a",
-			expectedIssues: []string{"Name is too long"},
-			expectedValue:  "",
+			name:       "Too long name",
+			input:      borderlineLongName + "a",
+			wantIssues: []string{"Name is too long"},
+			wantValue:  "",
 		},
 		{
-			name:           "Empty name",
-			input:          "",
-			expectedIssues: []string{"Name is too short"},
-			expectedValue:  "",
+			name:       "Empty name",
+			input:      "",
+			wantIssues: []string{"Name is too short"},
+			wantValue:  "",
 		},
 		{
-			name:           "Whitespace name",
-			input:          "    ",
-			expectedIssues: []string{"Name is too short"},
-			expectedValue:  "",
+			name:       "Whitespace name",
+			input:      "    ",
+			wantIssues: []string{"Name is too short"},
+			wantValue:  "",
 		},
 		{
-			name:           "Single character name",
-			input:          "a",
-			expectedIssues: nil,
-			expectedValue:  "a",
+			name:       "Single character name",
+			input:      "a",
+			wantIssues: nil,
+			wantValue:  "a",
 		},
 	}
 
@@ -70,24 +70,24 @@ func TestName(t *testing.T) {
 
 			name, err := domain.NewBoardName(tt.input)
 
-			var actualIssues []string
+			var gotIssues []string
 			if err != nil {
 				var ve *domain.ErrValidation
 				if errors.As(err, &ve) {
-					actualIssues = ve.Issues
+					gotIssues = ve.Issues
 				} else {
-					actualIssues = []string{err.Error()}
+					gotIssues = []string{err.Error()}
 				}
 			}
 
-			if !reflect.DeepEqual(actualIssues, tt.expectedIssues) {
-				t.Errorf("expected issues %v, got %v", tt.expectedIssues, actualIssues)
+			if !reflect.DeepEqual(gotIssues, tt.wantIssues) {
+				t.Errorf("got issues %v, want %v", gotIssues, tt.wantIssues)
 			}
-			if name.String() != tt.expectedValue {
-				t.Errorf("expected value %q, got %q", tt.expectedValue, name)
+			if name.String() != tt.wantValue {
+				t.Errorf("got value %q, want %q", name, tt.wantValue)
 			}
-			if name.IsEmpty() != (tt.expectedValue == "") {
-				t.Errorf("expected is empty %t, got %t", tt.expectedValue == "", name.IsEmpty())
+			if name.IsEmpty() != (tt.wantValue == "") {
+				t.Errorf("got is empty %t, want %t", name.IsEmpty(), tt.wantValue == "")
 			}
 		})
 	}
@@ -99,46 +99,46 @@ func TestDescription(t *testing.T) {
 	borderlineLongDescription := strings.Repeat("a", 1024)
 
 	descriptionTests := []struct {
-		name           string
-		input          string
-		expectedIssues []string
-		expectedValue  string
+		name       string
+		input      string
+		wantIssues []string
+		wantValue  string
 	}{
 		{
-			name:           "Valid description",
-			input:          "My Todo Description",
-			expectedValue:  "My Todo Description",
-			expectedIssues: nil,
+			name:       "Valid description",
+			input:      "My Todo Description",
+			wantValue:  "My Todo Description",
+			wantIssues: nil,
 		},
 		{
-			name:           "Long valid description",
-			input:          borderlineLongDescription,
-			expectedValue:  borderlineLongDescription,
-			expectedIssues: nil,
+			name:       "Long valid description",
+			input:      borderlineLongDescription,
+			wantValue:  borderlineLongDescription,
+			wantIssues: nil,
 		},
 		{
-			name:           "Too long but valid when trimmed",
-			input:          "      " + borderlineLongDescription + "     ",
-			expectedValue:  borderlineLongDescription,
-			expectedIssues: nil,
+			name:       "Too long but valid when trimmed",
+			input:      "      " + borderlineLongDescription + "     ",
+			wantValue:  borderlineLongDescription,
+			wantIssues: nil,
 		},
 		{
-			name:           "Too long description",
-			input:          borderlineLongDescription + "a",
-			expectedIssues: []string{"Description is too long"},
-			expectedValue:  "",
+			name:       "Too long description",
+			input:      borderlineLongDescription + "a",
+			wantIssues: []string{"Description is too long"},
+			wantValue:  "",
 		},
 		{
-			name:           "Empty description",
-			input:          "",
-			expectedIssues: nil,
-			expectedValue:  "",
+			name:       "Empty description",
+			input:      "",
+			wantIssues: nil,
+			wantValue:  "",
 		},
 		{
-			name:           "Whitespace description",
-			input:          "    ",
-			expectedIssues: nil,
-			expectedValue:  "",
+			name:       "Whitespace description",
+			input:      "    ",
+			wantIssues: nil,
+			wantValue:  "",
 		},
 	}
 
@@ -148,24 +148,24 @@ func TestDescription(t *testing.T) {
 
 			description, err := domain.NewBoardDescription(tt.input)
 
-			var actualIssues []string
+			var gotIssues []string
 			if err != nil {
 				var validationError *domain.ErrValidation
 				if errors.As(err, &validationError) {
-					actualIssues = validationError.Issues
+					gotIssues = validationError.Issues
 				} else {
-					actualIssues = []string{err.Error()}
+					gotIssues = []string{err.Error()}
 				}
 			}
 
-			if !reflect.DeepEqual(actualIssues, tt.expectedIssues) {
-				t.Errorf("expected issues %v, got %v", tt.expectedIssues, actualIssues)
+			if !reflect.DeepEqual(gotIssues, tt.wantIssues) {
+				t.Errorf("got issues %v, want %v", gotIssues, tt.wantIssues)
 			}
-			if description.String() != tt.expectedValue {
-				t.Errorf("expected value %q, got %q", tt.expectedValue, description)
+			if description.String() != tt.wantValue {
+				t.Errorf("got value %q, want %q", description, tt.wantValue)
 			}
-			if description.IsEmpty() != (tt.expectedValue == "") {
-				t.Errorf("expected is empty %t, got %t", tt.expectedValue == "", description.IsEmpty())
+			if description.IsEmpty() != (tt.wantValue == "") {
+				t.Errorf("got is empty %t, want %t", description.IsEmpty(), tt.wantValue == "")
 			}
 		})
 	}
@@ -218,12 +218,12 @@ func TestBoardName_Scan(t *testing.T) {
 
 			if tt.wantErr {
 				if err == nil {
-					t.Error("expected error, got nil")
+					t.Error("got nil error, want non-nil")
 				} else if tt.errIs != nil && !errors.Is(err, tt.errIs) {
-					t.Errorf("expected error %v, got %v", tt.errIs, err)
+					t.Errorf("got error %v, want %v", err, tt.errIs)
 				}
 			} else if err != nil {
-				t.Errorf("did not expect error, got %v", err)
+				t.Errorf("got error %v, want nil", err)
 			}
 		})
 	}
@@ -270,12 +270,12 @@ func TestBoardDescription_Scan(t *testing.T) {
 
 			if tt.wantErr {
 				if err == nil {
-					t.Error("expected error, got nil")
+					t.Error("got nil error, want non-nil")
 				} else if tt.errIs != nil && !errors.Is(err, tt.errIs) {
-					t.Errorf("expected error %v, got %v", tt.errIs, err)
+					t.Errorf("got error %v, want %v", err, tt.errIs)
 				}
 			} else if err != nil {
-				t.Errorf("did not expect error, got %v", err)
+				t.Errorf("got error %v, want nil", err)
 			}
 		})
 	}
@@ -336,16 +336,16 @@ func TestBoardID_Scan(t *testing.T) {
 
 			if tt.wantErr {
 				if err == nil {
-					t.Error("expected error, got nil")
+					t.Error("got nil error, want non-nil")
 				} else if tt.errIs != nil && !errors.Is(err, tt.errIs) {
-					t.Errorf("expected error %v, got %v", tt.errIs, err)
+					t.Errorf("got error %v, want %v", err, tt.errIs)
 				}
 			} else {
 				if err != nil {
-					t.Errorf("did not expect error, got %v", err)
+					t.Errorf("got error %v, want nil", err)
 				}
 				if tt.input != nil && id.IsEmpty() {
-					t.Error("expected BoardID to not be empty")
+					t.Error("got empty BoardID after Scan, want non-empty")
 				}
 			}
 		})

--- a/internal/domain/column_test.go
+++ b/internal/domain/column_test.go
@@ -15,17 +15,17 @@ func TestColumnName(t *testing.T) {
 
 	borderlineLongName := strings.Repeat("a", 128)
 	tests := []struct {
-		name           string
-		input          string
-		expectedIssues []string
-		expectedValue  string
+		name       string
+		input      string
+		wantIssues []string
+		wantValue  string
 	}{
-		{name: "Valid", input: "In Progress", expectedValue: "In Progress"},
-		{name: "Long valid", input: borderlineLongName, expectedValue: borderlineLongName},
-		{name: "Too long but valid when trimmed", input: "   " + borderlineLongName + "   ", expectedValue: borderlineLongName},
-		{name: "Too long", input: borderlineLongName + "a", expectedIssues: []string{domain.ErrColumnNameTooLong}},
-		{name: "Empty", input: "", expectedIssues: []string{domain.ErrColumnNameTooShort}},
-		{name: "Whitespace", input: "   ", expectedIssues: []string{domain.ErrColumnNameTooShort}},
+		{name: "Valid", input: "In Progress", wantValue: "In Progress"},
+		{name: "Long valid", input: borderlineLongName, wantValue: borderlineLongName},
+		{name: "Too long but valid when trimmed", input: "   " + borderlineLongName + "   ", wantValue: borderlineLongName},
+		{name: "Too long", input: borderlineLongName + "a", wantIssues: []string{domain.ErrColumnNameTooLong}},
+		{name: "Empty", input: "", wantIssues: []string{domain.ErrColumnNameTooShort}},
+		{name: "Whitespace", input: "   ", wantIssues: []string{domain.ErrColumnNameTooShort}},
 	}
 
 	for _, tt := range tests {
@@ -33,21 +33,21 @@ func TestColumnName(t *testing.T) {
 			t.Parallel()
 
 			name, err := domain.NewColumnName(tt.input)
-			var actualIssues []string
+			var gotIssues []string
 			if err != nil {
 				var ve *domain.ErrValidation
 				if errors.As(err, &ve) {
-					actualIssues = ve.Issues
+					gotIssues = ve.Issues
 				} else {
-					actualIssues = []string{err.Error()}
+					gotIssues = []string{err.Error()}
 				}
 			}
 
-			if !reflect.DeepEqual(actualIssues, tt.expectedIssues) {
-				t.Errorf("expected issues %v, got %v", tt.expectedIssues, actualIssues)
+			if !reflect.DeepEqual(gotIssues, tt.wantIssues) {
+				t.Errorf("got issues %v, want %v", gotIssues, tt.wantIssues)
 			}
-			if name.String() != tt.expectedValue {
-				t.Errorf("expected value %q, got %q", tt.expectedValue, name.String())
+			if name.String() != tt.wantValue {
+				t.Errorf("got value %q, want %q", name.String(), tt.wantValue)
 			}
 		})
 	}
@@ -75,10 +75,10 @@ func TestParseColumnPosition(t *testing.T) {
 
 			_, err := domain.ParseColumnPosition(tt.input)
 			if tt.wantErr && err == nil {
-				t.Error("expected error, got nil")
+				t.Error("got nil error, want non-nil")
 			}
 			if !tt.wantErr && err != nil {
-				t.Errorf("did not expect error, got %v", err)
+				t.Errorf("got error %v, want nil", err)
 			}
 		})
 	}
@@ -88,16 +88,16 @@ func TestColumnPosition(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		input          int64
-		expectedIssues []string
-		expectedValue  int64
+		name       string
+		input      int64
+		wantIssues []string
+		wantValue  int64
 	}{
-		{name: "Valid", input: 1, expectedValue: 1},
-		{name: "Valid max int32", input: math.MaxInt32, expectedValue: math.MaxInt32},
-		{name: "Zero", input: 0, expectedIssues: []string{domain.ErrColumnPositionValue}},
-		{name: "Negative", input: -10, expectedIssues: []string{domain.ErrColumnPositionValue}},
-		{name: "Overflow", input: math.MaxInt32 + 1, expectedIssues: []string{domain.ErrColumnPositionValue}},
+		{name: "Valid", input: 1, wantValue: 1},
+		{name: "Valid max int32", input: math.MaxInt32, wantValue: math.MaxInt32},
+		{name: "Zero", input: 0, wantIssues: []string{domain.ErrColumnPositionValue}},
+		{name: "Negative", input: -10, wantIssues: []string{domain.ErrColumnPositionValue}},
+		{name: "Overflow", input: math.MaxInt32 + 1, wantIssues: []string{domain.ErrColumnPositionValue}},
 	}
 
 	for _, tt := range tests {
@@ -105,21 +105,21 @@ func TestColumnPosition(t *testing.T) {
 			t.Parallel()
 
 			position, err := domain.NewColumnPosition(tt.input)
-			var actualIssues []string
+			var gotIssues []string
 			if err != nil {
 				var ve *domain.ErrValidation
 				if errors.As(err, &ve) {
-					actualIssues = ve.Issues
+					gotIssues = ve.Issues
 				} else {
-					actualIssues = []string{err.Error()}
+					gotIssues = []string{err.Error()}
 				}
 			}
 
-			if !reflect.DeepEqual(actualIssues, tt.expectedIssues) {
-				t.Errorf("expected issues %v, got %v", tt.expectedIssues, actualIssues)
+			if !reflect.DeepEqual(gotIssues, tt.wantIssues) {
+				t.Errorf("got issues %v, want %v", gotIssues, tt.wantIssues)
 			}
-			if tt.expectedIssues == nil && position.Int64() != tt.expectedValue {
-				t.Errorf("expected value %d, got %d", tt.expectedValue, position.Int64())
+			if tt.wantIssues == nil && position.Int64() != tt.wantValue {
+				t.Errorf("got value %d, want %d", position.Int64(), tt.wantValue)
 			}
 		})
 	}
@@ -149,15 +149,15 @@ func TestColumnName_Scan(t *testing.T) {
 			err := name.Scan(tt.input)
 			if tt.wantErr {
 				if err == nil {
-					t.Error("expected error, got nil")
+					t.Error("got nil error, want non-nil")
 				} else if tt.errIs != nil && !errors.Is(err, tt.errIs) {
-					t.Errorf("expected error %v, got %v", tt.errIs, err)
+					t.Errorf("got error %v, want %v", err, tt.errIs)
 				}
 				return
 			}
 
 			if err != nil {
-				t.Errorf("did not expect error, got %v", err)
+				t.Errorf("got error %v, want nil", err)
 			}
 		})
 	}
@@ -187,15 +187,15 @@ func TestColumnPosition_Scan(t *testing.T) {
 			err := position.Scan(tt.input)
 			if tt.wantErr {
 				if err == nil {
-					t.Error("expected error, got nil")
+					t.Error("got nil error, want non-nil")
 				} else if tt.errIs != nil && !errors.Is(err, tt.errIs) {
-					t.Errorf("expected error %v, got %v", tt.errIs, err)
+					t.Errorf("got error %v, want %v", err, tt.errIs)
 				}
 				return
 			}
 
 			if err != nil {
-				t.Errorf("did not expect error, got %v", err)
+				t.Errorf("got error %v, want nil", err)
 			}
 		})
 	}

--- a/internal/domain/email_test.go
+++ b/internal/domain/email_test.go
@@ -11,48 +11,48 @@ func TestEmail(t *testing.T) {
 	t.Parallel()
 
 	emailTests := []struct {
-		name          string
-		input         string
-		expectedValue string
-		expectErr     bool
+		name      string
+		input     string
+		wantValue string
+		wantErr   bool
 	}{
 		{
-			name:      "Valid email",
-			input:     "test@example.com",
-			expectErr: false,
+			name:    "Valid email",
+			input:   "test@example.com",
+			wantErr: false,
 		},
 		{
-			name:      "Invalid email",
-			input:     "invalid-email",
-			expectErr: true,
+			name:    "Invalid email",
+			input:   "invalid-email",
+			wantErr: true,
 		},
 		{
-			name:      "Empty email",
-			input:     "",
-			expectErr: true,
+			name:    "Empty email",
+			input:   "",
+			wantErr: true,
 		},
 		{
-			name:      "Whitespace email",
-			input:     "   ",
-			expectErr: true,
+			name:    "Whitespace email",
+			input:   "   ",
+			wantErr: true,
 		},
 		{
-			name:          "Valid email with whitespace",
-			input:         "   test@example.com   ",
-			expectedValue: "test@example.com",
-			expectErr:     false,
+			name:      "Valid email with whitespace",
+			input:     "   test@example.com   ",
+			wantValue: "test@example.com",
+			wantErr:   false,
 		},
 		{
-			name:          "Uppercase email",
-			input:         "TEST@EXAMPLE.COM",
-			expectedValue: "test@example.com",
-			expectErr:     false,
+			name:      "Uppercase email",
+			input:     "TEST@EXAMPLE.COM",
+			wantValue: "test@example.com",
+			wantErr:   false,
 		},
 		{
-			name:          "Mixed case email",
-			input:         "TeSt@ExAmpLe.CoM",
-			expectedValue: "test@example.com",
-			expectErr:     false,
+			name:      "Mixed case email",
+			input:     "TeSt@ExAmpLe.CoM",
+			wantValue: "test@example.com",
+			wantErr:   false,
 		},
 	}
 
@@ -62,15 +62,15 @@ func TestEmail(t *testing.T) {
 
 			email, err := domain.NewEmail(tt.input)
 
-			if !tt.expectErr {
-				if tt.expectedValue != "" && email.String() != tt.expectedValue {
-					t.Errorf("expected email %q, got %q", tt.expectedValue, email)
+			if !tt.wantErr {
+				if tt.wantValue != "" && email.String() != tt.wantValue {
+					t.Errorf("got email %q, want %q", email, tt.wantValue)
 				}
 				if err != nil {
-					t.Errorf("did not expect error but got: %v", err)
+					t.Errorf("got error %v, want nil", err)
 				}
 			} else if err == nil {
-				t.Errorf("expected error but got none")
+				t.Error("got nil error, want non-nil")
 			}
 		})
 	}
@@ -80,31 +80,31 @@ func TestEmail_Scan(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		input     any
-		expectErr bool
-		errKind   error
+		name    string
+		input   any
+		wantErr bool
+		errKind error
 	}{
 		{
-			name:      "Valid email",
-			input:     "test@example.com",
-			expectErr: false,
+			name:    "Valid email",
+			input:   "test@example.com",
+			wantErr: false,
 		},
 		{
-			name:      "Invalid email",
-			input:     "invalid-email",
-			expectErr: true,
-			errKind:   domain.ErrDataCorrupted,
+			name:    "Invalid email",
+			input:   "invalid-email",
+			wantErr: true,
+			errKind: domain.ErrDataCorrupted,
 		},
 		{
-			name:      "Null value",
-			input:     nil,
-			expectErr: false,
+			name:    "Null value",
+			input:   nil,
+			wantErr: false,
 		},
 		{
-			name:      "Invalid type",
-			input:     123,
-			expectErr: true,
+			name:    "Invalid type",
+			input:   123,
+			wantErr: true,
 		},
 	}
 
@@ -115,14 +115,14 @@ func TestEmail_Scan(t *testing.T) {
 			var e domain.Email
 			err := e.Scan(tt.input)
 
-			if tt.expectErr {
+			if tt.wantErr {
 				if err == nil {
-					t.Error("expected error, got nil")
+					t.Error("got nil error, want non-nil")
 				} else if tt.errKind != nil && !errors.Is(err, tt.errKind) {
-					t.Errorf("expected error %v, got %v", tt.errKind, err)
+					t.Errorf("got error %v, want %v", err, tt.errKind)
 				}
 			} else if err != nil {
-				t.Errorf("did not expect error, got %v", err)
+				t.Errorf("got error %v, want nil", err)
 			}
 		})
 	}

--- a/internal/domain/user_test.go
+++ b/internal/domain/user_test.go
@@ -15,10 +15,10 @@ func TestNewUserID(t *testing.T) {
 	id := domain.NewUserID()
 
 	if id.IsEmpty() {
-		t.Error("NewUserID() should not be empty")
+		t.Error("got empty UserID from NewUserID(), want non-empty")
 	}
 	if id.UUID().Version() != 7 {
-		t.Errorf("Expected UUID v7, got v%d", id.UUID().Version())
+		t.Errorf("got UUID version %d, want 7", id.UUID().Version())
 	}
 }
 
@@ -30,16 +30,16 @@ func TestParseUserID(t *testing.T) {
 
 	id, err := domain.ParseUserID(s)
 	if err != nil {
-		t.Errorf("ParseUserID() error = %v", err)
+		t.Errorf("ParseUserID(): got error %v, want nil", err)
 	}
 
 	if id.String() != s {
-		t.Errorf("Expected %q, got %q", s, id)
+		t.Errorf("ParseUserID() = %q, want %q", id, s)
 	}
 
 	_, err = domain.ParseUserID("invalid")
 	if err == nil {
-		t.Error("ParseUserID() with invalid string should return error")
+		t.Error("got nil error from ParseUserID(\"invalid\"), want non-nil")
 	}
 }
 
@@ -97,16 +97,16 @@ func TestUserID_Scan(t *testing.T) {
 
 			if tt.wantErr {
 				if err == nil {
-					t.Error("expected error, got nil")
+					t.Error("got nil error, want non-nil")
 				} else if tt.errIs != nil && !errors.Is(err, tt.errIs) {
-					t.Errorf("expected error %v, got %v", tt.errIs, err)
+					t.Errorf("got error %v, want %v", err, tt.errIs)
 				}
 			} else {
 				if err != nil {
-					t.Errorf("did not expect error, got %v", err)
+					t.Errorf("got error %v, want nil", err)
 				}
 				if tt.input != nil && id.IsEmpty() {
-					t.Error("expected UserID to not be empty")
+					t.Error("got empty UserID after Scan, want non-empty")
 				}
 			}
 		})
@@ -117,29 +117,29 @@ func TestUserPassword(t *testing.T) {
 	t.Parallel()
 
 	passwordTests := []struct {
-		name      string
-		input     string
-		expectErr bool
+		name    string
+		input   string
+		wantErr bool
 	}{
 		{
-			name:      "Valid password",
-			input:     "securePass123",
-			expectErr: false,
+			name:    "Valid password",
+			input:   "securePass123",
+			wantErr: false,
 		},
 		{
-			name:      "Less than 6 characters",
-			input:     "12345",
-			expectErr: true,
+			name:    "Less than 6 characters",
+			input:   "12345",
+			wantErr: true,
 		},
 		{
-			name:      "Empty password",
-			input:     "",
-			expectErr: true,
+			name:    "Empty password",
+			input:   "",
+			wantErr: true,
 		},
 		{
-			name:      "Whitespace password",
-			input:     "     ",
-			expectErr: true,
+			name:    "Whitespace password",
+			input:   "     ",
+			wantErr: true,
 		},
 	}
 
@@ -148,11 +148,11 @@ func TestUserPassword(t *testing.T) {
 			t.Parallel()
 
 			_, err := domain.NewUserPassword(tt.input)
-			if tt.expectErr && err == nil {
-				t.Errorf("expected error but got none")
+			if tt.wantErr && err == nil {
+				t.Error("got nil error, want non-nil")
 			}
-			if !tt.expectErr && err != nil {
-				t.Errorf("did not expect error but got: %v", err)
+			if !tt.wantErr && err != nil {
+				t.Errorf("got error %v, want nil", err)
 			}
 		})
 	}
@@ -205,12 +205,12 @@ func TestUserPassword_Scan(t *testing.T) {
 
 			if tt.wantErr {
 				if err == nil {
-					t.Error("expected error, got nil")
+					t.Error("got nil error, want non-nil")
 				} else if tt.errIs != nil && !errors.Is(err, tt.errIs) {
-					t.Errorf("expected error %v, got %v", tt.errIs, err)
+					t.Errorf("got error %v, want %v", err, tt.errIs)
 				}
 			} else if err != nil {
-				t.Errorf("did not expect error, got %v", err)
+				t.Errorf("got error %v, want nil", err)
 			}
 		})
 	}

--- a/internal/domain/user_test.go
+++ b/internal/domain/user_test.go
@@ -30,7 +30,7 @@ func TestParseUserID(t *testing.T) {
 
 	id, err := domain.ParseUserID(s)
 	if err != nil {
-		t.Errorf("ParseUserID(): got error %v, want nil", err)
+		t.Errorf("ParseUserID() error = %v", err)
 	}
 
 	if id.String() != s {

--- a/internal/http/handler/auth_test.go
+++ b/internal/http/handler/auth_test.go
@@ -18,8 +18,8 @@ type authTestCase struct {
 	name             string
 	inputBody        any
 	setupAuthService func(t *testing.T, s *MockAuthService)
-	expectedCode     int
-	expectedBody     any
+	wantCode         int
+	wantBody         any
 }
 
 func TestAuth_Register(t *testing.T) {
@@ -35,16 +35,16 @@ func TestAuth_Register(t *testing.T) {
 			setupAuthService: func(t *testing.T, s *MockAuthService) {
 				s.RegisterFunc = func(ctx context.Context, e domain.Email, p domain.UserPassword) error {
 					if e != email {
-						t.Errorf("expected email %q, got %q", email, e)
+						t.Errorf("got email %q, want %q", e, email)
 					}
 					if p != password {
-						t.Errorf("expected password %q, got %q", password, p)
+						t.Errorf("got password %q, want %q", p, password)
 					}
 					return nil
 				}
 			},
-			expectedCode: http.StatusOK,
-			expectedBody: map[string]string{"status": "ok"},
+			wantCode: http.StatusOK,
+			wantBody: map[string]string{"status": "ok"},
 		},
 		{
 			name:      "Internal error",
@@ -54,18 +54,18 @@ func TestAuth_Register(t *testing.T) {
 					return service.ErrInternal
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: map[string]any{
+			wantCode: http.StatusInternalServerError,
+			wantBody: map[string]any{
 				"code":      "INTERNAL_SERVER_ERROR",
 				"message":   "Internal server error",
 				"timestamp": testutil.FixedTimeNowStr(),
 			},
 		},
 		{
-			name:         "Invalid email format",
-			inputBody:    map[string]string{"email": "invalid-email", "password": password.String()},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: map[string]any{
+			name:      "Invalid email format",
+			inputBody: map[string]string{"email": "invalid-email", "password": password.String()},
+			wantCode:  http.StatusBadRequest,
+			wantBody: map[string]any{
 				"code":      "VALIDATION_ERROR",
 				"message":   "Some fields are invalid",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -75,10 +75,10 @@ func TestAuth_Register(t *testing.T) {
 			},
 		},
 		{
-			name:         "Password too short",
-			inputBody:    map[string]string{"email": email.String(), "password": "123"},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: map[string]any{
+			name:      "Password too short",
+			inputBody: map[string]string{"email": email.String(), "password": "123"},
+			wantCode:  http.StatusBadRequest,
+			wantBody: map[string]any{
 				"code":      "VALIDATION_ERROR",
 				"message":   "Some fields are invalid",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -88,10 +88,10 @@ func TestAuth_Register(t *testing.T) {
 			},
 		},
 		{
-			name:         "Invalid JSON",
-			inputBody:    json.RawMessage([]byte(`{"email": "test@example.com", "password": "password"`)), // missing closing brace
-			expectedCode: http.StatusBadRequest,
-			expectedBody: map[string]any{
+			name:      "Invalid JSON",
+			inputBody: json.RawMessage([]byte(`{"email": "test@example.com", "password": "password"`)), // missing closing brace
+			wantCode:  http.StatusBadRequest,
+			wantBody: map[string]any{
 				"code":      "VALIDATION_ERROR",
 				"message":   "Some fields are invalid",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -108,8 +108,8 @@ func TestAuth_Register(t *testing.T) {
 					return service.ErrUserAlreadyExists
 				}
 			},
-			expectedCode: http.StatusConflict,
-			expectedBody: userAlreadyExistsErrorBody(),
+			wantCode: http.StatusConflict,
+			wantBody: userAlreadyExistsErrorBody(),
 		},
 		{
 			name:      "Unknown error",
@@ -119,8 +119,8 @@ func TestAuth_Register(t *testing.T) {
 					return errors.New("unknown error")
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: map[string]any{
+			wantCode: http.StatusInternalServerError,
+			wantBody: map[string]any{
 				"code":      "INTERNAL_SERVER_ERROR",
 				"message":   "Internal server error",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -144,9 +144,9 @@ func TestAuth_Register(t *testing.T) {
 			h := handler.NewAuth(logger, &s, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
 			h.Register(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
 			testutil.AssertContentType(t, rr, "application/json")
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }
@@ -164,16 +164,16 @@ func TestAuth_Login(t *testing.T) {
 			setupAuthService: func(t *testing.T, s *MockAuthService) {
 				s.LoginFunc = func(ctx context.Context, e domain.Email, p domain.UserPassword) (string, error) {
 					if e != email {
-						t.Errorf("expected email %q, got %q", email, e)
+						t.Errorf("got email %q, want %q", e, email)
 					}
 					if p != password {
-						t.Errorf("expected password %q, got %q", password, p)
+						t.Errorf("got password %q, want %q", p, password)
 					}
 					return "jwt_token", nil
 				}
 			},
-			expectedCode: http.StatusOK,
-			expectedBody: map[string]string{"token": "jwt_token"},
+			wantCode: http.StatusOK,
+			wantBody: map[string]string{"token": "jwt_token"},
 		},
 		{
 			name:      "Invalid credentials",
@@ -183,8 +183,8 @@ func TestAuth_Login(t *testing.T) {
 					return "", service.ErrInvalidCredentials
 				}
 			},
-			expectedCode: http.StatusUnauthorized,
-			expectedBody: map[string]any{
+			wantCode: http.StatusUnauthorized,
+			wantBody: map[string]any{
 				"code":      "INVALID_CREDENTIALS",
 				"message":   "Invalid login or password",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -201,8 +201,8 @@ func TestAuth_Login(t *testing.T) {
 					return "", service.ErrUserNotFound // Enumeration and timing attacks are known, this is fine
 				}
 			},
-			expectedCode: http.StatusUnauthorized,
-			expectedBody: map[string]any{
+			wantCode: http.StatusUnauthorized,
+			wantBody: map[string]any{
 				"code":      "USER_NOT_FOUND",
 				"message":   "User not found",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -217,18 +217,18 @@ func TestAuth_Login(t *testing.T) {
 					return "", service.ErrInternal
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: map[string]any{
+			wantCode: http.StatusInternalServerError,
+			wantBody: map[string]any{
 				"code":      "INTERNAL_SERVER_ERROR",
 				"message":   "Internal server error",
 				"timestamp": testutil.FixedTimeNowStr(),
 			},
 		},
 		{
-			name:         "Empty email",
-			inputBody:    map[string]string{"email": "", "password": password.String()},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: map[string]any{
+			name:      "Empty email",
+			inputBody: map[string]string{"email": "", "password": password.String()},
+			wantCode:  http.StatusBadRequest,
+			wantBody: map[string]any{
 				"code":      "VALIDATION_ERROR",
 				"message":   "Some fields are invalid",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -238,10 +238,10 @@ func TestAuth_Login(t *testing.T) {
 			},
 		},
 		{
-			name:         "Invalid email format",
-			inputBody:    map[string]string{"email": "invalid-email", "password": password.String()},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: map[string]any{
+			name:      "Invalid email format",
+			inputBody: map[string]string{"email": "invalid-email", "password": password.String()},
+			wantCode:  http.StatusBadRequest,
+			wantBody: map[string]any{
 				"code":      "VALIDATION_ERROR",
 				"message":   "Some fields are invalid",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -251,10 +251,10 @@ func TestAuth_Login(t *testing.T) {
 			},
 		},
 		{
-			name:         "Empty email and password",
-			inputBody:    map[string]any{"email": "", "password": ""},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: map[string]any{
+			name:      "Empty email and password",
+			inputBody: map[string]any{"email": "", "password": ""},
+			wantCode:  http.StatusBadRequest,
+			wantBody: map[string]any{
 				"code":      "VALIDATION_ERROR",
 				"message":   "Some fields are invalid",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -265,10 +265,10 @@ func TestAuth_Login(t *testing.T) {
 			},
 		},
 		{
-			name:         "Empty password",
-			inputBody:    map[string]string{"email": email.String(), "password": ""},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: map[string]any{
+			name:      "Empty password",
+			inputBody: map[string]string{"email": email.String(), "password": ""},
+			wantCode:  http.StatusBadRequest,
+			wantBody: map[string]any{
 				"code":      "VALIDATION_ERROR",
 				"message":   "Some fields are invalid",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -278,10 +278,10 @@ func TestAuth_Login(t *testing.T) {
 			},
 		},
 		{
-			name:         "Invalid JSON",
-			inputBody:    json.RawMessage([]byte(`{"email": "test@example.com"`)), // missing password and closing brace
-			expectedCode: http.StatusBadRequest,
-			expectedBody: map[string]any{
+			name:      "Invalid JSON",
+			inputBody: json.RawMessage([]byte(`{"email": "test@example.com"`)), // missing password and closing brace
+			wantCode:  http.StatusBadRequest,
+			wantBody: map[string]any{
 				"code":      "VALIDATION_ERROR",
 				"message":   "Some fields are invalid",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -307,9 +307,9 @@ func TestAuth_Login(t *testing.T) {
 			h := handler.NewAuth(logger, s, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
 			h.Login(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
 			testutil.AssertContentType(t, rr, "application/json")
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }
@@ -318,22 +318,22 @@ func TestAuth_WhoAmI(t *testing.T) {
 	testUserID := testutil.ValidUserID()
 
 	tests := []struct {
-		name         string
-		context      context.Context
-		expectedCode int
-		expectedBody any
+		name     string
+		context  context.Context
+		wantCode int
+		wantBody any
 	}{
 		{
-			name:         "Success",
-			context:      context.WithValue(context.Background(), httpschema.ContextKeyUserID, testUserID),
-			expectedCode: http.StatusOK,
-			expectedBody: map[string]string{"uid": testUserID.String()},
+			name:     "Success",
+			context:  context.WithValue(context.Background(), httpschema.ContextKeyUserID, testUserID),
+			wantCode: http.StatusOK,
+			wantBody: map[string]string{"uid": testUserID.String()},
 		},
 		{
-			name:         "No user ID",
-			context:      context.Background(),
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: map[string]any{
+			name:     "No user ID",
+			context:  context.Background(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: map[string]any{
 				"code":      "INTERNAL_SERVER_ERROR",
 				"message":   "Internal server error",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -352,9 +352,9 @@ func TestAuth_WhoAmI(t *testing.T) {
 			h := handler.NewAuth(logger, &MockAuthService{}, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
 			h.WhoAmI(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
 			testutil.AssertContentType(t, rr, "application/json")
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }

--- a/internal/http/handler/boards_test.go
+++ b/internal/http/handler/boards_test.go
@@ -22,8 +22,8 @@ type boardsTestCase struct {
 	inputBody         any
 	context           context.Context
 	setupBoardService func(t *testing.T, s *MockBoardService)
-	expectedCode      int
-	expectedBody      any
+	wantCode          int
+	wantBody          any
 	path              string
 }
 
@@ -41,13 +41,13 @@ func TestBoards_Create(t *testing.T) {
 			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.CreateFunc = func(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
 					if ownerID != validBoard.OwnerID {
-						t.Errorf("expected ownerID %v, got %v", validBoard.OwnerID, ownerID)
+						t.Errorf("got ownerID %v, want %v", ownerID, validBoard.OwnerID)
 					}
 					return validBoard, nil
 				}
 			},
-			expectedCode: http.StatusCreated,
-			expectedBody: map[string]string{
+			wantCode: http.StatusCreated,
+			wantBody: map[string]string{
 				"id":          validBoard.ID.String(),
 				"ownerId":     validBoard.OwnerID.String(),
 				"name":        validBoard.Name.String(),
@@ -57,29 +57,29 @@ func TestBoards_Create(t *testing.T) {
 			},
 		},
 		{
-			name:         "Empty name",
-			inputBody:    map[string]string{"name": "", "description": validBoard.Description.String()},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("name", []string{"Name is too short"}),
+			name:      "Empty name",
+			inputBody: map[string]string{"name": "", "description": validBoard.Description.String()},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("name", []string{"Name is too short"}),
 		},
 		{
-			name:         "Description too long",
-			inputBody:    map[string]string{"name": validBoard.Name.String(), "description": strings.Repeat("a", 1025)},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("description", []string{"Description is too long"}),
+			name:      "Description too long",
+			inputBody: map[string]string{"name": validBoard.Name.String(), "description": strings.Repeat("a", 1025)},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("description", []string{"Description is too long"}),
 		},
 		{
-			name:         "Invalid JSON",
-			inputBody:    json.RawMessage([]byte(fmt.Sprintf(`{"name": %q, "description": %q`, validBoard.Name.String(), validBoard.Description.String()))), // missing closing brace
-			expectedCode: http.StatusBadRequest,
-			expectedBody: invalidJsonBody(),
+			name:      "Invalid JSON",
+			inputBody: json.RawMessage([]byte(fmt.Sprintf(`{"name": %q, "description": %q`, validBoard.Name.String(), validBoard.Description.String()))), // missing closing brace
+			wantCode:  http.StatusBadRequest,
+			wantBody:  invalidJsonBody(),
 		},
 		{
-			name:         "No context user ID",
-			inputBody:    map[string]string{"name": validBoard.Name.String(), "description": validBoard.Description.String()},
-			context:      context.Background(),
-			expectedCode: http.StatusUnauthorized,
-			expectedBody: unauthorizedTokenBody(),
+			name:      "No context user ID",
+			inputBody: map[string]string{"name": validBoard.Name.String(), "description": validBoard.Description.String()},
+			context:   context.Background(),
+			wantCode:  http.StatusUnauthorized,
+			wantBody:  unauthorizedTokenBody(),
 		},
 		{
 			name:      "Internal error",
@@ -89,8 +89,8 @@ func TestBoards_Create(t *testing.T) {
 					return domain.Board{}, service.ErrInternal
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 		{
 			name:      "Unknown error",
@@ -100,8 +100,8 @@ func TestBoards_Create(t *testing.T) {
 					return domain.Board{}, errors.New("unknown error")
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 	}
 
@@ -128,9 +128,9 @@ func TestBoards_Create(t *testing.T) {
 
 			h.Create(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
 			testutil.AssertContentType(t, rr, "application/json")
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }
@@ -147,14 +147,14 @@ func TestBoards_Get(t *testing.T) {
 			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.GetManyFunc = func(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error) {
 					if ownerID != validBoard.OwnerID {
-						t.Errorf("expected ownerID %v, got %v", validBoard.OwnerID, ownerID)
+						t.Errorf("got ownerID %v, want %v", ownerID, validBoard.OwnerID)
 					}
 
 					return []domain.Board{validBoard}, nil
 				}
 			},
-			expectedCode: http.StatusOK,
-			expectedBody: []map[string]string{
+			wantCode: http.StatusOK,
+			wantBody: []map[string]string{
 				{
 					"id":          validBoard.ID.String(),
 					"ownerId":     validBoard.OwnerID.String(),
@@ -166,11 +166,11 @@ func TestBoards_Get(t *testing.T) {
 			},
 		},
 		{
-			name:         "No context user ID",
-			inputBody:    "",
-			context:      context.Background(),
-			expectedCode: http.StatusUnauthorized,
-			expectedBody: unauthorizedTokenBody(),
+			name:      "No context user ID",
+			inputBody: "",
+			context:   context.Background(),
+			wantCode:  http.StatusUnauthorized,
+			wantBody:  unauthorizedTokenBody(),
 		},
 		{
 			name:      "Internal error",
@@ -180,8 +180,8 @@ func TestBoards_Get(t *testing.T) {
 					return nil, service.ErrInternal
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 		{
 			name:      "Unknown error",
@@ -191,8 +191,8 @@ func TestBoards_Get(t *testing.T) {
 					return nil, errors.New("unknown error")
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 	}
 
@@ -219,9 +219,9 @@ func TestBoards_Get(t *testing.T) {
 
 			h.GetMany(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
 			testutil.AssertContentType(t, rr, "application/json")
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }
@@ -238,14 +238,17 @@ func TestBoards_GetByID(t *testing.T) {
 			path: okPath,
 			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.GetFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
-					if ownerID != validBoard.OwnerID || boardID != validBoard.ID {
-						t.Errorf("unexpected ownerID %v boardID %v", ownerID, boardID)
+					if ownerID != validBoard.OwnerID {
+						t.Errorf("got ownerID %v, want %v", ownerID, validBoard.OwnerID)
+					}
+					if boardID != validBoard.ID {
+						t.Errorf("got boardID %v, want %v", boardID, validBoard.ID)
 					}
 					return validBoard, nil
 				}
 			},
-			expectedCode: http.StatusOK,
-			expectedBody: map[string]string{
+			wantCode: http.StatusOK,
+			wantBody: map[string]string{
 				"id":          validBoard.ID.String(),
 				"ownerId":     validBoard.OwnerID.String(),
 				"name":        validBoard.Name.String(),
@@ -255,10 +258,10 @@ func TestBoards_GetByID(t *testing.T) {
 			},
 		},
 		{
-			name:         "Invalid board id",
-			path:         "/v1/boards/not-a-uuid",
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("boardId", []string{"Invalid board id"}),
+			name:     "Invalid board id",
+			path:     "/v1/boards/not-a-uuid",
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("boardId", []string{"Invalid board id"}),
 		},
 		{
 			name: "Not found",
@@ -268,8 +271,8 @@ func TestBoards_GetByID(t *testing.T) {
 					return domain.Board{}, service.ErrBoardNotFound
 				}
 			},
-			expectedCode: http.StatusNotFound,
-			expectedBody: notFoundErrorBody(),
+			wantCode: http.StatusNotFound,
+			wantBody: notFoundErrorBody(),
 		},
 		{
 			name: "Internal error",
@@ -279,8 +282,8 @@ func TestBoards_GetByID(t *testing.T) {
 					return domain.Board{}, service.ErrInternal
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 		{
 			name: "Unknown error",
@@ -290,15 +293,15 @@ func TestBoards_GetByID(t *testing.T) {
 					return domain.Board{}, errors.New("unknown")
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 		{
-			name:         "No context user ID",
-			path:         okPath,
-			context:      context.Background(),
-			expectedCode: http.StatusUnauthorized,
-			expectedBody: unauthorizedTokenBody(),
+			name:     "No context user ID",
+			path:     okPath,
+			context:  context.Background(),
+			wantCode: http.StatusUnauthorized,
+			wantBody: unauthorizedTokenBody(),
 		},
 	}
 
@@ -325,9 +328,9 @@ func TestBoards_GetByID(t *testing.T) {
 			h := handler.NewBoards(logger, s, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
 			h.Get(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
 			testutil.AssertContentType(t, rr, "application/json")
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }
@@ -353,19 +356,22 @@ func TestBoards_UpdateByID(t *testing.T) {
 			},
 			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
-					if ownerID != validBoard.OwnerID || boardID != validBoard.ID {
-						t.Errorf("unexpected ownerID %v boardID %v", ownerID, boardID)
+					if ownerID != validBoard.OwnerID {
+						t.Errorf("got ownerID %v, want %v", ownerID, validBoard.OwnerID)
+					}
+					if boardID != validBoard.ID {
+						t.Errorf("got boardID %v, want %v", boardID, validBoard.ID)
 					}
 					if name == nil || *name != updatedValidBoard.Name {
-						t.Errorf("unexpected name %+v", name)
+						t.Errorf("got name %+v, want %+v", name, updatedValidBoard.Name)
 					}
 					if description == nil || *description != updatedValidBoard.Description {
-						t.Errorf("unexpected description %+v", description)
+						t.Errorf("got description %+v, want %+v", description, updatedValidBoard.Description)
 					}
 					return updatedValidBoard, nil
 				}
 			},
-			expectedBody: map[string]string{
+			wantBody: map[string]string{
 				"id":          updatedValidBoard.ID.String(),
 				"ownerId":     updatedValidBoard.OwnerID.String(),
 				"name":        updatedValidBoard.Name.String(),
@@ -373,7 +379,7 @@ func TestBoards_UpdateByID(t *testing.T) {
 				"createdAt":   updatedValidBoard.CreatedAt.Format(timeFormat),
 				"updatedAt":   updatedValidBoard.UpdatedAt.Format(timeFormat),
 			},
-			expectedCode: http.StatusOK,
+			wantCode: http.StatusOK,
 		},
 		{
 			name: "Empty name",
@@ -382,8 +388,8 @@ func TestBoards_UpdateByID(t *testing.T) {
 				"name":        "",
 				"description": validBoard.Description.String(),
 			},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("name", []string{"Name is too short"}),
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("name", []string{"Name is too short"}),
 		},
 		{
 			name: "Success (name only)",
@@ -394,15 +400,15 @@ func TestBoards_UpdateByID(t *testing.T) {
 			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 					if name == nil || *name != updatedNameOnlyBoard.Name {
-						t.Errorf("unexpected name %+v", name)
+						t.Errorf("got name %+v, want %+v", name, updatedNameOnlyBoard.Name)
 					}
 					if description != nil {
-						t.Errorf("expected nil description, got %+v", description)
+						t.Errorf("got description %+v, want nil", description)
 					}
 					return updatedNameOnlyBoard, nil
 				}
 			},
-			expectedBody: map[string]any{
+			wantBody: map[string]any{
 				"id":          updatedNameOnlyBoard.ID.String(),
 				"ownerId":     updatedNameOnlyBoard.OwnerID.String(),
 				"name":        updatedNameOnlyBoard.Name.String(),
@@ -410,7 +416,7 @@ func TestBoards_UpdateByID(t *testing.T) {
 				"createdAt":   updatedNameOnlyBoard.CreatedAt.Format(timeFormat),
 				"updatedAt":   updatedNameOnlyBoard.UpdatedAt.Format(timeFormat),
 			},
-			expectedCode: http.StatusOK,
+			wantCode: http.StatusOK,
 		},
 		{
 			name: "Success (description only)",
@@ -421,15 +427,15 @@ func TestBoards_UpdateByID(t *testing.T) {
 			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 					if name != nil {
-						t.Errorf("expected nil name, got %+v", name)
+						t.Errorf("got name %+v, want nil", name)
 					}
 					if description == nil || *description != updatedDescriptionOnlyBoard.Description {
-						t.Errorf("unexpected description %+v", description)
+						t.Errorf("got description %+v, want %+v", description, updatedDescriptionOnlyBoard.Description)
 					}
 					return updatedDescriptionOnlyBoard, nil
 				}
 			},
-			expectedBody: map[string]any{
+			wantBody: map[string]any{
 				"id":          updatedDescriptionOnlyBoard.ID.String(),
 				"ownerId":     updatedDescriptionOnlyBoard.OwnerID.String(),
 				"name":        updatedDescriptionOnlyBoard.Name.String(),
@@ -437,7 +443,7 @@ func TestBoards_UpdateByID(t *testing.T) {
 				"createdAt":   updatedDescriptionOnlyBoard.CreatedAt.Format(timeFormat),
 				"updatedAt":   updatedDescriptionOnlyBoard.UpdatedAt.Format(timeFormat),
 			},
-			expectedCode: http.StatusOK,
+			wantCode: http.StatusOK,
 		},
 		{
 			name:      "Success (null fields mean skip)",
@@ -446,12 +452,12 @@ func TestBoards_UpdateByID(t *testing.T) {
 			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 					if name != nil || description != nil {
-						t.Errorf("expected nil pointers, got name=%+v description=%+v", name, description)
+						t.Errorf("got name %+v, description %+v, want nil, nil", name, description)
 					}
 					return validBoard, nil
 				}
 			},
-			expectedBody: map[string]any{
+			wantBody: map[string]any{
 				"id":          validBoard.ID.String(),
 				"ownerId":     validBoard.OwnerID.String(),
 				"name":        validBoard.Name.String(),
@@ -459,7 +465,7 @@ func TestBoards_UpdateByID(t *testing.T) {
 				"createdAt":   validBoard.CreatedAt.Format(timeFormat),
 				"updatedAt":   validBoard.UpdatedAt.Format(timeFormat),
 			},
-			expectedCode: http.StatusOK,
+			wantCode: http.StatusOK,
 		},
 		{
 			name: "Empty description",
@@ -471,12 +477,12 @@ func TestBoards_UpdateByID(t *testing.T) {
 			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.UpdateByIDFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
 					if name == nil || description == nil {
-						t.Errorf("expected non-nil pointers")
+						t.Errorf("got name %+v, description %+v, want non-nil, non-nil", name, description)
 					}
 					return emptyDescriptionBoard, nil
 				}
 			},
-			expectedBody: map[string]any{
+			wantBody: map[string]any{
 				"id":          emptyDescriptionBoard.ID.String(),
 				"ownerId":     emptyDescriptionBoard.OwnerID.String(),
 				"name":        emptyDescriptionBoard.Name.String(),
@@ -484,13 +490,13 @@ func TestBoards_UpdateByID(t *testing.T) {
 				"createdAt":   emptyDescriptionBoard.CreatedAt.Format(timeFormat),
 				"updatedAt":   emptyDescriptionBoard.UpdatedAt.Format(timeFormat),
 			},
-			expectedCode: http.StatusOK,
+			wantCode: http.StatusOK,
 		},
 		{
-			name:         "Invalid board id",
-			path:         "/v1/boards/not-a-uuid",
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("boardId", []string{"Invalid board id"}),
+			name:     "Invalid board id",
+			path:     "/v1/boards/not-a-uuid",
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("boardId", []string{"Invalid board id"}),
 		},
 		{
 			name: "Not found",
@@ -504,8 +510,8 @@ func TestBoards_UpdateByID(t *testing.T) {
 					return domain.Board{}, service.ErrBoardNotFound
 				}
 			},
-			expectedCode: http.StatusNotFound,
-			expectedBody: notFoundErrorBody(),
+			wantCode: http.StatusNotFound,
+			wantBody: notFoundErrorBody(),
 		},
 		{
 			name: "Internal error",
@@ -519,8 +525,8 @@ func TestBoards_UpdateByID(t *testing.T) {
 					return domain.Board{}, service.ErrInternal
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 		{
 			name: "Unknown error",
@@ -534,8 +540,8 @@ func TestBoards_UpdateByID(t *testing.T) {
 					return domain.Board{}, errors.New("unknown")
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 		{
 			name: "No context user ID",
@@ -544,9 +550,9 @@ func TestBoards_UpdateByID(t *testing.T) {
 				"name":        validBoard.Name.String(),
 				"description": validBoard.Description.String(),
 			},
-			context:      context.Background(),
-			expectedCode: http.StatusUnauthorized,
-			expectedBody: unauthorizedTokenBody(),
+			context:  context.Background(),
+			wantCode: http.StatusUnauthorized,
+			wantBody: unauthorizedTokenBody(),
 		},
 	}
 
@@ -571,9 +577,9 @@ func TestBoards_UpdateByID(t *testing.T) {
 			h := handler.NewBoards(logger, s, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
 			h.UpdateByID(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
 			testutil.AssertContentType(t, rr, "application/json")
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }
@@ -590,20 +596,23 @@ func TestBoards_Delete(t *testing.T) {
 			path: okPath,
 			setupBoardService: func(t *testing.T, s *MockBoardService) {
 				s.DeleteFunc = func(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) error {
-					if ownerID != validBoard.OwnerID || boardID != validBoard.ID {
-						t.Errorf("unexpected ownerID %v boardID %v", ownerID, boardID)
+					if ownerID != validBoard.OwnerID {
+						t.Errorf("got ownerID %v, want %v", ownerID, validBoard.OwnerID)
+					}
+					if boardID != validBoard.ID {
+						t.Errorf("got boardID %v, want %v", boardID, validBoard.ID)
 					}
 					return nil
 				}
 			},
-			expectedCode: http.StatusNoContent,
-			expectedBody: nil,
+			wantCode: http.StatusNoContent,
+			wantBody: nil,
 		},
 		{
-			name:         "Invalid board id",
-			path:         "/v1/boards/not-a-uuid",
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("boardId", []string{"Invalid board id"}),
+			name:     "Invalid board id",
+			path:     "/v1/boards/not-a-uuid",
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("boardId", []string{"Invalid board id"}),
 		},
 		{
 			name: "Not found",
@@ -613,8 +622,8 @@ func TestBoards_Delete(t *testing.T) {
 					return service.ErrBoardNotFound
 				}
 			},
-			expectedCode: http.StatusNotFound,
-			expectedBody: notFoundErrorBody(),
+			wantCode: http.StatusNotFound,
+			wantBody: notFoundErrorBody(),
 		},
 		{
 			name: "Internal error",
@@ -624,8 +633,8 @@ func TestBoards_Delete(t *testing.T) {
 					return service.ErrInternal
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 		{
 			name: "Unknown error",
@@ -635,15 +644,15 @@ func TestBoards_Delete(t *testing.T) {
 					return errors.New("unknown")
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 		{
-			name:         "No context user ID",
-			path:         okPath,
-			context:      context.Background(),
-			expectedCode: http.StatusUnauthorized,
-			expectedBody: unauthorizedTokenBody(),
+			name:     "No context user ID",
+			path:     okPath,
+			context:  context.Background(),
+			wantCode: http.StatusUnauthorized,
+			wantBody: unauthorizedTokenBody(),
 		},
 	}
 
@@ -670,11 +679,11 @@ func TestBoards_Delete(t *testing.T) {
 			h := handler.NewBoards(logger, s, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
 			h.Delete(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
-			if tt.expectedCode != http.StatusNoContent {
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
+			if tt.wantCode != http.StatusNoContent {
 				testutil.AssertContentType(t, rr, "application/json")
 			}
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }

--- a/internal/http/handler/columns_test.go
+++ b/internal/http/handler/columns_test.go
@@ -27,8 +27,8 @@ func TestColumns_Create(t *testing.T) {
 		inputBody          any
 		context            context.Context
 		setupColumnService func(t *testing.T, s *MockColumnService)
-		expectedCode       int
-		expectedBody       any
+		wantCode           int
+		wantBody           any
 	}{
 		{
 			name:      "Success",
@@ -37,19 +37,19 @@ func TestColumns_Create(t *testing.T) {
 			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName) (domain.Column, error) {
 					if callerID != validBoard.OwnerID {
-						t.Errorf("expected caller id %v, got %v", validBoard.OwnerID, callerID)
+						t.Errorf("got caller id %v, want %v", callerID, validBoard.OwnerID)
 					}
 					if boardID != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
 					}
 					if name != validColumn.Name {
-						t.Errorf("expected name %v, got %v", validColumn.Name, name)
+						t.Errorf("got name %v, want %v", name, validColumn.Name)
 					}
 					return validColumn, nil
 				}
 			},
-			expectedCode: http.StatusCreated,
-			expectedBody: map[string]any{
+			wantCode: http.StatusCreated,
+			wantBody: map[string]any{
 				"id":        validColumn.ID.String(),
 				"boardId":   validColumn.BoardID.String(),
 				"name":      validColumn.Name.String(),
@@ -59,33 +59,33 @@ func TestColumns_Create(t *testing.T) {
 			},
 		},
 		{
-			name:         "Invalid board id",
-			path:         "/v1/boards/not-a-uuid/columns",
-			inputBody:    map[string]string{"name": "To Do"},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("boardId", []string{"Invalid board id"}),
+			name:      "Invalid board id",
+			path:      "/v1/boards/not-a-uuid/columns",
+			inputBody: map[string]string{"name": "To Do"},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("boardId", []string{"Invalid board id"}),
 		},
 		{
-			name:         "Invalid JSON",
-			path:         "/v1/boards/" + validBoard.ID.String() + "/columns",
-			inputBody:    "{\"name\":\"broken\"",
-			expectedCode: http.StatusBadRequest,
-			expectedBody: invalidJsonBody(),
+			name:      "Invalid JSON",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns",
+			inputBody: "{\"name\":\"broken\"",
+			wantCode:  http.StatusBadRequest,
+			wantBody:  invalidJsonBody(),
 		},
 		{
-			name:         "Invalid name",
-			path:         "/v1/boards/" + validBoard.ID.String() + "/columns",
-			inputBody:    map[string]string{"name": "   "},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("name", []string{"Name is too short"}),
+			name:      "Invalid name",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns",
+			inputBody: map[string]string{"name": "   "},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("name", []string{"Name is too short"}),
 		},
 		{
-			name:         "Missing context user",
-			path:         "/v1/boards/" + validBoard.ID.String() + "/columns",
-			inputBody:    map[string]string{"name": "To Do"},
-			context:      context.Background(),
-			expectedCode: http.StatusUnauthorized,
-			expectedBody: unauthorizedTokenBody(),
+			name:      "Missing context user",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns",
+			inputBody: map[string]string{"name": "To Do"},
+			context:   context.Background(),
+			wantCode:  http.StatusUnauthorized,
+			wantBody:  unauthorizedTokenBody(),
 		},
 		{
 			name:      "Board not found",
@@ -96,8 +96,8 @@ func TestColumns_Create(t *testing.T) {
 					return domain.Column{}, service.ErrBoardNotFound
 				}
 			},
-			expectedCode: http.StatusNotFound,
-			expectedBody: boardNotFoundErrorBody(),
+			wantCode: http.StatusNotFound,
+			wantBody: boardNotFoundErrorBody(),
 		},
 		{
 			name:      "Internal error",
@@ -108,8 +108,8 @@ func TestColumns_Create(t *testing.T) {
 					return domain.Column{}, service.ErrInternal
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 		{
 			name:      "Unexpected error",
@@ -120,8 +120,8 @@ func TestColumns_Create(t *testing.T) {
 					return domain.Column{}, errors.New("db exploded")
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 	}
 
@@ -154,9 +154,9 @@ func TestColumns_Create(t *testing.T) {
 			h := handler.NewColumns(logger, mockColumns, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
 			h.Create(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
 			testutil.AssertContentType(t, rr, "application/json")
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }
@@ -174,8 +174,8 @@ func TestColumns_List(t *testing.T) {
 		path               string
 		context            context.Context
 		setupColumnService func(t *testing.T, s *MockColumnService)
-		expectedCode       int
-		expectedBody       any
+		wantCode           int
+		wantBody           any
 	}{
 		{
 			name: "Success",
@@ -183,16 +183,16 @@ func TestColumns_List(t *testing.T) {
 			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.ListFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error) {
 					if callerID != validBoard.OwnerID {
-						t.Errorf("expected caller id %v, got %v", validBoard.OwnerID, callerID)
+						t.Errorf("got caller id %v, want %v", callerID, validBoard.OwnerID)
 					}
 					if boardID != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
 					}
 					return []domain.Column{first, second}, nil
 				}
 			},
-			expectedCode: http.StatusOK,
-			expectedBody: []map[string]any{
+			wantCode: http.StatusOK,
+			wantBody: []map[string]any{
 				{
 					"id":        first.ID.String(),
 					"boardId":   first.BoardID.String(),
@@ -212,17 +212,17 @@ func TestColumns_List(t *testing.T) {
 			},
 		},
 		{
-			name:         "Invalid board id",
-			path:         "/v1/boards/not-a-uuid/columns",
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("boardId", []string{"Invalid board id"}),
+			name:     "Invalid board id",
+			path:     "/v1/boards/not-a-uuid/columns",
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("boardId", []string{"Invalid board id"}),
 		},
 		{
-			name:         "Missing context user",
-			path:         "/v1/boards/" + validBoard.ID.String() + "/columns",
-			context:      context.Background(),
-			expectedCode: http.StatusUnauthorized,
-			expectedBody: unauthorizedTokenBody(),
+			name:     "Missing context user",
+			path:     "/v1/boards/" + validBoard.ID.String() + "/columns",
+			context:  context.Background(),
+			wantCode: http.StatusUnauthorized,
+			wantBody: unauthorizedTokenBody(),
 		},
 		{
 			name: "Board not found",
@@ -232,8 +232,8 @@ func TestColumns_List(t *testing.T) {
 					return nil, service.ErrBoardNotFound
 				}
 			},
-			expectedCode: http.StatusNotFound,
-			expectedBody: boardNotFoundErrorBody(),
+			wantCode: http.StatusNotFound,
+			wantBody: boardNotFoundErrorBody(),
 		},
 		{
 			name: "Internal error",
@@ -243,8 +243,8 @@ func TestColumns_List(t *testing.T) {
 					return nil, service.ErrInternal
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 	}
 
@@ -270,9 +270,9 @@ func TestColumns_List(t *testing.T) {
 			h := handler.NewColumns(logger, mockColumns, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
 			h.List(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
 			testutil.AssertContentType(t, rr, "application/json")
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }
@@ -284,7 +284,7 @@ func TestColumns_UpdateByID(t *testing.T) {
 	validColumn := testutil.ValidColumn(validBoard.ID)
 	updatedName, err := domain.NewColumnName("Renamed Column")
 	if err != nil {
-		t.Fatalf("NewColumnName: %v", err)
+		t.Fatalf("NewColumnName() error = %v", err)
 	}
 	updatedColumn := validColumn
 	updatedColumn.Name = updatedName
@@ -298,8 +298,8 @@ func TestColumns_UpdateByID(t *testing.T) {
 		inputBody          any
 		context            context.Context
 		setupColumnService func(t *testing.T, s *MockColumnService)
-		expectedCode       int
-		expectedBody       any
+		wantCode           int
+		wantBody           any
 	}{
 		{
 			name:      "Success (name update)",
@@ -308,22 +308,22 @@ func TestColumns_UpdateByID(t *testing.T) {
 			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.UpdateByIDFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName) (domain.Column, error) {
 					if callerID != validBoard.OwnerID {
-						t.Errorf("expected caller id %v, got %v", validBoard.OwnerID, callerID)
+						t.Errorf("got caller id %v, want %v", callerID, validBoard.OwnerID)
 					}
 					if boardID != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
 					}
 					if columnID != validColumn.ID {
-						t.Errorf("expected column id %v, got %v", validColumn.ID, columnID)
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
 					}
 					if name == nil || *name != updatedName {
-						t.Errorf("expected updated name %v, got %+v", updatedName, name)
+						t.Errorf("got name %v, want %v", name, updatedName)
 					}
 					return updatedColumn, nil
 				}
 			},
-			expectedCode: http.StatusOK,
-			expectedBody: map[string]any{
+			wantCode: http.StatusOK,
+			wantBody: map[string]any{
 				"id":        updatedColumn.ID.String(),
 				"boardId":   updatedColumn.BoardID.String(),
 				"name":      updatedColumn.Name.String(),
@@ -339,13 +339,13 @@ func TestColumns_UpdateByID(t *testing.T) {
 			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.UpdateByIDFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName) (domain.Column, error) {
 					if name != nil {
-						t.Errorf("expected nil name for no-op patch, got %+v", name)
+						t.Errorf("got name %+v, want nil", name)
 					}
 					return validColumn, nil
 				}
 			},
-			expectedCode: http.StatusOK,
-			expectedBody: map[string]any{
+			wantCode: http.StatusOK,
+			wantBody: map[string]any{
 				"id":        validColumn.ID.String(),
 				"boardId":   validColumn.BoardID.String(),
 				"name":      validColumn.Name.String(),
@@ -355,40 +355,40 @@ func TestColumns_UpdateByID(t *testing.T) {
 			},
 		},
 		{
-			name:         "Invalid board id",
-			path:         "/v1/boards/not-a-uuid/columns/" + validColumn.ID.String(),
-			inputBody:    map[string]string{"name": "Renamed"},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("boardId", []string{"Invalid board id"}),
+			name:      "Invalid board id",
+			path:      "/v1/boards/not-a-uuid/columns/" + validColumn.ID.String(),
+			inputBody: map[string]string{"name": "Renamed"},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("boardId", []string{"Invalid board id"}),
 		},
 		{
-			name:         "Invalid column id",
-			path:         "/v1/boards/" + validBoard.ID.String() + "/columns/not-a-uuid",
-			inputBody:    map[string]string{"name": "Renamed"},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("columnId", []string{"Invalid column id"}),
+			name:      "Invalid column id",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns/not-a-uuid",
+			inputBody: map[string]string{"name": "Renamed"},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("columnId", []string{"Invalid column id"}),
 		},
 		{
-			name:         "Invalid JSON",
-			path:         okPath,
-			inputBody:    "{\"name\":\"broken\"",
-			expectedCode: http.StatusBadRequest,
-			expectedBody: invalidJsonBody(),
+			name:      "Invalid JSON",
+			path:      okPath,
+			inputBody: "{\"name\":\"broken\"",
+			wantCode:  http.StatusBadRequest,
+			wantBody:  invalidJsonBody(),
 		},
 		{
-			name:         "Invalid name",
-			path:         okPath,
-			inputBody:    map[string]string{"name": "   "},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("name", []string{"Name is too short"}),
+			name:      "Invalid name",
+			path:      okPath,
+			inputBody: map[string]string{"name": "   "},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("name", []string{"Name is too short"}),
 		},
 		{
-			name:         "Missing context user",
-			path:         okPath,
-			inputBody:    map[string]string{"name": "Renamed"},
-			context:      context.Background(),
-			expectedCode: http.StatusUnauthorized,
-			expectedBody: unauthorizedTokenBody(),
+			name:      "Missing context user",
+			path:      okPath,
+			inputBody: map[string]string{"name": "Renamed"},
+			context:   context.Background(),
+			wantCode:  http.StatusUnauthorized,
+			wantBody:  unauthorizedTokenBody(),
 		},
 		{
 			name:      "Column not found",
@@ -399,8 +399,8 @@ func TestColumns_UpdateByID(t *testing.T) {
 					return domain.Column{}, service.ErrColumnNotFound
 				}
 			},
-			expectedCode: http.StatusNotFound,
-			expectedBody: columnNotFoundErrorBody(),
+			wantCode: http.StatusNotFound,
+			wantBody: columnNotFoundErrorBody(),
 		},
 		{
 			name:      "Internal error",
@@ -411,8 +411,8 @@ func TestColumns_UpdateByID(t *testing.T) {
 					return domain.Column{}, service.ErrInternal
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 	}
 
@@ -451,9 +451,9 @@ func TestColumns_UpdateByID(t *testing.T) {
 			h := handler.NewColumns(logger, mockColumns, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
 			h.UpdateByID(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
 			testutil.AssertContentType(t, rr, "application/json")
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }
@@ -465,7 +465,7 @@ func TestColumns_Move(t *testing.T) {
 	validColumn := testutil.ValidColumn(validBoard.ID)
 	targetPosition, err := domain.NewColumnPosition(2)
 	if err != nil {
-		t.Fatalf("NewColumnPosition: %v", err)
+		t.Fatalf("NewColumnPosition() error = %v", err)
 	}
 
 	okPath := "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String() + "/position"
@@ -476,8 +476,8 @@ func TestColumns_Move(t *testing.T) {
 		inputBody          any
 		context            context.Context
 		setupColumnService func(t *testing.T, s *MockColumnService)
-		expectedCode       int
-		expectedBody       any
+		wantCode           int
+		wantBody           any
 	}{
 		{
 			name:      "Success",
@@ -486,60 +486,60 @@ func TestColumns_Move(t *testing.T) {
 			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.MoveFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, gotTargetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
 					if callerID != validBoard.OwnerID {
-						t.Errorf("expected caller id %v, got %v", validBoard.OwnerID, callerID)
+						t.Errorf("got caller id %v, want %v", callerID, validBoard.OwnerID)
 					}
 					if boardID != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
 					}
 					if columnID != validColumn.ID {
-						t.Errorf("expected column id %v, got %v", validColumn.ID, columnID)
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
 					}
 					if gotTargetPosition != targetPosition {
-						t.Errorf("expected target position %v, got %v", targetPosition, gotTargetPosition)
+						t.Errorf("got target position %v, want %v", gotTargetPosition, targetPosition)
 					}
 					return targetPosition, nil
 				}
 			},
-			expectedCode: http.StatusOK,
-			expectedBody: map[string]any{
+			wantCode: http.StatusOK,
+			wantBody: map[string]any{
 				"position": targetPosition.Int64(),
 			},
 		},
 		{
-			name:         "Invalid board id",
-			path:         "/v1/boards/not-a-uuid/columns/" + validColumn.ID.String() + "/position",
-			inputBody:    map[string]int64{"targetPosition": 1},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("boardId", []string{"Invalid board id"}),
+			name:      "Invalid board id",
+			path:      "/v1/boards/not-a-uuid/columns/" + validColumn.ID.String() + "/position",
+			inputBody: map[string]int64{"targetPosition": 1},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("boardId", []string{"Invalid board id"}),
 		},
 		{
-			name:         "Invalid column id",
-			path:         "/v1/boards/" + validBoard.ID.String() + "/columns/not-a-uuid/position",
-			inputBody:    map[string]int64{"targetPosition": 1},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("columnId", []string{"Invalid column id"}),
+			name:      "Invalid column id",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns/not-a-uuid/position",
+			inputBody: map[string]int64{"targetPosition": 1},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("columnId", []string{"Invalid column id"}),
 		},
 		{
-			name:         "Invalid JSON",
-			path:         okPath,
-			inputBody:    "{\"targetPosition\":",
-			expectedCode: http.StatusBadRequest,
-			expectedBody: invalidJsonBody(),
+			name:      "Invalid JSON",
+			path:      okPath,
+			inputBody: "{\"targetPosition\":",
+			wantCode:  http.StatusBadRequest,
+			wantBody:  invalidJsonBody(),
 		},
 		{
-			name:         "Invalid target position",
-			path:         okPath,
-			inputBody:    map[string]int64{"targetPosition": 0},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("targetPosition", []string{"Position is invalid"}),
+			name:      "Invalid target position",
+			path:      okPath,
+			inputBody: map[string]int64{"targetPosition": 0},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("targetPosition", []string{"Position is invalid"}),
 		},
 		{
-			name:         "Missing context user",
-			path:         okPath,
-			inputBody:    map[string]int64{"targetPosition": 1},
-			context:      context.Background(),
-			expectedCode: http.StatusUnauthorized,
-			expectedBody: unauthorizedTokenBody(),
+			name:      "Missing context user",
+			path:      okPath,
+			inputBody: map[string]int64{"targetPosition": 1},
+			context:   context.Background(),
+			wantCode:  http.StatusUnauthorized,
+			wantBody:  unauthorizedTokenBody(),
 		},
 		{
 			name:      "Index out of bounds",
@@ -550,8 +550,8 @@ func TestColumns_Move(t *testing.T) {
 					return domain.ColumnPosition{}, service.ErrIndexOutOfBounds
 				}
 			},
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("targetPosition", []string{"Index out of bounds"}),
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("targetPosition", []string{"Index out of bounds"}),
 		},
 		{
 			name:      "Column not found",
@@ -562,8 +562,8 @@ func TestColumns_Move(t *testing.T) {
 					return domain.ColumnPosition{}, service.ErrColumnNotFound
 				}
 			},
-			expectedCode: http.StatusNotFound,
-			expectedBody: columnNotFoundErrorBody(),
+			wantCode: http.StatusNotFound,
+			wantBody: columnNotFoundErrorBody(),
 		},
 		{
 			name:      "Internal error",
@@ -574,8 +574,8 @@ func TestColumns_Move(t *testing.T) {
 					return domain.ColumnPosition{}, service.ErrInternal
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 	}
 
@@ -614,9 +614,9 @@ func TestColumns_Move(t *testing.T) {
 			h := handler.NewColumns(logger, mockColumns, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
 			h.Move(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
 			testutil.AssertContentType(t, rr, "application/json")
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }
@@ -633,8 +633,8 @@ func TestColumns_Delete(t *testing.T) {
 		path               string
 		context            context.Context
 		setupColumnService func(t *testing.T, s *MockColumnService)
-		expectedCode       int
-		expectedBody       any
+		wantCode           int
+		wantBody           any
 	}{
 		{
 			name: "Success",
@@ -642,38 +642,38 @@ func TestColumns_Delete(t *testing.T) {
 			setupColumnService: func(t *testing.T, s *MockColumnService) {
 				s.DeleteFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error {
 					if callerID != validBoard.OwnerID {
-						t.Errorf("expected caller id %v, got %v", validBoard.OwnerID, callerID)
+						t.Errorf("got caller id %v, want %v", callerID, validBoard.OwnerID)
 					}
 					if boardID != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
 					}
 					if columnID != validColumn.ID {
-						t.Errorf("expected column id %v, got %v", validColumn.ID, columnID)
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
 					}
 					return nil
 				}
 			},
-			expectedCode: http.StatusNoContent,
-			expectedBody: nil,
+			wantCode: http.StatusNoContent,
+			wantBody: nil,
 		},
 		{
-			name:         "Invalid board id",
-			path:         "/v1/boards/not-a-uuid/columns/" + validColumn.ID.String(),
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("boardId", []string{"Invalid board id"}),
+			name:     "Invalid board id",
+			path:     "/v1/boards/not-a-uuid/columns/" + validColumn.ID.String(),
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("boardId", []string{"Invalid board id"}),
 		},
 		{
-			name:         "Invalid column id",
-			path:         "/v1/boards/" + validBoard.ID.String() + "/columns/not-a-uuid",
-			expectedCode: http.StatusBadRequest,
-			expectedBody: validationErrorBody("columnId", []string{"Invalid column id"}),
+			name:     "Invalid column id",
+			path:     "/v1/boards/" + validBoard.ID.String() + "/columns/not-a-uuid",
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("columnId", []string{"Invalid column id"}),
 		},
 		{
-			name:         "Missing context user",
-			path:         okPath,
-			context:      context.Background(),
-			expectedCode: http.StatusUnauthorized,
-			expectedBody: unauthorizedTokenBody(),
+			name:     "Missing context user",
+			path:     okPath,
+			context:  context.Background(),
+			wantCode: http.StatusUnauthorized,
+			wantBody: unauthorizedTokenBody(),
 		},
 		{
 			name: "Column not found",
@@ -683,8 +683,8 @@ func TestColumns_Delete(t *testing.T) {
 					return service.ErrColumnNotFound
 				}
 			},
-			expectedCode: http.StatusNotFound,
-			expectedBody: columnNotFoundErrorBody(),
+			wantCode: http.StatusNotFound,
+			wantBody: columnNotFoundErrorBody(),
 		},
 		{
 			name: "Internal error",
@@ -694,8 +694,8 @@ func TestColumns_Delete(t *testing.T) {
 					return service.ErrInternal
 				}
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: internalErrorBody(),
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
 		},
 	}
 
@@ -727,11 +727,11 @@ func TestColumns_Delete(t *testing.T) {
 			h := handler.NewColumns(logger, mockColumns, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
 			h.Delete(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedCode)
-			if tt.expectedCode != http.StatusNoContent {
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
+			if tt.wantCode != http.StatusNoContent {
 				testutil.AssertContentType(t, rr, "application/json")
 			}
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }

--- a/internal/http/handler/helpers_test.go
+++ b/internal/http/handler/helpers_test.go
@@ -15,7 +15,7 @@ type MockAuthService struct {
 
 func AssertFuncNotNil(funcName string, fn any) {
 	if fn == nil {
-		panic(fmt.Sprintf("BUG: Mock: %s is not set", funcName))
+		panic(fmt.Sprintf("%s = nil, want configured mock", funcName))
 	}
 }
 

--- a/internal/http/httpschema/code_map_test.go
+++ b/internal/http/httpschema/code_map_test.go
@@ -43,7 +43,7 @@ func TestMapCodeToDescription(t *testing.T) {
 
 			description := httpschema.MapCodeToDescription(tt.code)
 			if description != tt.description {
-				t.Errorf("expected %q, got %q", tt.description, description)
+				t.Errorf("got %q, want %q", description, tt.description)
 			}
 		})
 	}

--- a/internal/http/middleware/auth_test.go
+++ b/internal/http/middleware/auth_test.go
@@ -22,17 +22,17 @@ func TestAuth(t *testing.T) {
 		name             string
 		headerName       string
 		headerValue      string
-		expectedStatus   int
-		expectedUserID   domain.UserID
-		expectedBody     any
+		wantStatus       int
+		wantUserID       domain.UserID
+		wantBody         any
 		setupAuthService func(r *MockAuthService)
 	}{
 		{
-			name:           "Valid token",
-			headerName:     "Authorization",
-			headerValue:    "Bearer valid.token.here",
-			expectedStatus: mockStatusCode,
-			expectedUserID: userID,
+			name:        "Valid token",
+			headerName:  "Authorization",
+			headerValue: "Bearer valid.token.here",
+			wantStatus:  mockStatusCode,
+			wantUserID:  userID,
 			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return userID, nil
@@ -40,16 +40,16 @@ func TestAuth(t *testing.T) {
 			},
 		},
 		{
-			name:           "Invalid token",
-			headerName:     "Authorization",
-			headerValue:    "Bearer invalid.token.here",
-			expectedStatus: http.StatusUnauthorized,
+			name:        "Invalid token",
+			headerName:  "Authorization",
+			headerValue: "Bearer invalid.token.here",
+			wantStatus:  http.StatusUnauthorized,
 			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, service.ErrInvalidToken
 				}
 			},
-			expectedBody: map[string]any{
+			wantBody: map[string]any{
 				"code":      "INVALID_TOKEN",
 				"message":   "Invalid token",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -59,16 +59,16 @@ func TestAuth(t *testing.T) {
 			},
 		},
 		{
-			name:           "Token expired",
-			headerName:     "Authorization",
-			headerValue:    "Bearer expired.token.here",
-			expectedStatus: http.StatusUnauthorized,
+			name:        "Token expired",
+			headerName:  "Authorization",
+			headerValue: "Bearer expired.token.here",
+			wantStatus:  http.StatusUnauthorized,
 			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, service.ErrTokenExpired
 				}
 			},
-			expectedBody: map[string]any{
+			wantBody: map[string]any{
 				"code":      "INVALID_TOKEN",
 				"message":   "Invalid token",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -78,16 +78,16 @@ func TestAuth(t *testing.T) {
 			},
 		},
 		{
-			name:           "Invalid signing method",
-			headerName:     "Authorization",
-			headerValue:    "Bearer invalid.signing.method.token.here",
-			expectedStatus: http.StatusUnauthorized,
+			name:        "Invalid signing method",
+			headerName:  "Authorization",
+			headerValue: "Bearer invalid.signing.method.token.here",
+			wantStatus:  http.StatusUnauthorized,
 			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, service.ErrInvalidSigningMethod
 				}
 			},
-			expectedBody: map[string]any{
+			wantBody: map[string]any{
 				"code":      "INVALID_TOKEN",
 				"message":   "Invalid token",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -97,16 +97,16 @@ func TestAuth(t *testing.T) {
 			},
 		},
 		{
-			name:           "Empty header value",
-			headerName:     "Authorization",
-			headerValue:    "",
-			expectedStatus: http.StatusUnauthorized,
+			name:        "Empty header value",
+			headerName:  "Authorization",
+			headerValue: "",
+			wantStatus:  http.StatusUnauthorized,
 			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, nil
 				}
 			},
-			expectedBody: map[string]any{
+			wantBody: map[string]any{
 				"code":      "INVALID_AUTH_HEADER",
 				"message":   "Invalid authorization header",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -116,16 +116,16 @@ func TestAuth(t *testing.T) {
 			},
 		},
 		{
-			name:           "Missing token",
-			headerName:     "Authorization",
-			headerValue:    "Bearer",
-			expectedStatus: http.StatusUnauthorized,
+			name:        "Missing token",
+			headerName:  "Authorization",
+			headerValue: "Bearer",
+			wantStatus:  http.StatusUnauthorized,
 			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, nil
 				}
 			},
-			expectedBody: map[string]any{
+			wantBody: map[string]any{
 				"code":      "INVALID_AUTH_HEADER",
 				"message":   "Invalid authorization header",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -135,16 +135,16 @@ func TestAuth(t *testing.T) {
 			},
 		},
 		{
-			name:           "Empty token",
-			headerName:     "Authorization",
-			headerValue:    "Bearer ",
-			expectedStatus: http.StatusUnauthorized,
+			name:        "Empty token",
+			headerName:  "Authorization",
+			headerValue: "Bearer ",
+			wantStatus:  http.StatusUnauthorized,
 			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, nil
 				}
 			},
-			expectedBody: map[string]any{
+			wantBody: map[string]any{
 				"code":      "INVALID_AUTH_HEADER",
 				"message":   "Invalid authorization header",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -154,16 +154,16 @@ func TestAuth(t *testing.T) {
 			},
 		},
 		{
-			name:           "Extra parts in header",
-			headerName:     "Authorization",
-			headerValue:    "Bearer token extra-part",
-			expectedStatus: http.StatusUnauthorized,
+			name:        "Extra parts in header",
+			headerName:  "Authorization",
+			headerValue: "Bearer token extra-part",
+			wantStatus:  http.StatusUnauthorized,
 			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, nil
 				}
 			},
-			expectedBody: map[string]any{
+			wantBody: map[string]any{
 				"code":      "INVALID_AUTH_HEADER",
 				"message":   "Invalid authorization header",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -173,11 +173,11 @@ func TestAuth(t *testing.T) {
 			},
 		},
 		{
-			name:           "Extra spaces in header",
-			headerName:     "Authorization",
-			headerValue:    "   Bearer     valid.token.here   ",
-			expectedStatus: mockStatusCode,
-			expectedUserID: userID,
+			name:        "Extra spaces in header",
+			headerName:  "Authorization",
+			headerValue: "   Bearer     valid.token.here   ",
+			wantStatus:  mockStatusCode,
+			wantUserID:  userID,
 			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return userID, nil
@@ -185,11 +185,11 @@ func TestAuth(t *testing.T) {
 			},
 		},
 		{
-			name:           "Random casing in header",
-			headerName:     "AuThorIzAtIoN",
-			headerValue:    "bEaReR vAlId.tOkEn.hErE",
-			expectedStatus: mockStatusCode,
-			expectedUserID: userID,
+			name:        "Random casing in header",
+			headerName:  "AuThorIzAtIoN",
+			headerValue: "bEaReR vAlId.tOkEn.hErE",
+			wantStatus:  mockStatusCode,
+			wantUserID:  userID,
 			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return userID, nil
@@ -197,16 +197,16 @@ func TestAuth(t *testing.T) {
 			},
 		},
 		{
-			name:           "Wrong prefix",
-			headerName:     "Authorization",
-			headerValue:    "Basic some-token",
-			expectedStatus: http.StatusUnauthorized,
+			name:        "Wrong prefix",
+			headerName:  "Authorization",
+			headerValue: "Basic some-token",
+			wantStatus:  http.StatusUnauthorized,
 			setupAuthService: func(r *MockAuthService) {
 				r.VerifyTokenFunc = func(ctx context.Context, token string) (domain.UserID, error) {
 					return domain.UserID{}, nil
 				}
 			},
-			expectedBody: map[string]any{
+			wantBody: map[string]any{
 				"code":      "INVALID_AUTH_HEADER",
 				"message":   "Invalid authorization header",
 				"timestamp": testutil.FixedTimeNowStr(),
@@ -227,11 +227,11 @@ func TestAuth(t *testing.T) {
 			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				id, ok := r.Context().Value(httpschema.ContextKeyUserID).(domain.UserID)
 				if !ok {
-					t.Errorf("Expected user ID, got %v", id)
+					t.Errorf("got context user ID ok=%v, want true", ok)
 				}
 
-				if id != tt.expectedUserID {
-					t.Errorf("Expected user ID %v, got %v", tt.expectedUserID, id)
+				if id != tt.wantUserID {
+					t.Errorf("got user ID %v, want %v", id, tt.wantUserID)
 				}
 
 				w.WriteHeader(mockStatusCode)
@@ -249,8 +249,8 @@ func TestAuth(t *testing.T) {
 			if rr.Code != mockStatusCode {
 				testutil.AssertContentType(t, rr, "application/json")
 			}
-			testutil.AssertStatusCode(t, rr, tt.expectedStatus)
-			testutil.AssertResponseBody(t, rr, tt.expectedBody)
+			testutil.AssertStatusCode(t, rr, tt.wantStatus)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
 		})
 	}
 }

--- a/internal/http/middleware/cors_test.go
+++ b/internal/http/middleware/cors_test.go
@@ -45,12 +45,12 @@ func TestCors_Wrap(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		method          string
-		allowedOrigins  map[string]struct{}
-		reqHeaders      map[string]string
-		expectedStatus  int
-		expectedHeaders map[string]string
+		name           string
+		method         string
+		allowedOrigins map[string]struct{}
+		reqHeaders     map[string]string
+		wantStatus     int
+		wantHeaders    map[string]string
 	}{
 		{
 			name:           "No Origin Header",
@@ -59,8 +59,8 @@ func TestCors_Wrap(t *testing.T) {
 			reqHeaders:     map[string]string{
 				// Not a browser
 			},
-			expectedStatus:  http.StatusTeapot,
-			expectedHeaders: map[string]string{},
+			wantStatus:  http.StatusTeapot,
+			wantHeaders: map[string]string{},
 		},
 		{
 			name:           "Origin Header is not allowed",
@@ -69,8 +69,8 @@ func TestCors_Wrap(t *testing.T) {
 			reqHeaders: map[string]string{
 				"Origin": evilSite,
 			},
-			expectedStatus:  http.StatusForbidden,
-			expectedHeaders: emptyCORSHeaders,
+			wantStatus:  http.StatusForbidden,
+			wantHeaders: emptyCORSHeaders,
 		},
 		{
 			name:           "Origin Header is allowed",
@@ -79,8 +79,8 @@ func TestCors_Wrap(t *testing.T) {
 			reqHeaders: map[string]string{
 				"Origin": goodSite,
 			},
-			expectedStatus:  http.StatusNoContent,
-			expectedHeaders: filledGoodCORSHeaders,
+			wantStatus:  http.StatusNoContent,
+			wantHeaders: filledGoodCORSHeaders,
 		},
 		{
 			name:           "Preflight rejected",
@@ -89,8 +89,8 @@ func TestCors_Wrap(t *testing.T) {
 			reqHeaders: map[string]string{
 				"Origin": evilSite,
 			},
-			expectedStatus:  http.StatusForbidden,
-			expectedHeaders: emptyCORSHeaders,
+			wantStatus:  http.StatusForbidden,
+			wantHeaders: emptyCORSHeaders,
 		},
 		{
 			name:           "Preflight allowed",
@@ -99,8 +99,8 @@ func TestCors_Wrap(t *testing.T) {
 			reqHeaders: map[string]string{
 				"Origin": goodSite,
 			},
-			expectedStatus:  http.StatusNoContent,
-			expectedHeaders: filledGoodCORSHeaders,
+			wantStatus:  http.StatusNoContent,
+			wantHeaders: filledGoodCORSHeaders,
 		},
 		{
 			name:           "Any origin allowed",
@@ -109,8 +109,8 @@ func TestCors_Wrap(t *testing.T) {
 			reqHeaders: map[string]string{
 				"Origin": evilSite,
 			},
-			expectedStatus:  http.StatusTeapot,
-			expectedHeaders: filledEvilCORSHeaders,
+			wantStatus:  http.StatusTeapot,
+			wantHeaders: filledEvilCORSHeaders,
 		},
 		{
 			name:           "No allowed origins",
@@ -119,8 +119,8 @@ func TestCors_Wrap(t *testing.T) {
 			reqHeaders: map[string]string{
 				"Origin": goodSite,
 			},
-			expectedStatus:  http.StatusForbidden,
-			expectedHeaders: emptyCORSHeaders,
+			wantStatus:  http.StatusForbidden,
+			wantHeaders: emptyCORSHeaders,
 		},
 	}
 
@@ -129,7 +129,7 @@ func TestCors_Wrap(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(tt.expectedStatus)
+				w.WriteHeader(tt.wantStatus)
 			})
 
 			mw := middleware.NewCORS(testutil.NewTestLogger(t), tt.allowedOrigins)
@@ -142,10 +142,10 @@ func TestCors_Wrap(t *testing.T) {
 			wrapped := mw.Wrap(handler)
 			wrapped.ServeHTTP(rr, req)
 
-			testutil.AssertStatusCode(t, rr, tt.expectedStatus)
-			for k, v := range tt.expectedHeaders {
+			testutil.AssertStatusCode(t, rr, tt.wantStatus)
+			for k, v := range tt.wantHeaders {
 				if rr.Header().Get(k) != v {
-					t.Errorf("expected header %q, got %q", v, rr.Header().Get(k))
+					t.Errorf("got header %q=%q, want %q", k, rr.Header().Get(k), v)
 				}
 			}
 		})
@@ -160,6 +160,6 @@ func TestCors_WarnsAnyOriginAllowed(t *testing.T) {
 	_ = middleware.NewCORS(logger, config.ParseAllowedOrigins(goodSite+",*,"+awesomeSite))
 
 	if !strings.Contains(buf.String(), "too permissive") {
-		t.Errorf("expected warn about too permissive CORS middleware, got %q", buf.String())
+		t.Errorf("got log output %q, want mention of %q", buf.String(), "too permissive")
 	}
 }

--- a/internal/http/middleware/helpers_test.go
+++ b/internal/http/middleware/helpers_test.go
@@ -2,6 +2,7 @@ package middleware_test
 
 import (
 	"context"
+	"fmt"
 
 	"goroutine/internal/domain"
 )
@@ -10,6 +11,13 @@ type MockAuthService struct {
 	VerifyTokenFunc func(ctx context.Context, token string) (domain.UserID, error)
 }
 
+func AssertFuncNotNil(funcName string, fn any) {
+	if fn == nil {
+		panic(fmt.Sprintf("%s = nil, want configured mock", funcName))
+	}
+}
+
 func (m *MockAuthService) VerifyToken(ctx context.Context, token string) (domain.UserID, error) {
+	AssertFuncNotNil("AuthService.VerifyTokenFunc", m.VerifyTokenFunc)
 	return m.VerifyTokenFunc(ctx, token)
 }

--- a/internal/http/middleware/metrics_test.go
+++ b/internal/http/middleware/metrics_test.go
@@ -30,9 +30,9 @@ func TestAbstractMetricPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			have := middleware.AbstractMetricPath(tt.rawPath)
-			if have != tt.abstractPath {
-				t.Errorf("AbstractMetricPath(%q) = %q, want %q", tt.rawPath, have, tt.abstractPath)
+			got := middleware.AbstractMetricPath(tt.rawPath)
+			if got != tt.abstractPath {
+				t.Errorf("AbstractMetricPath(%q) = %q, want %q", tt.rawPath, got, tt.abstractPath)
 			}
 		})
 	}

--- a/internal/http/middleware/requestid_test.go
+++ b/internal/http/middleware/requestid_test.go
@@ -22,35 +22,35 @@ func TestRequestIDMiddleware(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		requestHeaders    map[string]string
-		expectedRequestID string
+		name           string
+		requestHeaders map[string]string
+		wantRequestID  string
 	}{
 		{
-			name:              "No input header",
-			requestHeaders:    map[string]string{},
-			expectedRequestID: mockRequestID,
+			name:           "No input header",
+			requestHeaders: map[string]string{},
+			wantRequestID:  mockRequestID,
 		},
 		{
 			name: "Valid input header",
 			requestHeaders: map[string]string{
 				"X-Request-Id": requestRequestID,
 			},
-			expectedRequestID: requestRequestID,
+			wantRequestID: requestRequestID,
 		},
 		{
 			name: "Empty input header",
 			requestHeaders: map[string]string{
 				"X-Request-Id": "",
 			},
-			expectedRequestID: mockRequestID,
+			wantRequestID: mockRequestID,
 		},
 		{
 			name: "Whitespace input header",
 			requestHeaders: map[string]string{
 				"X-Request-Id": "   ",
 			},
-			expectedRequestID: mockRequestID,
+			wantRequestID: mockRequestID,
 		},
 	}
 
@@ -59,13 +59,13 @@ func TestRequestIDMiddleware(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if tt.expectedRequestID != "" {
+				if tt.wantRequestID != "" {
 					reqID, ok := r.Context().Value(httpschema.ContextKeyRequestID).(string)
 					if !ok {
 						t.Errorf("RequestID missing in context")
 					}
-					if reqID != tt.expectedRequestID {
-						t.Errorf("expected request ID in context %q, got %q", tt.expectedRequestID, reqID)
+					if reqID != tt.wantRequestID {
+						t.Errorf("got request ID in context %q, want %q", reqID, tt.wantRequestID)
 					}
 				}
 				w.WriteHeader(mockStatusCode)
@@ -85,10 +85,10 @@ func TestRequestIDMiddleware(t *testing.T) {
 
 			testutil.AssertStatusCode(t, rr, mockStatusCode)
 
-			if tt.expectedRequestID != "" {
+			if tt.wantRequestID != "" {
 				headerID := rr.Header().Get("X-Request-ID")
-				if headerID != tt.expectedRequestID {
-					t.Errorf("expected response request ID %q, got %q", tt.expectedRequestID, headerID)
+				if headerID != tt.wantRequestID {
+					t.Errorf("got response request ID %q, want %q", headerID, tt.wantRequestID)
 				}
 			}
 		})

--- a/internal/http/route_test.go
+++ b/internal/http/route_test.go
@@ -112,22 +112,22 @@ func TestNewRouter_Full(t *testing.T) {
 			router.ServeHTTP(rr, req)
 
 			if rr.Code == http.StatusNotFound {
-				t.Errorf("Path %q %q not registered in router (got 404)", tt.entry.method, tt.entry.path)
+				t.Errorf("got 404 for %s %q, want registered route", tt.entry.method, tt.entry.path)
 			}
 
 			hasMetrics := rr.Header().Get("X-Metrics-Tracked") == "true"
 			if hasMetrics != tt.metrics {
-				t.Errorf("Metrics middleware application mismatch for %q: got %v, want %v", tt.entry.path, hasMetrics, tt.metrics)
+				t.Errorf("got metrics middleware=%v for %q, want %v", hasMetrics, tt.entry.path, tt.metrics)
 			}
 
 			hasCors := rr.Header().Get("X-Cors-Tracked") == "true"
 			if hasCors != tt.cors {
-				t.Errorf("CORS middleware application mismatch for %q: got %v, want %v", tt.entry.path, hasCors, tt.cors)
+				t.Errorf("got CORS middleware=%v for %q, want %v", hasCors, tt.entry.path, tt.cors)
 			}
 
 			hasReqID := rr.Header().Get("X-RequestId-Tracked") == "true"
 			if hasReqID != tt.requestID {
-				t.Errorf("RequestID middleware application mismatch for %q: got %v, want %v", tt.entry.path, hasReqID, tt.requestID)
+				t.Errorf("got request ID middleware=%v for %q, want %v", hasReqID, tt.entry.path, tt.requestID)
 			}
 		})
 	}
@@ -150,6 +150,6 @@ func TestNewAdminRouter(t *testing.T) {
 	_, pattern := router.Handler(req)
 
 	if pattern == "" {
-		t.Errorf("Path GET /metrics not registered in admin router")
+		t.Errorf("got empty pattern for GET /metrics, want registered route")
 	}
 }

--- a/internal/repository/board_test.go
+++ b/internal/repository/board_test.go
@@ -34,25 +34,25 @@ func TestBoardRepository_Create(t *testing.T) {
 			t.Errorf("Create() error = %v", err)
 		}
 		if board.ID.IsEmpty() {
-			t.Errorf("Expected board ID to be generated, got empty")
+			t.Errorf("got empty board ID, want generated ID")
 		}
 		if board.OwnerID != userID {
-			t.Errorf("Expected owner ID %q, got %q", userID, board.OwnerID)
+			t.Errorf("got owner ID %q, want %q", board.OwnerID, userID)
 		}
 		if board.Name != boardName {
-			t.Errorf("Expected name %q, got %q", boardName, board.Name)
+			t.Errorf("got name %q, want %q", board.Name, boardName)
 		}
 		if board.Description != boardDescription {
-			t.Errorf("Expected description %q, got %q", boardDescription, board.Description)
+			t.Errorf("got description %q, want %q", board.Description, boardDescription)
 		}
 		if board.CreatedAt.IsZero() {
-			t.Errorf("Expected created at to be set, got zero value")
+			t.Errorf("got zero createdAt, want set value")
 		}
 		if board.UpdatedAt.IsZero() {
-			t.Errorf("Expected updated at to be set, got zero value")
+			t.Errorf("got zero updatedAt, want set value")
 		}
 		if !board.CreatedAt.Equal(board.UpdatedAt) {
-			t.Errorf("Expected created at and updated at to be the same, got %v and %v", board.CreatedAt, board.UpdatedAt)
+			t.Errorf("got createdAt=%v updatedAt=%v, want equal", board.CreatedAt, board.UpdatedAt)
 		}
 
 		const query = `
@@ -70,22 +70,22 @@ func TestBoardRepository_Create(t *testing.T) {
 		err = pool.QueryRow(context.Background(), query, board.ID).
 			Scan(&dbOwnerID, &dbName, &dbDescription, &dbCreatedAt, &dbUpdatedAt)
 		if err != nil {
-			t.Fatalf("Failed to find board in DB by ID %q: %v", board.ID, err)
+			t.Fatalf("Board row Scan() error = %v", err)
 		}
 		if dbOwnerID != userID {
-			t.Errorf("DB: expected owner ID %q, got %q", userID, dbOwnerID)
+			t.Errorf("DB: got owner ID %q, want %q", dbOwnerID, userID)
 		}
 		if dbName != boardName {
-			t.Errorf("DB: expected name %q, got %q", boardName, dbName)
+			t.Errorf("DB: got name %q, want %q", dbName, boardName)
 		}
 		if dbDescription != boardDescription {
-			t.Errorf("DB: expected description %q, got %q", boardDescription, dbDescription)
+			t.Errorf("DB: got description %q, want %q", dbDescription, boardDescription)
 		}
 		if !dbCreatedAt.Equal(board.CreatedAt) {
-			t.Errorf("DB: expected created_at %v, got %v", board.CreatedAt, dbCreatedAt)
+			t.Errorf("DB: got created_at %v, want %v", dbCreatedAt, board.CreatedAt)
 		}
 		if !dbUpdatedAt.Equal(board.UpdatedAt) {
-			t.Errorf("DB: expected updated_at %v, got %v", board.UpdatedAt, dbUpdatedAt)
+			t.Errorf("DB: got updated_at %v, want %v", dbUpdatedAt, board.UpdatedAt)
 		}
 	})
 }
@@ -155,7 +155,7 @@ func TestBoardRepository_GetMany(t *testing.T) {
 			t.Errorf("GetMany() error = %v", err)
 		}
 		if len(got) != 0 {
-			t.Errorf("expected no boards, got %d", len(got))
+			t.Errorf("got %d boards, want 0", len(got))
 		}
 	})
 
@@ -167,17 +167,17 @@ func TestBoardRepository_GetMany(t *testing.T) {
 
 		first, err := r.Create(context.Background(), userID, boardName, boardDescription)
 		if err != nil {
-			t.Fatalf("Create first board: %v", err)
+			t.Fatalf("Create() error = %v", err)
 		}
 
 		otherName, err := domain.NewBoardName(boardName.String() + "-2")
 		if err != nil {
-			t.Fatalf("NewBoardName: %v", err)
+			t.Fatalf("NewBoardName() error = %v", err)
 		}
 		time.Sleep(5 * time.Millisecond)
 		second, err := r.Create(context.Background(), userID, otherName, boardDescription)
 		if err != nil {
-			t.Fatalf("Create second board: %v", err)
+			t.Fatalf("Create() error = %v", err)
 		}
 
 		got, err := r.GetMany(context.Background(), userID)
@@ -185,7 +185,7 @@ func TestBoardRepository_GetMany(t *testing.T) {
 			t.Errorf("GetMany() error = %v", err)
 		}
 		if len(got) != 2 {
-			t.Fatalf("expected 2 boards, got %d", len(got))
+			t.Fatalf("got %d boards, want 2", len(got))
 		}
 		want := []domain.Board{first, second}
 		if !reflect.DeepEqual(want, got) {
@@ -288,7 +288,7 @@ func TestBoardRepository_Delete(t *testing.T) {
 
 		board, err := r.Create(context.Background(), userID, boardName, boardDescription)
 		if err != nil {
-			t.Fatalf("Create: %v", err)
+			t.Fatalf("Create() error = %v", err)
 		}
 
 		err = r.Delete(context.Background(), board.ID)
@@ -298,7 +298,7 @@ func TestBoardRepository_Delete(t *testing.T) {
 
 		_, err = r.GetByID(context.Background(), board.ID)
 		if !errors.Is(err, repository.ErrRowNotFound) {
-			t.Errorf("GetByID after delete: %v, want ErrRowNotFound", err)
+			t.Errorf("GetByID() error = %v, want ErrRowNotFound", err)
 		}
 	})
 

--- a/internal/repository/column_test.go
+++ b/internal/repository/column_test.go
@@ -44,22 +44,22 @@ func TestColumnRepository_Create(t *testing.T) {
 		}
 
 		if column.ID.IsEmpty() {
-			t.Error("expected generated column id")
+			t.Error("got empty column id, want generated id")
 		}
 		if column.BoardID != board.ID {
-			t.Errorf("expected boardID %q, got %q", board.ID, column.BoardID)
+			t.Errorf("got boardID %q, want %q", column.BoardID, board.ID)
 		}
 		if column.Name != validColumn.Name {
-			t.Errorf("expected name %q, got %q", validColumn.Name, column.Name)
+			t.Errorf("got name %q, want %q", column.Name, validColumn.Name)
 		}
 		if column.Position.Int64() != 1 {
-			t.Errorf("expected position 1, got %d", column.Position.Int64())
+			t.Errorf("got position %d, want 1", column.Position.Int64())
 		}
 		if !column.CreatedAt.Equal(validColumn.CreatedAt) {
-			t.Errorf("expected createdAt %v, got %v", validColumn.CreatedAt, column.CreatedAt)
+			t.Errorf("got createdAt %v, want %v", column.CreatedAt, validColumn.CreatedAt)
 		}
 		if !column.UpdatedAt.Equal(validColumn.UpdatedAt) {
-			t.Errorf("expected updatedAt %v, got %v", validColumn.UpdatedAt, column.UpdatedAt)
+			t.Errorf("got updatedAt %v, want %v", column.UpdatedAt, validColumn.UpdatedAt)
 		}
 	})
 }
@@ -94,10 +94,10 @@ func TestColumnRepository_Create_AppendsPosition(t *testing.T) {
 		toCreate.UpdatedAt,
 	)
 	if err != nil {
-		t.Fatalf("Create second: %v", err)
+		t.Fatalf("Create() error = %v", err)
 	}
 	if second.Position.Int64() != 2 {
-		t.Errorf("second position expected 2, got %d", second.Position.Int64())
+		t.Errorf("got second position %d, want 2", second.Position.Int64())
 	}
 }
 
@@ -123,7 +123,7 @@ func TestColumnRepository_ListByBoardID(t *testing.T) {
 			t.Fatalf("ListByBoardID() error = %v", err)
 		}
 		if len(columns) != 0 {
-			t.Fatalf("expected 0 columns, got %d", len(columns))
+			t.Fatalf("got %d columns, want 0", len(columns))
 		}
 	})
 
@@ -298,7 +298,7 @@ func TestColumnRepository_Move(t *testing.T) {
 
 		targetPosition, err := domain.NewColumnPosition(3)
 		if err != nil {
-			t.Fatalf("NewColumnPosition: %v", err)
+			t.Fatalf("NewColumnPosition() error = %v", err)
 		}
 
 		gotPosition, err := r.Move(context.Background(), board.ID, first.ID, targetPosition)
@@ -311,16 +311,16 @@ func TestColumnRepository_Move(t *testing.T) {
 
 		got := ListColumnsByBoardID(t, pool, board.ID)
 		if len(got) != 3 {
-			t.Fatalf("expected 3 columns after move, got %d", len(got))
+			t.Fatalf("got %d columns after move, want 3", len(got))
 		}
 		if got[0].ID != second.ID || got[0].Position.Int64() != 1 {
-			t.Errorf("expected second column at position 1, got id=%q position=%d", got[0].ID, got[0].Position.Int64())
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", got[0].ID, got[0].Position.Int64(), second.ID, 1)
 		}
 		if got[1].ID != third.ID || got[1].Position.Int64() != 2 {
-			t.Errorf("expected third column at position 2, got id=%q position=%d", got[1].ID, got[1].Position.Int64())
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", got[1].ID, got[1].Position.Int64(), third.ID, 2)
 		}
 		if got[2].ID != first.ID || got[2].Position.Int64() != 3 {
-			t.Errorf("expected first column at position 3, got id=%q position=%d", got[2].ID, got[2].Position.Int64())
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", got[2].ID, got[2].Position.Int64(), first.ID, 3)
 		}
 	})
 
@@ -345,7 +345,7 @@ func TestColumnRepository_Move(t *testing.T) {
 
 		targetPosition, err := domain.NewColumnPosition(1)
 		if err != nil {
-			t.Fatalf("NewColumnPosition: %v", err)
+			t.Fatalf("NewColumnPosition() error = %v", err)
 		}
 
 		gotPosition, err := r.Move(context.Background(), board.ID, third.ID, targetPosition)
@@ -358,16 +358,16 @@ func TestColumnRepository_Move(t *testing.T) {
 
 		got := ListColumnsByBoardID(t, pool, board.ID)
 		if len(got) != 3 {
-			t.Fatalf("expected 3 columns after move, got %d", len(got))
+			t.Fatalf("got %d columns after move, want 3", len(got))
 		}
 		if got[0].ID != third.ID || got[0].Position.Int64() != 1 {
-			t.Errorf("expected third column at position 1, got id=%q position=%d", got[0].ID, got[0].Position.Int64())
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", got[0].ID, got[0].Position.Int64(), third.ID, 1)
 		}
 		if got[1].ID != first.ID || got[1].Position.Int64() != 2 {
-			t.Errorf("expected first column at position 2, got id=%q position=%d", got[1].ID, got[1].Position.Int64())
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", got[1].ID, got[1].Position.Int64(), first.ID, 2)
 		}
 		if got[2].ID != second.ID || got[2].Position.Int64() != 3 {
-			t.Errorf("expected second column at position 3, got id=%q position=%d", got[2].ID, got[2].Position.Int64())
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", got[2].ID, got[2].Position.Int64(), second.ID, 3)
 		}
 	})
 
@@ -390,7 +390,7 @@ func TestColumnRepository_Move(t *testing.T) {
 
 		targetPosition, err := domain.NewColumnPosition(2)
 		if err != nil {
-			t.Fatalf("NewColumnPosition: %v", err)
+			t.Fatalf("NewColumnPosition() error = %v", err)
 		}
 
 		gotPosition, err := r.Move(context.Background(), board.ID, second.ID, targetPosition)
@@ -403,13 +403,13 @@ func TestColumnRepository_Move(t *testing.T) {
 
 		got := ListColumnsByBoardID(t, pool, board.ID)
 		if len(got) != 2 {
-			t.Fatalf("expected 2 columns after no-op move, got %d", len(got))
+			t.Fatalf("got %d columns after no-op move, want 2", len(got))
 		}
 		if got[0].ID != first.ID || got[0].Position.Int64() != 1 {
-			t.Errorf("expected first column to stay at position 1, got id=%q position=%d", got[0].ID, got[0].Position.Int64())
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", got[0].ID, got[0].Position.Int64(), first.ID, 1)
 		}
 		if got[1].ID != second.ID || got[1].Position.Int64() != 2 {
-			t.Errorf("expected second column to stay at position 2, got id=%q position=%d", got[1].ID, got[1].Position.Int64())
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", got[1].ID, got[1].Position.Int64(), second.ID, 2)
 		}
 	})
 
@@ -434,7 +434,7 @@ func TestColumnRepository_Move(t *testing.T) {
 
 		targetPosition, err := domain.NewColumnPosition(4)
 		if err != nil {
-			t.Fatalf("NewColumnPosition: %v", err)
+			t.Fatalf("NewColumnPosition() error = %v", err)
 		}
 
 		_, err = r.Move(context.Background(), board.ID, second.ID, targetPosition)
@@ -444,16 +444,16 @@ func TestColumnRepository_Move(t *testing.T) {
 
 		got := ListColumnsByBoardID(t, pool, board.ID)
 		if len(got) != 3 {
-			t.Fatalf("expected 3 columns after failed move, got %d", len(got))
+			t.Fatalf("got %d columns after failed move, want 3", len(got))
 		}
 		if got[0].ID != first.ID || got[0].Position.Int64() != 1 {
-			t.Errorf("expected first column unchanged, got id=%q position=%d", got[0].ID, got[0].Position.Int64())
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", got[0].ID, got[0].Position.Int64(), first.ID, 1)
 		}
 		if got[1].ID != second.ID || got[1].Position.Int64() != 2 {
-			t.Errorf("expected second column unchanged, got id=%q position=%d", got[1].ID, got[1].Position.Int64())
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", got[1].ID, got[1].Position.Int64(), second.ID, 2)
 		}
 		if got[2].ID != third.ID || got[2].Position.Int64() != 3 {
-			t.Errorf("expected third column unchanged, got id=%q position=%d", got[2].ID, got[2].Position.Int64())
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", got[2].ID, got[2].Position.Int64(), third.ID, 3)
 		}
 	})
 
@@ -470,7 +470,7 @@ func TestColumnRepository_Move(t *testing.T) {
 
 		targetPosition, err := domain.NewColumnPosition(1)
 		if err != nil {
-			t.Fatalf("NewColumnPosition: %v", err)
+			t.Fatalf("NewColumnPosition() error = %v", err)
 		}
 
 		_, err = r.Move(context.Background(), board.ID, domain.NewColumnID(), targetPosition)
@@ -495,7 +495,7 @@ func TestColumnRepository_Move(t *testing.T) {
 
 		targetPosition, err := domain.NewColumnPosition(1)
 		if err != nil {
-			t.Fatalf("NewColumnPosition: %v", err)
+			t.Fatalf("NewColumnPosition() error = %v", err)
 		}
 
 		_, err = r.Move(context.Background(), domain.NewBoardID(), created.ID, targetPosition)
@@ -538,24 +538,24 @@ func TestColumnRepository_Delete(t *testing.T) {
 		got := ListColumnsByBoardID(t, pool, board.ID)
 
 		if len(got) != 2 {
-			t.Fatalf("expected 2 columns after delete, got %d", len(got))
+			t.Fatalf("got %d columns after delete, want 2", len(got))
 		}
 		if got[0].ID != first.ID {
-			t.Errorf("expected first column id %q, got %q", first.ID, got[0].ID)
+			t.Errorf("got first column id %q, want %q", got[0].ID, first.ID)
 		}
 		if got[0].Position.Int64() != 1 {
-			t.Errorf("expected first position 1, got %d", got[0].Position.Int64())
+			t.Errorf("got first position %d, want 1", got[0].Position.Int64())
 		}
 		if got[1].ID != third.ID {
-			t.Errorf("expected second column id %q, got %q", third.ID, got[1].ID)
+			t.Errorf("got second column id %q, want %q", got[1].ID, third.ID)
 		}
 		if got[1].Position.Int64() != 2 {
-			t.Errorf("expected second position 2 after shift, got %d", got[1].Position.Int64())
+			t.Errorf("got second position %d after shift, want 2", got[1].Position.Int64())
 		}
 
 		_, ok := FindColumnByID(t, pool, second.ID)
 		if ok {
-			t.Error("expected deleted column to be absent in DB")
+			t.Error("got deleted column in DB, want absent")
 		}
 	})
 

--- a/internal/repository/helpers_test.go
+++ b/internal/repository/helpers_test.go
@@ -21,7 +21,7 @@ func CreateUser(t *testing.T, pool *pgxpool.Pool, id domain.UserID, email string
 	const query = `INSERT INTO users (id, email, password_hash) VALUES ($1, $2, $3)`
 	_, err := pool.Exec(ctx, query, id, email, "hash")
 	if err != nil {
-		t.Fatalf("Failed to create user: %v", err)
+		t.Fatalf("CreateUser() error = %v", err)
 	}
 }
 
@@ -43,7 +43,7 @@ func InsertBoard(t *testing.T, pool *pgxpool.Pool, board *domain.Board) {
 		board.UpdatedAt,
 	)
 	if err != nil {
-		t.Fatalf("insert board: %v", err)
+		t.Fatalf("InsertBoard() error = %v", err)
 	}
 }
 
@@ -65,7 +65,7 @@ func InsertColumn(t *testing.T, pool *pgxpool.Pool, column *domain.Column) {
 		column.UpdatedAt,
 	)
 	if err != nil {
-		t.Fatalf("insert column: %v", err)
+		t.Fatalf("InsertColumn() error = %v", err)
 	}
 }
 
@@ -93,7 +93,7 @@ func FindColumnByID(t *testing.T, pool *pgxpool.Pool, columnID domain.ColumnID) 
 		if errors.Is(err, pgx.ErrNoRows) {
 			return domain.Column{}, false
 		}
-		t.Fatalf("find column by id: %v", err)
+		t.Fatalf("FindColumnByID() error = %v", err)
 	}
 
 	return column, true
@@ -113,7 +113,7 @@ func ListColumnsByBoardID(t *testing.T, pool *pgxpool.Pool, boardID domain.Board
 
 	rows, err := pool.Query(ctx, q, boardID)
 	if err != nil {
-		t.Fatalf("list columns by board id: %v", err)
+		t.Fatalf("ListColumnsByBoardID() error = %v", err)
 	}
 	defer rows.Close()
 
@@ -129,14 +129,14 @@ func ListColumnsByBoardID(t *testing.T, pool *pgxpool.Pool, boardID domain.Board
 			&column.UpdatedAt,
 		)
 		if err != nil {
-			t.Fatalf("list columns by board id scan: %v", err)
+			t.Fatalf("Column row Scan() error = %v", err)
 		}
 
 		columns = append(columns, column)
 	}
 
 	if err := rows.Err(); err != nil {
-		t.Fatalf("list columns by board id rows: %v", err)
+		t.Fatalf("rows.Err() error = %v", err)
 	}
 
 	return columns

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -35,10 +35,10 @@ func TestUserRepository_Insert(t *testing.T) {
 		var dbEmail domain.Email
 		err = pool.QueryRow(ctx, "SELECT email FROM users WHERE email=$1", email).Scan(&dbEmail)
 		if err != nil {
-			t.Errorf("Failed to find user in DB: %v", err)
+			t.Errorf("User row Scan() error = %v", err)
 		}
 		if dbEmail != email {
-			t.Errorf("Expected email %q, got %q", email, dbEmail)
+			t.Errorf("got email %q, want %q", dbEmail, email)
 		}
 	})
 
@@ -49,7 +49,7 @@ func TestUserRepository_Insert(t *testing.T) {
 		err := r.Insert(ctx, email, hash)
 
 		if !errors.Is(err, repository.ErrUniqueViolation) {
-			t.Errorf("Expected ErrUniqueViolation, got %v", err)
+			t.Errorf("got error %v, want ErrUniqueViolation", err)
 		}
 	})
 }
@@ -71,7 +71,7 @@ func TestUserRepository_GetByEmail(t *testing.T) {
 
 		err := r.Insert(ctx, email, hash)
 		if err != nil {
-			t.Fatalf("Failed to insert user for test: %v", err)
+			t.Fatalf("Insert() error = %v", err)
 		}
 
 		gotID, gotHash, err := r.GetByEmail(ctx, email)
@@ -79,10 +79,10 @@ func TestUserRepository_GetByEmail(t *testing.T) {
 			t.Errorf("GetByEmail() error = %v", err)
 		}
 		if gotHash != hash {
-			t.Errorf("Expected hash %q, got %q", hash, gotHash)
+			t.Errorf("got hash %q, want %q", gotHash, hash)
 		}
 		if gotID.IsEmpty() {
-			t.Errorf("Expected non-empty id, got %v", gotID)
+			t.Errorf("got id %v, want non-empty", gotID)
 		}
 	})
 
@@ -93,7 +93,7 @@ func TestUserRepository_GetByEmail(t *testing.T) {
 		_, _, err := r.GetByEmail(ctx, unknownEmail)
 
 		if !errors.Is(err, repository.ErrRowNotFound) {
-			t.Errorf("Expected ErrRowNotFound, got %v", err)
+			t.Errorf("got error %v, want ErrRowNotFound", err)
 		}
 	})
 }

--- a/internal/secrecy/secrecy_test.go
+++ b/internal/secrecy/secrecy_test.go
@@ -14,14 +14,14 @@ func TestSecretString(t *testing.T) {
 	ssRevealed := ss.RevealSecret()
 
 	if ss.RevealSecret() != s {
-		t.Fatalf("Expected %q after reveal, got %q", s, ssRevealed)
+		t.Fatalf("got %q after reveal, want %q", ssRevealed, s)
 	}
 
 	ssHiddenRepr := ss.String()
 	ssLogged := ss.LogValue().String()
 
 	if ssLogged != ssHiddenRepr {
-		t.Fatalf("Expected LogValue %q == String %q", ssLogged, ssHiddenRepr)
+		t.Fatalf("LogValue().String() = %q, want String() = %q", ssLogged, ssHiddenRepr)
 	}
 
 	sLower := strings.ToLower(s)

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -18,7 +18,7 @@ import (
 type TestCase struct {
 	name          string
 	setupUserRepo func(r *MockUserRepository)
-	expectedErr   error
+	wantErr       error
 }
 
 func TestAuth_Register(t *testing.T) {
@@ -26,8 +26,8 @@ func TestAuth_Register(t *testing.T) {
 
 	tests := []TestCase{
 		{
-			name:        "Success",
-			expectedErr: nil,
+			name:    "Success",
+			wantErr: nil,
 			setupUserRepo: func(r *MockUserRepository) {
 				r.InsertFunc = func(ctx context.Context, email domain.Email, hash string) error {
 					if hash == testutil.ValidPassword().String() {
@@ -38,8 +38,8 @@ func TestAuth_Register(t *testing.T) {
 			},
 		},
 		{
-			name:        "User already exists",
-			expectedErr: service.ErrUserAlreadyExists,
+			name:    "User already exists",
+			wantErr: service.ErrUserAlreadyExists,
 			setupUserRepo: func(r *MockUserRepository) {
 				r.InsertFunc = func(ctx context.Context, email domain.Email, hash string) error {
 					return repository.ErrUniqueViolation
@@ -47,8 +47,8 @@ func TestAuth_Register(t *testing.T) {
 			},
 		},
 		{
-			name:        "Internal repository error",
-			expectedErr: service.ErrInternal,
+			name:    "Internal repository error",
+			wantErr: service.ErrInternal,
 			setupUserRepo: func(r *MockUserRepository) {
 				r.InsertFunc = func(ctx context.Context, email domain.Email, hash string) error {
 					return repository.ErrInternal
@@ -56,8 +56,8 @@ func TestAuth_Register(t *testing.T) {
 			},
 		},
 		{
-			name:        "Unexpected repository error",
-			expectedErr: service.ErrInternal,
+			name:    "Unexpected repository error",
+			wantErr: service.ErrInternal,
 			setupUserRepo: func(r *MockUserRepository) {
 				r.InsertFunc = func(ctx context.Context, email domain.Email, hash string) error {
 					return errors.New("Super unknown error happened")
@@ -76,8 +76,8 @@ func TestAuth_Register(t *testing.T) {
 
 			err := s.Register(context.Background(), testutil.ValidEmail(), testutil.ValidPassword())
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("Expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -94,11 +94,11 @@ func TestAuth_Login(t *testing.T) {
 					return testutil.ValidUserID(), testutil.ValidPasswordHash(), nil
 				}
 			},
-			expectedErr: nil,
+			wantErr: nil,
 		},
 		{
-			name:        "User not found",
-			expectedErr: service.ErrUserNotFound,
+			name:    "User not found",
+			wantErr: service.ErrUserNotFound,
 			setupUserRepo: func(r *MockUserRepository) {
 				r.GetByEmailFunc = func(ctx context.Context, email domain.Email) (domain.UserID, string, error) {
 					return domain.UserID{}, "", repository.ErrRowNotFound
@@ -106,8 +106,8 @@ func TestAuth_Login(t *testing.T) {
 			},
 		},
 		{
-			name:        "Invalid password",
-			expectedErr: service.ErrInvalidCredentials,
+			name:    "Invalid password",
+			wantErr: service.ErrInvalidCredentials,
 			setupUserRepo: func(r *MockUserRepository) {
 				r.GetByEmailFunc = func(ctx context.Context, email domain.Email) (domain.UserID, string, error) {
 					return testutil.ValidUserID(), testutil.AnotherValidPasswordHash(), nil
@@ -115,8 +115,8 @@ func TestAuth_Login(t *testing.T) {
 			},
 		},
 		{
-			name:        "Internal repository error",
-			expectedErr: service.ErrInternal,
+			name:    "Internal repository error",
+			wantErr: service.ErrInternal,
 			setupUserRepo: func(r *MockUserRepository) {
 				r.GetByEmailFunc = func(ctx context.Context, email domain.Email) (domain.UserID, string, error) {
 					return domain.UserID{}, "", repository.ErrInternal
@@ -124,8 +124,8 @@ func TestAuth_Login(t *testing.T) {
 			},
 		},
 		{
-			name:        "Unexpected repository error",
-			expectedErr: service.ErrInternal,
+			name:    "Unexpected repository error",
+			wantErr: service.ErrInternal,
 			setupUserRepo: func(r *MockUserRepository) {
 				r.GetByEmailFunc = func(ctx context.Context, email domain.Email) (domain.UserID, string, error) {
 					return domain.UserID{}, "", errors.New("Super unknown error happened")
@@ -145,14 +145,14 @@ func TestAuth_Login(t *testing.T) {
 
 			token, err := s.Login(context.Background(), testutil.ValidEmail(), testutil.ValidPassword())
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("Expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
 
-			if tt.expectedErr == nil {
+			if tt.wantErr == nil {
 				parts := strings.Split(token, ".")
 				if len(parts) != 3 {
-					t.Errorf("Expected JWT token, got %q", token)
+					t.Errorf("got %d JWT segments, want 3", len(parts))
 				}
 			}
 		})
@@ -166,25 +166,25 @@ func TestAuth_VerifyToken(t *testing.T) {
 	s := service.NewAuth(nil, jwtOpts)
 
 	tests := []struct {
-		name           string
-		tokenFunc      func() (string, error)
-		expectedUserID domain.UserID
-		expectedErr    error
+		name       string
+		tokenFunc  func() (string, error)
+		wantUserID domain.UserID
+		wantErr    error
 	}{
 		{
 			name: "Valid token",
 			tokenFunc: func() (string, error) {
 				return s.CreateToken(testutil.ValidUserID(), jwtOpts.Exp)
 			},
-			expectedUserID: testutil.ValidUserID(),
-			expectedErr:    nil,
+			wantUserID: testutil.ValidUserID(),
+			wantErr:    nil,
 		},
 		{
 			name: "Invalid token",
 			tokenFunc: func() (string, error) {
 				return "invalid.token.here", nil
 			},
-			expectedErr: service.ErrInvalidToken,
+			wantErr: service.ErrInvalidToken,
 		},
 		{
 			name: "Different secret",
@@ -197,14 +197,14 @@ func TestAuth_VerifyToken(t *testing.T) {
 				token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 				return token.SignedString([]byte("wrong_secret"))
 			},
-			expectedErr: service.ErrInvalidToken,
+			wantErr: service.ErrInvalidToken,
 		},
 		{
 			name: "Expired token",
 			tokenFunc: func() (string, error) {
 				return s.CreateToken(testutil.ValidUserID(), -time.Hour)
 			},
-			expectedErr: service.ErrTokenExpired,
+			wantErr: service.ErrTokenExpired,
 		},
 		{
 			name: "Different signing method",
@@ -217,7 +217,7 @@ func TestAuth_VerifyToken(t *testing.T) {
 				token := jwt.NewWithClaims(jwt.SigningMethodHS384, claims)
 				return token.SignedString([]byte(testutil.ValidJWTSecret().RevealSecret()))
 			},
-			expectedErr: service.ErrInvalidSigningMethod,
+			wantErr: service.ErrInvalidSigningMethod,
 		},
 		{
 			name: "Missing sub claim",
@@ -229,7 +229,7 @@ func TestAuth_VerifyToken(t *testing.T) {
 				token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 				return token.SignedString([]byte(testutil.ValidJWTSecret().RevealSecret()))
 			},
-			expectedErr: service.ErrInvalidToken,
+			wantErr: service.ErrInvalidToken,
 		},
 		{
 			name: "Sub claim not a string",
@@ -242,7 +242,7 @@ func TestAuth_VerifyToken(t *testing.T) {
 				token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 				return token.SignedString([]byte(testutil.ValidJWTSecret().RevealSecret()))
 			},
-			expectedErr: service.ErrInvalidToken,
+			wantErr: service.ErrInvalidToken,
 		},
 		{
 			name: "Invalid ID in sub",
@@ -255,7 +255,7 @@ func TestAuth_VerifyToken(t *testing.T) {
 				token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 				return token.SignedString([]byte(testutil.ValidJWTSecret().RevealSecret()))
 			},
-			expectedErr: service.ErrInvalidToken,
+			wantErr: service.ErrInvalidToken,
 		},
 	}
 
@@ -265,17 +265,17 @@ func TestAuth_VerifyToken(t *testing.T) {
 
 			token, err := tt.tokenFunc()
 			if err != nil {
-				t.Fatalf("token generation failed: %v", err)
+				t.Fatalf("tokenFunc() error = %v", err)
 			}
 
-			returnedUserID, err := s.VerifyToken(context.Background(), token)
+			gotUserID, err := s.VerifyToken(context.Background(), token)
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("Expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
 
-			if tt.expectedErr == nil && returnedUserID != tt.expectedUserID {
-				t.Errorf("Expected userID %q, got %q", tt.expectedUserID, returnedUserID)
+			if tt.wantErr == nil && gotUserID != tt.wantUserID {
+				t.Errorf("got userID %q, want %q", gotUserID, tt.wantUserID)
 			}
 		})
 	}
@@ -290,44 +290,44 @@ func TestAuth_CreateToken(t *testing.T) {
 	userID := testutil.ValidUserID()
 	token, err := s.CreateToken(userID, jwtOpts.Exp)
 	if err != nil {
-		t.Fatalf("token creation failed: %v", err)
+		t.Fatalf("CreateToken() error = %v", err)
 	}
 
 	parsedToken, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
 		return []byte(testutil.ValidJWTSecret().RevealSecret()), nil
 	})
 	if err != nil {
-		t.Fatalf("token parsing failed: %v", err)
+		t.Fatalf("jwt.Parse() error = %v", err)
 	}
 
 	claims, ok := parsedToken.Claims.(jwt.MapClaims)
 	if !ok {
-		t.Fatalf("claims are not map %v", claims)
+		t.Fatalf("got claims type %T, want jwt.MapClaims", parsedToken.Claims)
 	}
 
 	if claims["sub"] != userID.String() {
-		t.Errorf("Expected sub %v, got %v", userID, claims["sub"])
+		t.Errorf("got sub %v, want %v", claims["sub"], userID.String())
 	}
 
 	exp, ok := claims["exp"].(float64)
 	if !ok {
-		t.Fatalf("exp claim is missing or not a number")
+		t.Fatalf("got exp claim %#v, want float64", claims["exp"])
 	}
-	expectedExp := now.Add(jwtOpts.Exp).Unix()
-	if int64(exp) < expectedExp-1 || int64(exp) > expectedExp+1 {
-		t.Errorf("Expected exp around %v, got %v", expectedExp, int64(exp))
+	wantExp := now.Add(jwtOpts.Exp).Unix()
+	if int64(exp) < wantExp-1 || int64(exp) > wantExp+1 {
+		t.Errorf("got exp %v, want around %v", int64(exp), wantExp)
 	}
 
 	iat, ok := claims["iat"].(float64)
 	if !ok {
-		t.Fatalf("iat claim is missing or not a number")
+		t.Fatalf("got iat claim %#v, want float64", claims["iat"])
 	}
-	expectedIat := now.Unix()
-	if int64(iat) < expectedIat-1 || int64(iat) > expectedIat+1 {
-		t.Errorf("Expected iat around %v, got %v", expectedIat, int64(iat))
+	wantIat := now.Unix()
+	if int64(iat) < wantIat-1 || int64(iat) > wantIat+1 {
+		t.Errorf("got iat %v, want around %v", int64(iat), wantIat)
 	}
 
 	if parsedToken.Method.Alg() != jwt.SigningMethodHS256.Alg() {
-		t.Errorf("Expected alg %v, got %v", jwt.SigningMethodHS256.Alg(), parsedToken.Method.Alg())
+		t.Errorf("got alg %v, want %v", parsedToken.Method.Alg(), jwt.SigningMethodHS256.Alg())
 	}
 }

--- a/internal/service/board_test.go
+++ b/internal/service/board_test.go
@@ -21,7 +21,7 @@ func TestBoard_Create(t *testing.T) {
 	tests := []struct {
 		name           string
 		setupBoardRepo func(t *testing.T, r *MockBoardRepository)
-		expectedErr    error
+		wantErr        error
 		wantBoard      domain.Board
 	}{
 		{
@@ -29,19 +29,19 @@ func TestBoard_Create(t *testing.T) {
 			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.CreateFunc = func(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
 					if ownerID != validBoard.OwnerID {
-						t.Errorf("expected ownerID %v, got %v", validBoard.OwnerID, ownerID)
+						t.Errorf("got ownerID %v, want %v", ownerID, validBoard.OwnerID)
 					}
 					if name != validBoard.Name {
-						t.Errorf("expected name %v, got %v", validBoard.Name, name)
+						t.Errorf("got name %v, want %v", name, validBoard.Name)
 					}
 					if description != validBoard.Description {
-						t.Errorf("expected description %v, got %v", validBoard.Description, description)
+						t.Errorf("got description %v, want %v", description, validBoard.Description)
 					}
 					return validBoard, nil
 				}
 			},
-			expectedErr: nil,
-			wantBoard:   validBoard,
+			wantErr:   nil,
+			wantBoard: validBoard,
 		},
 		{
 			name: "Internal error",
@@ -50,7 +50,7 @@ func TestBoard_Create(t *testing.T) {
 					return domain.Board{}, repository.ErrInternal
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 		{
 			name: "Unexpected error",
@@ -59,7 +59,7 @@ func TestBoard_Create(t *testing.T) {
 					return domain.Board{}, errors.New("unexpected error")
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 	}
 
@@ -73,10 +73,10 @@ func TestBoard_Create(t *testing.T) {
 
 			got, err := s.Create(context.Background(), validBoard.OwnerID, validBoard.Name, validBoard.Description)
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.expectedErr == nil && !reflect.DeepEqual(tt.wantBoard, got) {
+			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantBoard, got) {
 				t.Errorf("Create() board = %#v, want %#v", got, tt.wantBoard)
 			}
 		})
@@ -91,7 +91,7 @@ func TestBoard_GetMany(t *testing.T) {
 	tests := []struct {
 		name           string
 		setupBoardRepo func(t *testing.T, r *MockBoardRepository)
-		expectedErr    error
+		wantErr        error
 		wantBoards     []domain.Board
 	}{
 		{
@@ -99,13 +99,13 @@ func TestBoard_GetMany(t *testing.T) {
 			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetManyFunc = func(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error) {
 					if ownerID != validBoard.OwnerID {
-						t.Errorf("expected ownerID %v, got %v", validBoard.OwnerID, ownerID)
+						t.Errorf("got ownerID %v, want %v", ownerID, validBoard.OwnerID)
 					}
 					return []domain.Board{validBoard}, nil
 				}
 			},
-			expectedErr: nil,
-			wantBoards:  []domain.Board{validBoard},
+			wantErr:    nil,
+			wantBoards: []domain.Board{validBoard},
 		},
 		{
 			name: "Internal error",
@@ -114,7 +114,7 @@ func TestBoard_GetMany(t *testing.T) {
 					return nil, repository.ErrInternal
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 		{
 			name: "Unexpected error",
@@ -123,7 +123,7 @@ func TestBoard_GetMany(t *testing.T) {
 					return nil, errors.New("unexpected error")
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 	}
 
@@ -137,10 +137,10 @@ func TestBoard_GetMany(t *testing.T) {
 
 			got, err := s.GetMany(context.Background(), validBoard.OwnerID)
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.expectedErr == nil && !reflect.DeepEqual(tt.wantBoards, got) {
+			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantBoards, got) {
 				t.Errorf("GetMany() = %#v, want %#v", got, tt.wantBoards)
 			}
 		})
@@ -151,7 +151,7 @@ type boardServiceGetTestCase struct {
 	name           string
 	callerID       domain.UserID
 	setupBoardRepo func(t *testing.T, r *MockBoardRepository)
-	expectedErr    error
+	wantErr        error
 	wantBoard      domain.Board
 }
 
@@ -168,13 +168,13 @@ func TestBoard_Get(t *testing.T) {
 			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					if id != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, id)
+						t.Errorf("got board id %v, want %v", id, validBoard.ID)
 					}
 					return validBoard, nil
 				}
 			},
-			expectedErr: nil,
-			wantBoard:   validBoard,
+			wantErr:   nil,
+			wantBoard: validBoard,
 		},
 		{
 			name:     "Not found when not owner",
@@ -184,7 +184,7 @@ func TestBoard_Get(t *testing.T) {
 					return validBoard, nil
 				}
 			},
-			expectedErr: service.ErrBoardNotFound,
+			wantErr: service.ErrBoardNotFound,
 		},
 		{
 			name:     "Not found when row missing",
@@ -194,7 +194,7 @@ func TestBoard_Get(t *testing.T) {
 					return domain.Board{}, repository.ErrRowNotFound
 				}
 			},
-			expectedErr: service.ErrBoardNotFound,
+			wantErr: service.ErrBoardNotFound,
 		},
 		{
 			name:     "Internal error from repository",
@@ -204,7 +204,7 @@ func TestBoard_Get(t *testing.T) {
 					return domain.Board{}, repository.ErrInternal
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 		{
 			name:     "Unexpected error from repository",
@@ -214,7 +214,7 @@ func TestBoard_Get(t *testing.T) {
 					return domain.Board{}, errors.New("db exploded")
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 	}
 
@@ -228,10 +228,10 @@ func TestBoard_Get(t *testing.T) {
 
 			got, err := s.Get(context.Background(), tt.callerID, validBoard.ID)
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.expectedErr == nil && !reflect.DeepEqual(tt.wantBoard, got) {
+			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantBoard, got) {
 				t.Errorf("Get() board = %#v, want %#v", got, tt.wantBoard)
 			}
 		})
@@ -258,7 +258,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 		inputName        *domain.BoardName
 		inputDescription *domain.BoardDescription
 		setupBoardRepo   func(t *testing.T, r *MockBoardRepository)
-		expectedErr      error
+		wantErr          error
 		wantBoard        domain.Board
 	}{
 		{
@@ -269,29 +269,29 @@ func TestBoard_UpdateByID(t *testing.T) {
 			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.UpdateByIDFunc = func(ctx context.Context, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription, updatedAt time.Time) (domain.Board, error) {
 					if boardID != validBoard.ID {
-						t.Errorf("unexpected boardID %v", boardID)
+						t.Errorf("got boardID %v, want %v", boardID, validBoard.ID)
 					}
 					if updatedAt != updatedValidBoard.UpdatedAt {
-						t.Errorf("unexpected updatedAt %v", updatedAt)
+						t.Errorf("got updatedAt %v, want %v", updatedAt, updatedValidBoard.UpdatedAt)
 					}
 					if name == nil || *name != updatedValidBoard.Name {
-						t.Errorf("unexpected name %+v", name)
+						t.Errorf("got name %+v, want %+v", name, updatedValidBoard.Name)
 					}
 					if description == nil || *description != updatedValidBoard.Description {
-						t.Errorf("unexpected description %+v", description)
+						t.Errorf("got description %+v, want %+v", description, updatedValidBoard.Description)
 					}
 					return updatedValidBoard, nil
 				}
 
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					if id != validBoard.ID {
-						t.Errorf("unexpected boardID %v", id)
+						t.Errorf("got boardID %v, want %v", id, validBoard.ID)
 					}
 					return validBoard, nil
 				}
 			},
-			expectedErr: nil,
-			wantBoard:   updatedValidBoard,
+			wantErr:   nil,
+			wantBoard: updatedValidBoard,
 		},
 		{
 			name:      "Success update only name",
@@ -300,13 +300,13 @@ func TestBoard_UpdateByID(t *testing.T) {
 			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.UpdateByIDFunc = func(ctx context.Context, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription, updatedAt time.Time) (domain.Board, error) {
 					if updatedAt != updatedNameOnlyBoard.UpdatedAt {
-						t.Errorf("unexpected updatedAt %v", updatedAt)
+						t.Errorf("got updatedAt %v, want %v", updatedAt, updatedNameOnlyBoard.UpdatedAt)
 					}
 					if name == nil || *name != updatedNameOnlyBoard.Name {
-						t.Errorf("unexpected name %+v", name)
+						t.Errorf("got name %+v, want %+v", name, updatedNameOnlyBoard.Name)
 					}
 					if description != nil {
-						t.Errorf("unexpected description %+v", description)
+						t.Errorf("got description %+v, want nil", description)
 					}
 					return updatedNameOnlyBoard, nil
 				}
@@ -314,8 +314,8 @@ func TestBoard_UpdateByID(t *testing.T) {
 					return validBoard, nil
 				}
 			},
-			expectedErr: nil,
-			wantBoard:   updatedNameOnlyBoard,
+			wantErr:   nil,
+			wantBoard: updatedNameOnlyBoard,
 		},
 		{
 			name:             "Success update only description",
@@ -324,13 +324,13 @@ func TestBoard_UpdateByID(t *testing.T) {
 			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.UpdateByIDFunc = func(ctx context.Context, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription, updatedAt time.Time) (domain.Board, error) {
 					if updatedAt != updatedDescriptionOnlyBoard.UpdatedAt {
-						t.Errorf("unexpected updatedAt %v", updatedAt)
+						t.Errorf("got updatedAt %v, want %v", updatedAt, updatedDescriptionOnlyBoard.UpdatedAt)
 					}
 					if name != nil {
-						t.Errorf("unexpected name %+v", name)
+						t.Errorf("got name %+v, want nil", name)
 					}
 					if description == nil || *description != updatedDescriptionOnlyBoard.Description {
-						t.Errorf("unexpected description %+v", description)
+						t.Errorf("got description %+v, want %+v", description, updatedDescriptionOnlyBoard.Description)
 					}
 					return updatedDescriptionOnlyBoard, nil
 				}
@@ -338,8 +338,8 @@ func TestBoard_UpdateByID(t *testing.T) {
 					return validBoard, nil
 				}
 			},
-			expectedErr: nil,
-			wantBoard:   updatedDescriptionOnlyBoard,
+			wantErr:   nil,
+			wantBoard: updatedDescriptionOnlyBoard,
 		},
 		{
 			name:     "Success update no fields",
@@ -349,8 +349,8 @@ func TestBoard_UpdateByID(t *testing.T) {
 					return validBoard, nil
 				}
 			},
-			expectedErr: nil,
-			wantBoard:   validBoard,
+			wantErr:   nil,
+			wantBoard: validBoard,
 		},
 		{
 			name:     "Not found when wrong owner",
@@ -360,7 +360,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 					return validBoard, nil
 				}
 			},
-			expectedErr: service.ErrBoardNotFound,
+			wantErr: service.ErrBoardNotFound,
 		},
 		{
 			name:     "Not found when row missing",
@@ -370,7 +370,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 					return domain.Board{}, repository.ErrRowNotFound
 				}
 			},
-			expectedErr: service.ErrBoardNotFound,
+			wantErr: service.ErrBoardNotFound,
 		},
 		{
 			name:      "Internal error",
@@ -384,7 +384,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 					return domain.Board{}, repository.ErrInternal
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 		{
 			name:      "Unexpected error",
@@ -398,7 +398,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 					return domain.Board{}, errors.New("db exploded")
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 		{
 			name:     "Unexpected get by id error",
@@ -408,7 +408,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 					return domain.Board{}, errors.New("db exploded")
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 	}
 
@@ -422,10 +422,10 @@ func TestBoard_UpdateByID(t *testing.T) {
 
 			got, err := s.UpdateByID(context.Background(), tt.callerID, validBoard.ID, tt.inputName, tt.inputDescription)
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.expectedErr == nil && !reflect.DeepEqual(tt.wantBoard, got) {
+			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantBoard, got) {
 				t.Errorf("UpdateByID() board = %#v, want %#v", got, tt.wantBoard)
 			}
 		})
@@ -442,7 +442,7 @@ func TestBoard_Delete(t *testing.T) {
 		name           string
 		callerID       domain.UserID
 		setupBoardRepo func(t *testing.T, r *MockBoardRepository)
-		expectedErr    error
+		wantErr        error
 	}{
 		{
 			name:     "Success",
@@ -450,18 +450,18 @@ func TestBoard_Delete(t *testing.T) {
 			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					if id != validBoard.ID {
-						t.Errorf("unexpected boardID %v", id)
+						t.Errorf("got boardID %v, want %v", id, validBoard.ID)
 					}
 					return validBoard, nil
 				}
 				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID) error {
 					if boardID != validBoard.ID {
-						t.Errorf("unexpected boardID %v", boardID)
+						t.Errorf("got boardID %v, want %v", boardID, validBoard.ID)
 					}
 					return nil
 				}
 			},
-			expectedErr: nil,
+			wantErr: nil,
 		},
 		{
 			name:     "Not found when wrong owner",
@@ -471,7 +471,7 @@ func TestBoard_Delete(t *testing.T) {
 					return validBoard, nil
 				}
 			},
-			expectedErr: service.ErrBoardNotFound,
+			wantErr: service.ErrBoardNotFound,
 		},
 		{
 			name:     "Not found when row missing",
@@ -481,7 +481,7 @@ func TestBoard_Delete(t *testing.T) {
 					return domain.Board{}, repository.ErrRowNotFound
 				}
 			},
-			expectedErr: service.ErrBoardNotFound,
+			wantErr: service.ErrBoardNotFound,
 		},
 		{
 			name:     "Internal error from repository",
@@ -491,7 +491,7 @@ func TestBoard_Delete(t *testing.T) {
 					return domain.Board{}, repository.ErrInternal
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 		{
 			name:     "Unexpected error from repository",
@@ -501,7 +501,7 @@ func TestBoard_Delete(t *testing.T) {
 					return domain.Board{}, errors.New("db exploded")
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 		{
 			name:     "Delete returns not found",
@@ -514,7 +514,7 @@ func TestBoard_Delete(t *testing.T) {
 					return repository.ErrRowNotFound
 				}
 			},
-			expectedErr: service.ErrBoardNotFound,
+			wantErr: service.ErrBoardNotFound,
 		},
 		{
 			name:     "Delete returns internal",
@@ -527,7 +527,7 @@ func TestBoard_Delete(t *testing.T) {
 					return repository.ErrInternal
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 	}
 
@@ -541,8 +541,8 @@ func TestBoard_Delete(t *testing.T) {
 
 			err := s.Delete(context.Background(), tt.callerID, validBoard.ID)
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/internal/service/column_test.go
+++ b/internal/service/column_test.go
@@ -19,11 +19,11 @@ func TestColumn_Create(t *testing.T) {
 	validBoard := testutil.ValidBoard()
 	validName, err := domain.NewColumnName("In Progress")
 	if err != nil {
-		t.Fatalf("NewColumnName: %v", err)
+		t.Fatalf("NewColumnName() error = %v", err)
 	}
 	validPosition, err := domain.NewColumnPosition(3)
 	if err != nil {
-		t.Fatalf("NewColumnPosition: %v", err)
+		t.Fatalf("NewColumnPosition() error = %v", err)
 	}
 	validColumn := domain.Column{
 		ID:        domain.NewColumnID(),
@@ -39,7 +39,7 @@ func TestColumn_Create(t *testing.T) {
 		callerID        domain.UserID
 		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
 		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
-		expectedErr     error
+		wantErr         error
 		wantColumn      domain.Column
 	}{
 		{
@@ -48,7 +48,7 @@ func TestColumn_Create(t *testing.T) {
 			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					if id != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, id)
+						t.Errorf("got board id %v, want %v", id, validBoard.ID)
 					}
 					return validBoard, nil
 				}
@@ -56,13 +56,14 @@ func TestColumn_Create(t *testing.T) {
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.CreateFunc = func(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, createdAt, updatedAt time.Time) (domain.Column, error) {
 					if boardID != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
 					}
 					if name != validName {
-						t.Errorf("expected name %v, got %v", validName, name)
+						t.Errorf("got name %v, want %v", name, validName)
 					}
-					if !createdAt.Equal(testutil.FixedTimeNow()) || !updatedAt.Equal(testutil.FixedTimeNow()) {
-						t.Errorf("expected service timestamp %v, got created=%v updated=%v", testutil.FixedTimeNow(), createdAt, updatedAt)
+					wantTs := testutil.FixedTimeNow()
+					if !createdAt.Equal(wantTs) || !updatedAt.Equal(wantTs) {
+						t.Errorf("got createdAt=%v updatedAt=%v, want both %v", createdAt, updatedAt, wantTs)
 					}
 					return validColumn, nil
 				}
@@ -79,11 +80,11 @@ func TestColumn_Create(t *testing.T) {
 			},
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.CreateFunc = func(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, createdAt, updatedAt time.Time) (domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.Column{}, nil
 				}
 			},
-			expectedErr: service.ErrBoardNotFound,
+			wantErr: service.ErrBoardNotFound,
 		},
 		{
 			name:     "Caller has no access",
@@ -95,11 +96,11 @@ func TestColumn_Create(t *testing.T) {
 			},
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.CreateFunc = func(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, createdAt, updatedAt time.Time) (domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.Column{}, nil
 				}
 			},
-			expectedErr: service.ErrBoardNotFound,
+			wantErr: service.ErrBoardNotFound,
 		},
 		{
 			name:     "Create internal error",
@@ -114,7 +115,7 @@ func TestColumn_Create(t *testing.T) {
 					return domain.Column{}, errors.New("insert failed")
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 	}
 
@@ -130,10 +131,10 @@ func TestColumn_Create(t *testing.T) {
 			s := service.NewColumn(columnRepo, boardRepo, testutil.FixedTimeNow)
 			got, err := s.Create(context.Background(), tt.callerID, validBoard.ID, validName)
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.expectedErr == nil && !reflect.DeepEqual(tt.wantColumn, got) {
+			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantColumn, got) {
 				t.Errorf("Create() column = %#v, want %#v", got, tt.wantColumn)
 			}
 		})
@@ -153,7 +154,7 @@ func TestColumn_List(t *testing.T) {
 		callerID        domain.UserID
 		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
 		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
-		expectedErr     error
+		wantErr         error
 		wantColumns     []domain.Column
 	}{
 		{
@@ -167,7 +168,7 @@ func TestColumn_List(t *testing.T) {
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.ListByBoardIDFunc = func(ctx context.Context, boardID domain.BoardID) ([]domain.Column, error) {
 					if boardID != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
 					}
 					return []domain.Column{first, second}, nil
 				}
@@ -184,11 +185,11 @@ func TestColumn_List(t *testing.T) {
 			},
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.ListByBoardIDFunc = func(ctx context.Context, boardID domain.BoardID) ([]domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return nil, nil
 				}
 			},
-			expectedErr: service.ErrBoardNotFound,
+			wantErr: service.ErrBoardNotFound,
 		},
 		{
 			name:     "No access",
@@ -200,11 +201,11 @@ func TestColumn_List(t *testing.T) {
 			},
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.ListByBoardIDFunc = func(ctx context.Context, boardID domain.BoardID) ([]domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return nil, nil
 				}
 			},
-			expectedErr: service.ErrBoardNotFound,
+			wantErr: service.ErrBoardNotFound,
 		},
 		{
 			name:     "Repository error",
@@ -219,7 +220,7 @@ func TestColumn_List(t *testing.T) {
 					return nil, errors.New("db failed")
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 	}
 
@@ -235,10 +236,10 @@ func TestColumn_List(t *testing.T) {
 			s := service.NewColumn(columnRepo, boardRepo, testutil.FixedTimeNow)
 			got, err := s.List(context.Background(), tt.callerID, validBoard.ID)
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.expectedErr == nil && !reflect.DeepEqual(tt.wantColumns, got) {
+			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantColumns, got) {
 				t.Errorf("List() columns = %#v, want %#v", got, tt.wantColumns)
 			}
 		})
@@ -252,7 +253,7 @@ func TestColumn_UpdateByID(t *testing.T) {
 	validColumn := testutil.ValidColumn(validBoard.ID)
 	updatedName, err := domain.NewColumnName("Renamed")
 	if err != nil {
-		t.Fatalf("NewColumnName: %v", err)
+		t.Fatalf("NewColumnName() error = %v", err)
 	}
 	updatedColumn := validColumn
 	updatedColumn.Name = updatedName
@@ -265,7 +266,7 @@ func TestColumn_UpdateByID(t *testing.T) {
 		patchName       *domain.ColumnName
 		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
 		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
-		expectedErr     error
+		wantErr         error
 		wantColumn      domain.Column
 	}{
 		{
@@ -281,22 +282,22 @@ func TestColumn_UpdateByID(t *testing.T) {
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					if columnID != validColumn.ID {
-						t.Errorf("expected column id %v, got %v", validColumn.ID, columnID)
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
 					}
 					return validColumn, nil
 				}
 				r.UpdateByIDFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName, updatedAt time.Time) (domain.Column, error) {
 					if boardID != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
 					}
 					if columnID != validColumn.ID {
-						t.Errorf("expected column id %v, got %v", validColumn.ID, columnID)
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
 					}
 					if name == nil || *name != updatedName {
-						t.Errorf("expected name %v, got %+v", updatedName, name)
+						t.Errorf("got name %v, want %v", name, updatedName)
 					}
 					if !updatedAt.Equal(testutil.FixedTimeNow()) {
-						t.Errorf("expected updatedAt %v, got %v", testutil.FixedTimeNow(), updatedAt)
+						t.Errorf("got updatedAt %v, want %v", updatedAt, testutil.FixedTimeNow())
 					}
 					return updatedColumn, nil
 				}
@@ -317,7 +318,7 @@ func TestColumn_UpdateByID(t *testing.T) {
 					return validColumn, nil
 				}
 				r.UpdateByIDFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName, updatedAt time.Time) (domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.Column{}, nil
 				}
 			},
@@ -334,15 +335,15 @@ func TestColumn_UpdateByID(t *testing.T) {
 			},
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.Column{}, nil
 				}
 				r.UpdateByIDFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName, updatedAt time.Time) (domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.Column{}, nil
 				}
 			},
-			expectedErr: service.ErrColumnNotFound,
+			wantErr: service.ErrColumnNotFound,
 		},
 		{
 			name:     "Caller has no access",
@@ -355,15 +356,15 @@ func TestColumn_UpdateByID(t *testing.T) {
 			},
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.Column{}, nil
 				}
 				r.UpdateByIDFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName, updatedAt time.Time) (domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.Column{}, nil
 				}
 			},
-			expectedErr: service.ErrColumnNotFound,
+			wantErr: service.ErrColumnNotFound,
 		},
 		{
 			name:     "Column does not belong to board",
@@ -381,11 +382,11 @@ func TestColumn_UpdateByID(t *testing.T) {
 					return otherBoardColumn, nil
 				}
 				r.UpdateByIDFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName, updatedAt time.Time) (domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.Column{}, nil
 				}
 			},
-			expectedErr: service.ErrColumnNotFound,
+			wantErr: service.ErrColumnNotFound,
 		},
 		{
 			name:     "Column not found",
@@ -401,11 +402,11 @@ func TestColumn_UpdateByID(t *testing.T) {
 					return domain.Column{}, repository.ErrRowNotFound
 				}
 				r.UpdateByIDFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName, updatedAt time.Time) (domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.Column{}, nil
 				}
 			},
-			expectedErr: service.ErrColumnNotFound,
+			wantErr: service.ErrColumnNotFound,
 		},
 		{
 			name:      "Update internal error",
@@ -425,7 +426,7 @@ func TestColumn_UpdateByID(t *testing.T) {
 					return domain.Column{}, errors.New("update failed")
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 	}
 
@@ -441,10 +442,10 @@ func TestColumn_UpdateByID(t *testing.T) {
 			s := service.NewColumn(columnRepo, boardRepo, testutil.FixedTimeNow)
 			got, err := s.UpdateByID(context.Background(), tt.callerID, validBoard.ID, tt.columnID, tt.patchName)
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.expectedErr == nil && !reflect.DeepEqual(tt.wantColumn, got) {
+			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantColumn, got) {
 				t.Errorf("UpdateByID() column = %#v, want %#v", got, tt.wantColumn)
 			}
 		})
@@ -458,7 +459,7 @@ func TestColumn_Move(t *testing.T) {
 	validColumn := testutil.ValidColumn(validBoard.ID)
 	targetPosition, err := domain.NewColumnPosition(2)
 	if err != nil {
-		t.Fatalf("NewColumnPosition: %v", err)
+		t.Fatalf("NewColumnPosition() error = %v", err)
 	}
 
 	tests := []struct {
@@ -467,7 +468,7 @@ func TestColumn_Move(t *testing.T) {
 		columnID        domain.ColumnID
 		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
 		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
-		expectedErr     error
+		wantErr         error
 		wantPosition    domain.ColumnPosition
 	}{
 		{
@@ -482,19 +483,19 @@ func TestColumn_Move(t *testing.T) {
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
 					if columnID != validColumn.ID {
-						t.Errorf("expected column id %v, got %v", validColumn.ID, columnID)
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
 					}
 					return validColumn, nil
 				}
 				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, gotTargetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
 					if boardID != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
 					}
 					if columnID != validColumn.ID {
-						t.Errorf("expected column id %v, got %v", validColumn.ID, columnID)
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
 					}
 					if gotTargetPosition != targetPosition {
-						t.Errorf("expected target position %v, got %v", targetPosition, gotTargetPosition)
+						t.Errorf("got target position %v, want %v", gotTargetPosition, targetPosition)
 					}
 					return targetPosition, nil
 				}
@@ -512,15 +513,15 @@ func TestColumn_Move(t *testing.T) {
 			},
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.Column{}, nil
 				}
 				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, targetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.ColumnPosition{}, nil
 				}
 			},
-			expectedErr: service.ErrColumnNotFound,
+			wantErr: service.ErrColumnNotFound,
 		},
 		{
 			name:     "Caller has no access",
@@ -533,15 +534,15 @@ func TestColumn_Move(t *testing.T) {
 			},
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.Column{}, nil
 				}
 				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, targetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.ColumnPosition{}, nil
 				}
 			},
-			expectedErr: service.ErrColumnNotFound,
+			wantErr: service.ErrColumnNotFound,
 		},
 		{
 			name:     "Column belongs to another board",
@@ -559,11 +560,11 @@ func TestColumn_Move(t *testing.T) {
 					return otherBoardColumn, nil
 				}
 				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, targetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.ColumnPosition{}, nil
 				}
 			},
-			expectedErr: service.ErrColumnNotFound,
+			wantErr: service.ErrColumnNotFound,
 		},
 		{
 			name:     "Column not found",
@@ -579,11 +580,11 @@ func TestColumn_Move(t *testing.T) {
 					return domain.Column{}, repository.ErrRowNotFound
 				}
 				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, targetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return domain.ColumnPosition{}, nil
 				}
 			},
-			expectedErr: service.ErrColumnNotFound,
+			wantErr: service.ErrColumnNotFound,
 		},
 		{
 			name:     "Index out of bounds",
@@ -602,7 +603,7 @@ func TestColumn_Move(t *testing.T) {
 					return domain.ColumnPosition{}, repository.ErrIndexOutOfBounds
 				}
 			},
-			expectedErr: service.ErrIndexOutOfBounds,
+			wantErr: service.ErrIndexOutOfBounds,
 		},
 		{
 			name:     "Move row not found",
@@ -621,7 +622,7 @@ func TestColumn_Move(t *testing.T) {
 					return domain.ColumnPosition{}, repository.ErrRowNotFound
 				}
 			},
-			expectedErr: service.ErrColumnNotFound,
+			wantErr: service.ErrColumnNotFound,
 		},
 		{
 			name:     "Move internal error",
@@ -640,7 +641,7 @@ func TestColumn_Move(t *testing.T) {
 					return domain.ColumnPosition{}, errors.New("move failed")
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 	}
 
@@ -656,10 +657,10 @@ func TestColumn_Move(t *testing.T) {
 			s := service.NewColumn(columnRepo, boardRepo, testutil.FixedTimeNow)
 			got, err := s.Move(context.Background(), tt.callerID, validBoard.ID, tt.columnID, targetPosition)
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.expectedErr == nil && got != tt.wantPosition {
+			if tt.wantErr == nil && got != tt.wantPosition {
 				t.Errorf("Move() position = %v, want %v", got, tt.wantPosition)
 			}
 		})
@@ -678,7 +679,7 @@ func TestColumn_Delete(t *testing.T) {
 		columnID        domain.ColumnID
 		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
 		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
-		expectedErr     error
+		wantErr         error
 	}{
 		{
 			name:     "Success",
@@ -687,7 +688,7 @@ func TestColumn_Delete(t *testing.T) {
 			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
 					if id != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, id)
+						t.Errorf("got board id %v, want %v", id, validBoard.ID)
 					}
 					return validBoard, nil
 				}
@@ -695,10 +696,10 @@ func TestColumn_Delete(t *testing.T) {
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
 					if boardID != validBoard.ID {
-						t.Errorf("expected board id %v, got %v", validBoard.ID, boardID)
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
 					}
 					if columnID != validColumn.ID {
-						t.Errorf("expected column id %v, got %v", validColumn.ID, columnID)
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
 					}
 					return nil
 				}
@@ -715,11 +716,11 @@ func TestColumn_Delete(t *testing.T) {
 			},
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return nil
 				}
 			},
-			expectedErr: service.ErrColumnNotFound,
+			wantErr: service.ErrColumnNotFound,
 		},
 		{
 			name:     "Caller has no access",
@@ -732,11 +733,11 @@ func TestColumn_Delete(t *testing.T) {
 			},
 			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
 				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error {
-					t.Fatalf("should not be called")
+					t.Fatalf("got call, want no call")
 					return nil
 				}
 			},
-			expectedErr: service.ErrColumnNotFound,
+			wantErr: service.ErrColumnNotFound,
 		},
 		{
 			name:     "Column not found",
@@ -752,7 +753,7 @@ func TestColumn_Delete(t *testing.T) {
 					return repository.ErrRowNotFound
 				}
 			},
-			expectedErr: service.ErrColumnNotFound,
+			wantErr: service.ErrColumnNotFound,
 		},
 		{
 			name:     "Delete internal error",
@@ -768,7 +769,7 @@ func TestColumn_Delete(t *testing.T) {
 					return errors.New("delete failed")
 				}
 			},
-			expectedErr: service.ErrInternal,
+			wantErr: service.ErrInternal,
 		},
 	}
 
@@ -784,8 +785,8 @@ func TestColumn_Delete(t *testing.T) {
 			s := service.NewColumn(columnRepo, boardRepo, testutil.FixedTimeNow)
 			err := s.Delete(context.Background(), tt.callerID, validBoard.ID, tt.columnID)
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/internal/service/helpers_test.go
+++ b/internal/service/helpers_test.go
@@ -10,7 +10,7 @@ import (
 
 func AssertFuncNotNil(funcName string, fn any) {
 	if fn == nil {
-		panic(fmt.Sprintf("BUG: Mock: %s is not set", funcName))
+		panic(fmt.Sprintf("%s = nil, want configured mock", funcName))
 	}
 }
 

--- a/internal/testutil/data.go
+++ b/internal/testutil/data.go
@@ -107,11 +107,11 @@ func UpdateValidBoard(t *testing.T, base *domain.Board, name, description string
 	t.Helper()
 	domainName, err := domain.NewBoardName(name)
 	if err != nil {
-		t.Fatalf("Failed to create board name: %v", err)
+		t.Fatalf("NewBoardName() error = %v", err)
 	}
 	domainDescription, err := domain.NewBoardDescription(description)
 	if err != nil {
-		t.Fatalf("Failed to create board description: %v", err)
+		t.Fatalf("NewBoardDescription() error = %v", err)
 	}
 
 	return domain.Board{
@@ -146,12 +146,12 @@ func NewValidColumn(t *testing.T, boardID domain.BoardID, name string, position 
 
 	domainName, err := domain.NewColumnName(name)
 	if err != nil {
-		t.Fatalf("Failed to create column name: %v", err)
+		t.Fatalf("NewColumnName() error = %v", err)
 	}
 
 	domainPosition, err := domain.NewColumnPosition(position)
 	if err != nil {
-		t.Fatalf("Failed to create column position: %v", err)
+		t.Fatalf("NewColumnPosition() error = %v", err)
 	}
 
 	column.Name = domainName
@@ -165,7 +165,7 @@ func UpdateValidColumn(t *testing.T, base *domain.Column, name string, updatedAt
 
 	domainName, err := domain.NewColumnName(name)
 	if err != nil {
-		t.Fatalf("Failed to create column name: %v", err)
+		t.Fatalf("NewColumnName() error = %v", err)
 	}
 
 	return domain.Column{

--- a/internal/testutil/database.go
+++ b/internal/testutil/database.go
@@ -20,7 +20,7 @@ func SetupTestDB(t *testing.T, migrationsDir string) *pgxpool.Pool {
 
 	pool, err := app.SetupDatabaseFromEnv(logger, migrationsDir)
 	if err != nil {
-		t.Fatalf("Failed to setup database: %v", err)
+		t.Fatalf("SetupDatabaseFromEnv() error = %v", err)
 	}
 
 	return pool
@@ -36,6 +36,6 @@ func TruncateTable(t *testing.T, pool *pgxpool.Pool, name string) {
 
 	_, err := pool.Exec(ctx, query)
 	if err != nil {
-		t.Fatalf("Failed to TRUNCATE TABLE %q: %v", name, err)
+		t.Fatalf("TRUNCATE TABLE %q error = %v", name, err)
 	}
 }

--- a/internal/testutil/http.go
+++ b/internal/testutil/http.go
@@ -10,16 +10,16 @@ import (
 	"testing"
 )
 
-func AssertContentType(t *testing.T, rr *httptest.ResponseRecorder, expectedMediaType string) {
+func AssertContentType(t *testing.T, rr *httptest.ResponseRecorder, wantMediaType string) {
 	t.Helper()
 
 	contentType := rr.Header().Get("Content-Type")
 	mediaType, _, err := mime.ParseMediaType(contentType)
 	if err != nil {
-		t.Fatalf("Failed to parse MIME %q: %v", contentType, err)
+		t.Fatalf("mime.ParseMediaType(%q) error = %v", contentType, err)
 	}
-	if mediaType != expectedMediaType {
-		t.Errorf("Expected %q, got %q", expectedMediaType, mediaType)
+	if mediaType != wantMediaType {
+		t.Errorf("got content type %q, want %q", mediaType, wantMediaType)
 	}
 }
 
@@ -28,7 +28,7 @@ func MarshalJSONBody(t *testing.T, body any) string {
 
 	b, err := json.Marshal(body)
 	if err != nil {
-		t.Fatalf("Failed to marshal body: %v", err)
+		t.Fatalf("json.Marshal() error = %v", err)
 	}
 
 	return string(b)
@@ -45,7 +45,7 @@ func NewJSONRequestAndRecorder(t *testing.T, method, url string, body any) (*htt
 		var err error
 		resultingBytes, err = json.Marshal(body)
 		if err != nil {
-			t.Fatalf("Failed to marshal request body: %v", err)
+			t.Fatalf("json.Marshal(request body) error = %v", err)
 		}
 	}
 
@@ -56,40 +56,40 @@ func NewJSONRequestAndRecorder(t *testing.T, method, url string, body any) (*htt
 	return req, rr
 }
 
-func AssertStatusCode(t *testing.T, rr *httptest.ResponseRecorder, expectedStatusCode int) {
+func AssertStatusCode(t *testing.T, rr *httptest.ResponseRecorder, wantStatusCode int) {
 	t.Helper()
 
-	if rr.Code != expectedStatusCode {
-		t.Errorf("Expected status code %d, got %d", expectedStatusCode, rr.Code)
+	if rr.Code != wantStatusCode {
+		t.Errorf("got status %d, want %d", rr.Code, wantStatusCode)
 	}
 }
 
-func AssertResponseBody(t *testing.T, rr *httptest.ResponseRecorder, expected any) {
+func AssertResponseBody(t *testing.T, rr *httptest.ResponseRecorder, want any) {
 	t.Helper()
 
-	if expected == nil {
+	if want == nil {
 		if rr.Body.Len() != 0 {
-			t.Fatalf("Expected body to be empty, got %q", rr.Body.String())
+			t.Fatalf("got body %q, want empty", rr.Body.String())
 		}
 		return
 	}
 
-	expectedJSON, err := json.Marshal(expected)
+	wantJSON, err := json.Marshal(want)
 	if err != nil {
-		t.Fatalf("Failed to marshal expected body: %v", err)
+		t.Fatalf("json.Marshal(want) error = %v", err)
 	}
 
-	actualBody := rr.Body.Bytes()
+	gotBody := rr.Body.Bytes()
 
-	var actualDecoded, expectedDecoded any
-	if err := json.Unmarshal(actualBody, &actualDecoded); err != nil {
-		t.Fatalf("Failed to unmarshal actual body: %v\nBody: %q", err, string(actualBody))
+	var gotDecoded, wantDecoded any
+	if err := json.Unmarshal(gotBody, &gotDecoded); err != nil {
+		t.Fatalf("json.Unmarshal(response body) error = %v\nBody: %q", err, string(gotBody))
 	}
-	if err := json.Unmarshal(expectedJSON, &expectedDecoded); err != nil {
-		t.Fatalf("Failed to unmarshal expected body: %v\nBody: %q", err, string(expectedJSON))
+	if err := json.Unmarshal(wantJSON, &wantDecoded); err != nil {
+		t.Fatalf("json.Unmarshal(want JSON) error = %v\nWant JSON: %q", err, string(wantJSON))
 	}
 
-	if !reflect.DeepEqual(actualDecoded, expectedDecoded) {
-		t.Errorf("Response body mismatch\nExpected: %s\nGot: %s", string(expectedJSON), string(actualBody))
+	if !reflect.DeepEqual(gotDecoded, wantDecoded) {
+		t.Errorf("got response body %s, want %s", string(gotBody), string(wantJSON))
 	}
 }

--- a/internal/testutil/logging.go
+++ b/internal/testutil/logging.go
@@ -37,22 +37,22 @@ func NewDiscardLogger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
 }
 
-func FailOnInvalidLogValue(t *testing.T, attrs []slog.Attr, expectedAttrs map[string]string) {
+func FailOnInvalidLogValue(t *testing.T, attrs []slog.Attr, wantAttrs map[string]string) {
 	t.Helper()
 
 	for _, a := range attrs {
-		expected, ok := expectedAttrs[a.Key]
+		want, ok := wantAttrs[a.Key]
 		if !ok {
-			t.Errorf("unexpected attribute %q", a.Key)
+			t.Errorf("got unexpected attribute %q, want only configured keys", a.Key)
 			continue
 		}
-		if a.Value.String() != expected {
-			t.Errorf("for key %q, expected %q, got %q", a.Key, expected, a.Value.String())
+		if a.Value.String() != want {
+			t.Errorf("for key %q, got %q, want %q", a.Key, a.Value.String(), want)
 		}
-		delete(expectedAttrs, a.Key)
+		delete(wantAttrs, a.Key)
 	}
 
-	for key := range expectedAttrs {
+	for key := range wantAttrs {
 		t.Errorf("missing attribute %q", key)
 	}
 }

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -23,7 +23,7 @@ func TestAuth_HappyPath(t *testing.T) {
 
 		parts := strings.Split(ac.Token, ".")
 		if len(parts) != 3 {
-			t.Fatal("Got invalid JWT token")
+			t.Fatalf("got %d JWT segments, want 3", len(parts))
 		}
 
 		whoamiResp := ac.Do(t, http.MethodGet, "/v1/whoami", nil)
@@ -32,18 +32,18 @@ func TestAuth_HappyPath(t *testing.T) {
 		}()
 
 		if whoamiResp.StatusCode != http.StatusOK {
-			t.Fatalf("Expected status 200, got %d", whoamiResp.StatusCode)
+			t.Fatalf("got status %d, want %d", whoamiResp.StatusCode, http.StatusOK)
 		}
 
 		var whoamiData struct {
 			UID string `json:"uid"`
 		}
 		if err := json.NewDecoder(whoamiResp.Body).Decode(&whoamiData); err != nil {
-			t.Fatalf("Failed to decode whoami response: %v", err)
+			t.Fatalf("Whoami response Decode() error = %v", err)
 		}
 
 		if _, err := uuid.Parse(whoamiData.UID); err != nil {
-			t.Errorf("Expected valid UUID user ID, got %q: %v", whoamiData.UID, err)
+			t.Errorf("uuid.Parse(%q) error = %v, want nil", whoamiData.UID, err)
 		}
 	})
 }

--- a/tests/board_test.go
+++ b/tests/board_test.go
@@ -48,28 +48,28 @@ func TestBoard_HappyPath(t *testing.T) {
 		}()
 
 		if createResp.StatusCode != http.StatusCreated {
-			t.Fatalf("Expected status %d, got %d", http.StatusCreated, createResp.StatusCode)
+			t.Fatalf("got status %d, want %d", createResp.StatusCode, http.StatusCreated)
 		}
 
 		createdBoard := parseBoard(t, createResp)
 
 		if _, err := uuid.Parse(createdBoard.ID); err != nil {
-			t.Errorf("Invalid board ID: %v", err)
+			t.Errorf("uuid.Parse(%q) error = %v, want nil", createdBoard.ID, err)
 		}
 		if _, err := uuid.Parse(createdBoard.OwnerID); err != nil {
-			t.Errorf("Invalid owner ID: %v", err)
+			t.Errorf("uuid.Parse(%q) error = %v, want nil", createdBoard.OwnerID, err)
 		}
 		if createdBoard.Name != name {
-			t.Errorf("Expected name %q, got %q", name, createdBoard.Name)
+			t.Errorf("got name %q, want %q", createdBoard.Name, name)
 		}
 		if createdBoard.Description != description {
-			t.Errorf("Expected description %q, got %q", description, createdBoard.Description)
+			t.Errorf("got description %q, want %q", createdBoard.Description, description)
 		}
 		if _, err := time.Parse(timeFormat, createdBoard.CreatedAt); err != nil {
-			t.Errorf("Invalid createdAt: %v", err)
+			t.Errorf("time.Parse(%q) error = %v, want nil", createdBoard.CreatedAt, err)
 		}
 		if _, err := time.Parse(timeFormat, createdBoard.UpdatedAt); err != nil {
-			t.Errorf("Invalid updatedAt: %v", err)
+			t.Errorf("time.Parse(%q) error = %v, want nil", createdBoard.UpdatedAt, err)
 		}
 
 		// 3. Get by id, store response in getByIDBoard, and perform deep comparison with createdBoard
@@ -78,7 +78,7 @@ func TestBoard_HappyPath(t *testing.T) {
 			_ = oneResp.Body.Close()
 		}()
 		if oneResp.StatusCode != http.StatusOK {
-			t.Fatalf("Expected Get by id status %d, got %d", http.StatusOK, oneResp.StatusCode)
+			t.Fatalf("got Get by id status %d, want %d", oneResp.StatusCode, http.StatusOK)
 		}
 
 		getByIDBoard := parseBoard(t, oneResp)
@@ -93,12 +93,12 @@ func TestBoard_HappyPath(t *testing.T) {
 		}()
 
 		if listResp.StatusCode != http.StatusOK {
-			t.Fatalf("Expected list status %d, got %d", http.StatusOK, listResp.StatusCode)
+			t.Fatalf("got list status %d, want %d", listResp.StatusCode, http.StatusOK)
 		}
 
 		listedBoards := parseBoardsList(t, listResp)
 		if len(listedBoards) != 1 {
-			t.Fatalf("Expected 1 board in list, got %d", len(listedBoards))
+			t.Fatalf("got %d boards in list, want 1", len(listedBoards))
 		}
 		if diff := cmp.Diff(createdBoard, listedBoards[0]); diff != "" {
 			t.Errorf("List item mismatch (-want +got):\n%s", diff)
@@ -113,7 +113,7 @@ func TestBoard_HappyPath(t *testing.T) {
 			_ = updateNameResp.Body.Close()
 		}()
 		if updateNameResp.StatusCode != http.StatusOK {
-			t.Fatalf("Expected Update by id status %d, got %d", http.StatusOK, updateNameResp.StatusCode)
+			t.Fatalf("got Update by id status %d, want %d", updateNameResp.StatusCode, http.StatusOK)
 		}
 
 		updatedNameBoard := parseBoard(t, updateNameResp)
@@ -123,12 +123,12 @@ func TestBoard_HappyPath(t *testing.T) {
 		checkBoard.Name = createdBoard.Name
 		checkBoard.UpdatedAt = createdBoard.UpdatedAt
 		if diff := cmp.Diff(createdBoard, checkBoard); diff != "" {
-			t.Errorf("Update by id changed unexpected fields (-want +got):\n%s", diff)
+			t.Errorf("UpdateByID() diff (-want +got):\n%s", diff)
 		}
 
 		// Verify specific changes
 		if updatedNameBoard.Name != updatedName {
-			t.Errorf("Expected updated name %q, got %q", updatedName, updatedNameBoard.Name)
+			t.Errorf("got updated name %q, want %q", updatedNameBoard.Name, updatedName)
 		}
 
 		updatedAtTime, _ := time.Parse(timeFormat, updatedNameBoard.UpdatedAt)
@@ -144,7 +144,7 @@ func TestBoard_HappyPath(t *testing.T) {
 		}()
 
 		if afterUpdateResp.StatusCode != http.StatusOK {
-			t.Fatalf("Expected Get by id status %d after update, got %d", http.StatusOK, afterUpdateResp.StatusCode)
+			t.Fatalf("got Get by id status %d after update, want %d", afterUpdateResp.StatusCode, http.StatusOK)
 		}
 
 		getByIDBoardAfterUpdate := parseBoard(t, afterUpdateResp)
@@ -158,7 +158,7 @@ func TestBoard_HappyPath(t *testing.T) {
 			_ = delResp.Body.Close()
 		}()
 		if delResp.StatusCode != http.StatusNoContent {
-			t.Fatalf("Expected Delete by id status %d, got %d", http.StatusNoContent, delResp.StatusCode)
+			t.Fatalf("got Delete by id status %d, want %d", delResp.StatusCode, http.StatusNoContent)
 		}
 
 		// 8. List boards and ensure an empty list is returned
@@ -167,12 +167,12 @@ func TestBoard_HappyPath(t *testing.T) {
 			_ = listAfterDelResp.Body.Close()
 		}()
 		if listAfterDelResp.StatusCode != http.StatusOK {
-			t.Fatalf("Expected list status %d after delete, got %d", http.StatusOK, listAfterDelResp.StatusCode)
+			t.Fatalf("got list status %d after delete, want %d", listAfterDelResp.StatusCode, http.StatusOK)
 		}
 
 		listedAfterDelete := parseBoardsList(t, listAfterDelResp)
 		if len(listedAfterDelete) != 0 {
-			t.Fatalf("Expected 0 boards after delete, got %d", len(listedAfterDelete))
+			t.Fatalf("got %d boards after delete, want 0", len(listedAfterDelete))
 		}
 	})
 }
@@ -181,7 +181,7 @@ func parseBoard(t *testing.T, resp *http.Response) boardJSON {
 	t.Helper()
 	var b boardJSON
 	if err := json.NewDecoder(resp.Body).Decode(&b); err != nil {
-		t.Fatalf("Failed to decode board: %v", err)
+		t.Fatalf("Board Decode() error = %v", err)
 	}
 	return b
 }
@@ -190,7 +190,7 @@ func parseBoardsList(t *testing.T, resp *http.Response) []boardJSON {
 	t.Helper()
 	var b []boardJSON
 	if err := json.NewDecoder(resp.Body).Decode(&b); err != nil {
-		t.Fatalf("Failed to decode boards list: %v", err)
+		t.Fatalf("Boards list Decode() error = %v", err)
 	}
 	return b
 }

--- a/tests/column_test.go
+++ b/tests/column_test.go
@@ -49,7 +49,7 @@ func TestColumn_HappyPath(t *testing.T) {
 			_ = createBoardResp.Body.Close()
 		}()
 		if createBoardResp.StatusCode != http.StatusCreated {
-			t.Fatalf("Expected create board status %d, got %d", http.StatusCreated, createBoardResp.StatusCode)
+			t.Fatalf("got create board status %d, want %d", createBoardResp.StatusCode, http.StatusCreated)
 		}
 
 		board := parseBoard(t, createBoardResp)
@@ -64,31 +64,31 @@ func TestColumn_HappyPath(t *testing.T) {
 			_ = createResp.Body.Close()
 		}()
 		if createResp.StatusCode != http.StatusCreated {
-			t.Fatalf("Expected status %d, got %d", http.StatusCreated, createResp.StatusCode)
+			t.Fatalf("got status %d, want %d", createResp.StatusCode, http.StatusCreated)
 		}
 
 		createdColumn := parseColumn(t, createResp)
 
 		if _, err := uuid.Parse(createdColumn.ID); err != nil {
-			t.Errorf("Invalid column ID: %v", err)
+			t.Errorf("uuid.Parse(%q) error = %v, want nil", createdColumn.ID, err)
 		}
 		if _, err := uuid.Parse(createdColumn.BoardID); err != nil {
-			t.Errorf("Invalid board ID: %v", err)
+			t.Errorf("uuid.Parse(%q) error = %v, want nil", createdColumn.BoardID, err)
 		}
 		if createdColumn.BoardID != board.ID {
-			t.Errorf("Expected board ID %q, got %q", board.ID, createdColumn.BoardID)
+			t.Errorf("got board ID %q, want %q", createdColumn.BoardID, board.ID)
 		}
 		if createdColumn.Name != name {
-			t.Errorf("Expected name %q, got %q", name, createdColumn.Name)
+			t.Errorf("got name %q, want %q", createdColumn.Name, name)
 		}
 		if createdColumn.Position != 1 {
-			t.Errorf("Expected position %d, got %d", 1, createdColumn.Position)
+			t.Errorf("got position %d, want %d", createdColumn.Position, 1)
 		}
 		if _, err := time.Parse(timeFormat, createdColumn.CreatedAt); err != nil {
-			t.Errorf("Invalid createdAt: %v", err)
+			t.Errorf("time.Parse(%q) error = %v, want nil", createdColumn.CreatedAt, err)
 		}
 		if _, err := time.Parse(timeFormat, createdColumn.UpdatedAt); err != nil {
-			t.Errorf("Invalid updatedAt: %v", err)
+			t.Errorf("time.Parse(%q) error = %v, want nil", createdColumn.UpdatedAt, err)
 		}
 
 		// 3. List columns, get the first column, and perform deep comparison with createdColumn
@@ -97,12 +97,12 @@ func TestColumn_HappyPath(t *testing.T) {
 			_ = listResp.Body.Close()
 		}()
 		if listResp.StatusCode != http.StatusOK {
-			t.Fatalf("Expected list status %d, got %d", http.StatusOK, listResp.StatusCode)
+			t.Fatalf("got list status %d, want %d", listResp.StatusCode, http.StatusOK)
 		}
 
 		listedColumns := parseColumnsList(t, listResp)
 		if len(listedColumns) != 1 {
-			t.Fatalf("Expected 1 column in list, got %d", len(listedColumns))
+			t.Fatalf("got %d columns in list, want 1", len(listedColumns))
 		}
 		if diff := cmp.Diff(createdColumn, listedColumns[0]); diff != "" {
 			t.Errorf("List item mismatch (-want +got):\n%s", diff)
@@ -117,7 +117,7 @@ func TestColumn_HappyPath(t *testing.T) {
 			_ = updateNameResp.Body.Close()
 		}()
 		if updateNameResp.StatusCode != http.StatusOK {
-			t.Fatalf("Expected Update by id status %d, got %d", http.StatusOK, updateNameResp.StatusCode)
+			t.Fatalf("got Update by id status %d, want %d", updateNameResp.StatusCode, http.StatusOK)
 		}
 
 		updatedNameColumn := parseColumn(t, updateNameResp)
@@ -127,12 +127,12 @@ func TestColumn_HappyPath(t *testing.T) {
 		checkColumn.Name = createdColumn.Name
 		checkColumn.UpdatedAt = createdColumn.UpdatedAt
 		if diff := cmp.Diff(createdColumn, checkColumn); diff != "" {
-			t.Errorf("Update by id changed unexpected fields (-want +got):\n%s", diff)
+			t.Errorf("UpdateByID() diff (-want +got):\n%s", diff)
 		}
 
 		// Verify specific changes
 		if updatedNameColumn.Name != updatedName {
-			t.Errorf("Expected updated name %q, got %q", updatedName, updatedNameColumn.Name)
+			t.Errorf("got updated name %q, want %q", updatedNameColumn.Name, updatedName)
 		}
 
 		updatedAtTime, _ := time.Parse(timeFormat, updatedNameColumn.UpdatedAt)
@@ -147,12 +147,12 @@ func TestColumn_HappyPath(t *testing.T) {
 			_ = listAfterUpdateResp.Body.Close()
 		}()
 		if listAfterUpdateResp.StatusCode != http.StatusOK {
-			t.Fatalf("Expected list status %d after update, got %d", http.StatusOK, listAfterUpdateResp.StatusCode)
+			t.Fatalf("got list status %d after update, want %d", listAfterUpdateResp.StatusCode, http.StatusOK)
 		}
 
 		listedAfterUpdate := parseColumnsList(t, listAfterUpdateResp)
 		if len(listedAfterUpdate) != 1 {
-			t.Fatalf("Expected 1 column after update, got %d", len(listedAfterUpdate))
+			t.Fatalf("got %d columns after update, want 1", len(listedAfterUpdate))
 		}
 		if diff := cmp.Diff(updatedNameColumn, listedAfterUpdate[0]); diff != "" {
 			t.Errorf("List item after update mismatch (-want +got):\n%s", diff)
@@ -166,12 +166,12 @@ func TestColumn_HappyPath(t *testing.T) {
 			_ = createSecondResp.Body.Close()
 		}()
 		if createSecondResp.StatusCode != http.StatusCreated {
-			t.Fatalf("Expected second create status %d, got %d", http.StatusCreated, createSecondResp.StatusCode)
+			t.Fatalf("got second create status %d, want %d", createSecondResp.StatusCode, http.StatusCreated)
 		}
 
 		secondColumn := parseColumn(t, createSecondResp)
 		if secondColumn.Position != 2 {
-			t.Errorf("Expected second column position %d, got %d", 2, secondColumn.Position)
+			t.Errorf("got second column position %d, want %d", secondColumn.Position, 2)
 		}
 
 		// 7. Create the third column so delete can verify position compaction for trailing items
@@ -182,12 +182,12 @@ func TestColumn_HappyPath(t *testing.T) {
 			_ = createThirdResp.Body.Close()
 		}()
 		if createThirdResp.StatusCode != http.StatusCreated {
-			t.Fatalf("Expected third create status %d, got %d", http.StatusCreated, createThirdResp.StatusCode)
+			t.Fatalf("got third create status %d, want %d", createThirdResp.StatusCode, http.StatusCreated)
 		}
 
 		thirdColumn := parseColumn(t, createThirdResp)
 		if thirdColumn.Position != 3 {
-			t.Errorf("Expected third column position %d, got %d", 3, thirdColumn.Position)
+			t.Errorf("got third column position %d, want %d", thirdColumn.Position, 3)
 		}
 
 		// 8. Delete the middle column and expect the request to succeed
@@ -196,7 +196,7 @@ func TestColumn_HappyPath(t *testing.T) {
 			_ = deleteResp.Body.Close()
 		}()
 		if deleteResp.StatusCode != http.StatusNoContent {
-			t.Fatalf("Expected delete status %d, got %d", http.StatusNoContent, deleteResp.StatusCode)
+			t.Fatalf("got delete status %d, want %d", deleteResp.StatusCode, http.StatusNoContent)
 		}
 
 		// 9. List columns again and verify delete preserved the first column and compacted positions
@@ -205,18 +205,18 @@ func TestColumn_HappyPath(t *testing.T) {
 			_ = listAfterDeleteResp.Body.Close()
 		}()
 		if listAfterDeleteResp.StatusCode != http.StatusOK {
-			t.Fatalf("Expected list status %d after delete, got %d", http.StatusOK, listAfterDeleteResp.StatusCode)
+			t.Fatalf("got list status %d after delete, want %d", listAfterDeleteResp.StatusCode, http.StatusOK)
 		}
 
 		listedAfterDelete := parseColumnsList(t, listAfterDeleteResp)
 		if len(listedAfterDelete) != 2 {
-			t.Fatalf("Expected 2 columns after delete, got %d", len(listedAfterDelete))
+			t.Fatalf("got %d columns after delete, want 2", len(listedAfterDelete))
 		}
 		if listedAfterDelete[0].ID != updatedNameColumn.ID || listedAfterDelete[0].Name != updatedNameColumn.Name || listedAfterDelete[0].Position != 1 {
-			t.Errorf("Expected updated first column to stay at position 1, got id=%s name=%q position=%d", listedAfterDelete[0].ID, listedAfterDelete[0].Name, listedAfterDelete[0].Position)
+			t.Errorf("got id=%s name=%q position=%d, want id=%s name=%q position=%d", listedAfterDelete[0].ID, listedAfterDelete[0].Name, listedAfterDelete[0].Position, updatedNameColumn.ID, updatedNameColumn.Name, 1)
 		}
 		if listedAfterDelete[1].ID != thirdColumn.ID || listedAfterDelete[1].Position != 2 {
-			t.Errorf("Expected third column to shift to position 2, got id=%s position=%d", listedAfterDelete[1].ID, listedAfterDelete[1].Position)
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterDelete[1].ID, listedAfterDelete[1].Position, thirdColumn.ID, 2)
 		}
 
 		// 10. Move the remaining second column to the first position and expect the new position in response
@@ -227,12 +227,12 @@ func TestColumn_HappyPath(t *testing.T) {
 			_ = moveResp.Body.Close()
 		}()
 		if moveResp.StatusCode != http.StatusOK {
-			t.Fatalf("Expected move status %d, got %d", http.StatusOK, moveResp.StatusCode)
+			t.Fatalf("got move status %d, want %d", moveResp.StatusCode, http.StatusOK)
 		}
 
 		movedPosition := parseColumnPosition(t, moveResp)
 		if movedPosition.Position != 1 {
-			t.Errorf("Expected move response position %d, got %d", 1, movedPosition.Position)
+			t.Errorf("got move response position %d, want %d", movedPosition.Position, 1)
 		}
 
 		// 11. List columns again and verify move reordered the remaining columns
@@ -241,18 +241,18 @@ func TestColumn_HappyPath(t *testing.T) {
 			_ = listAfterMoveResp.Body.Close()
 		}()
 		if listAfterMoveResp.StatusCode != http.StatusOK {
-			t.Fatalf("Expected list status %d after move, got %d", http.StatusOK, listAfterMoveResp.StatusCode)
+			t.Fatalf("got list status %d after move, want %d", listAfterMoveResp.StatusCode, http.StatusOK)
 		}
 
 		listedAfterMove := parseColumnsList(t, listAfterMoveResp)
 		if len(listedAfterMove) != 2 {
-			t.Fatalf("Expected 2 columns after move, got %d", len(listedAfterMove))
+			t.Fatalf("got %d columns after move, want 2", len(listedAfterMove))
 		}
 		if listedAfterMove[0].ID != thirdColumn.ID || listedAfterMove[0].Position != 1 {
-			t.Errorf("Expected third column to move to position 1, got id=%s position=%d", listedAfterMove[0].ID, listedAfterMove[0].Position)
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterMove[0].ID, listedAfterMove[0].Position, thirdColumn.ID, 1)
 		}
 		if listedAfterMove[1].ID != updatedNameColumn.ID || listedAfterMove[1].Position != 2 {
-			t.Errorf("Expected updated first column to shift to position 2, got id=%s position=%d", listedAfterMove[1].ID, listedAfterMove[1].Position)
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterMove[1].ID, listedAfterMove[1].Position, updatedNameColumn.ID, 2)
 		}
 	})
 }
@@ -261,7 +261,7 @@ func parseColumn(t *testing.T, resp *http.Response) columnJSON {
 	t.Helper()
 	var c columnJSON
 	if err := json.NewDecoder(resp.Body).Decode(&c); err != nil {
-		t.Fatalf("decode column: %v", err)
+		t.Fatalf("Column Decode() error = %v", err)
 	}
 	return c
 }
@@ -270,7 +270,7 @@ func parseColumnsList(t *testing.T, resp *http.Response) []columnJSON {
 	t.Helper()
 	var c []columnJSON
 	if err := json.NewDecoder(resp.Body).Decode(&c); err != nil {
-		t.Fatalf("decode columns list: %v", err)
+		t.Fatalf("Columns list Decode() error = %v", err)
 	}
 	return c
 }
@@ -279,7 +279,7 @@ func parseColumnPosition(t *testing.T, resp *http.Response) columnPositionJSON {
 	t.Helper()
 	var p columnPositionJSON
 	if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
-		t.Fatalf("decode column position: %v", err)
+		t.Fatalf("Column position Decode() error = %v", err)
 	}
 	return p
 }

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -31,10 +31,10 @@ func Prelude(t *testing.T) (*http.Client, *httptest.Server, *pgxpool.Pool) {
 	if os.Getenv("ENV") != "prod" {
 		err := godotenv.Load("../.env.dev")
 		if err != nil {
-			t.Fatalf("Failed to load .env.dev: %v", err)
+			t.Fatalf("godotenv.Load() error = %v", err)
 		}
 	} else {
-		t.Fatalf("BUG: tests run with ENV=prod, but should run with ENV=dev")
+		t.Fatalf("ENV = %q, want non-prod", os.Getenv("ENV"))
 	}
 
 	logger := testutil.NewTestLogger(t)
@@ -62,19 +62,19 @@ func Register(t *testing.T, c *http.Client, baseURL, email, password string) {
 		"password": password,
 	})
 	if err != nil {
-		t.Fatalf("register: marshal body: %v", err)
+		t.Fatalf("Register() json.Marshal() error = %v", err)
 	}
 
 	resp, err := c.Post(baseURL+"/v1/register", "application/json", bytes.NewReader(body))
 	if err != nil {
-		t.Fatalf("register: request: %v", err)
+		t.Fatalf("Register() Post() error = %v", err)
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("register: status %d, want %d", resp.StatusCode, http.StatusOK)
+		t.Fatalf("Register() status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 }
 
@@ -86,29 +86,29 @@ func Login(t *testing.T, c *http.Client, baseURL, email, password string) string
 		"password": password,
 	})
 	if err != nil {
-		t.Fatalf("login: marshal body: %v", err)
+		t.Fatalf("Login() json.Marshal() error = %v", err)
 	}
 
 	resp, err := c.Post(baseURL+"/v1/login", "application/json", bytes.NewReader(body))
 	if err != nil {
-		t.Fatalf("login: request: %v", err)
+		t.Fatalf("Login() Post() error = %v", err)
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("login: status %d, want %d", resp.StatusCode, http.StatusOK)
+		t.Fatalf("Login() status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 
 	var out struct {
 		Token string `json:"token"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		t.Fatalf("login: decode response: %v", err)
+		t.Fatalf("Login response Decode() error = %v", err)
 	}
 	if out.Token == "" {
-		t.Fatal("login: empty token in response")
+		t.Fatalf("got token %q, want non-empty", out.Token)
 	}
 
 	return out.Token
@@ -152,7 +152,7 @@ func (c *AuthenticatedClient) Do(t *testing.T, method, path string, body any) *h
 		default:
 			data, err := json.Marshal(b)
 			if err != nil {
-				t.Fatalf("authenticated request: marshal body: %v", err)
+				t.Fatalf("AuthenticatedClient.Do() json.Marshal() error = %v", err)
 			}
 			rdr = bytes.NewReader(data)
 		}
@@ -160,7 +160,7 @@ func (c *AuthenticatedClient) Do(t *testing.T, method, path string, body any) *h
 
 	req, err := http.NewRequest(method, c.BaseURL+path, rdr)
 	if err != nil {
-		t.Fatalf("authenticated request: new request: %v", err)
+		t.Fatalf("AuthenticatedClient.Do() NewRequest() error = %v", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.Token)
 	if body != nil {
@@ -169,7 +169,7 @@ func (c *AuthenticatedClient) Do(t *testing.T, method, path string, body any) *h
 
 	resp, err := c.Client.Do(req)
 	if err != nil {
-		t.Fatalf("authenticated request: %s %s: %v", method, path, err)
+		t.Fatalf("AuthenticatedClient.Do(%s %s) error = %v", method, path, err)
 	}
 
 	return resp


### PR DESCRIPTION
### Related Issues
Refers to #150 

### Summary
- Use only two assertion/failure styles in tests:
  - **Short form** when the context is already obvious from the subtest name or the assertion itself: `got ..., want ...`.
  - **Long form** when the failing operation must be named explicitly, especially for unexpected errors, helper functions, or tests with multiple meaningful calls: `SomeCall() error = %v` or `SomeCall() = ..., want ...`.
- Update developer guidelines

### Verification
- [x] Tests are green
- [x] Almost logic modified

### Checklist
- [x] Code follows the style guidelines
- [x] Unit tests added/updated
- [x] Documentation updated
- [x] No sensitive data committed