### PR TITLE
refactor: uppercase test names, dedup, decouple test suite

### DIFF
--- a/internal/http/handler/boards.go
+++ b/internal/http/handler/boards.go
@@ -93,7 +93,7 @@ func (h *Boards) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, ok := ExtractUserIDOrHandleMissing(w, r, h)
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
 	if !ok {
 		return
 	}
@@ -129,7 +129,7 @@ func (h *Boards) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, ok := ExtractUserIDOrHandleMissing(w, r, h)
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
 	if !ok {
 		return
 	}
@@ -160,7 +160,7 @@ func (h *Boards) Get(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards [get]
 func (h *Boards) GetMany(w http.ResponseWriter, r *http.Request) {
-	userID, ok := ExtractUserIDOrHandleMissing(w, r, h)
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
 	if !ok {
 		return
 	}
@@ -227,7 +227,7 @@ func (h *Boards) UpdateByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, ok := ExtractUserIDOrHandleMissing(w, r, h)
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
 	if !ok {
 		return
 	}
@@ -267,7 +267,7 @@ func (h *Boards) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, ok := ExtractUserIDOrHandleMissing(w, r, h)
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
 	if !ok {
 		return
 	}
@@ -284,24 +284,4 @@ func (h *Boards) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-func ExtractUserIDOrHandleMissing(w http.ResponseWriter, r *http.Request, h *Boards) (domain.UserID, bool) {
-	valid := true
-
-	userID, ok := r.Context().Value(httpschema.ContextKeyUserID).(domain.UserID)
-	if !ok {
-		valid = false
-	}
-	if userID.IsEmpty() {
-		valid = false
-	}
-
-	if !valid {
-		h.logger.ErrorContext(r.Context(), "BUG: valid UserID not found in context. Middleware should have handled this.")
-		h.responder.InvalidToken(w, []httpschema.Detail{{Field: "Authorization", Issues: []string{"Invalid token"}}})
-		return domain.UserID{}, false
-	}
-
-	return userID, valid
 }

--- a/internal/http/handler/columns.go
+++ b/internal/http/handler/columns.go
@@ -102,7 +102,7 @@ func (h *Columns) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, ok := h.extractUserIDOrHandleMissing(w, r)
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
 	if !ok {
 		return
 	}
@@ -141,7 +141,7 @@ func (h *Columns) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, ok := h.extractUserIDOrHandleMissing(w, r)
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
 	if !ok {
 		return
 	}
@@ -212,7 +212,7 @@ func (h *Columns) UpdateByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, ok := h.extractUserIDOrHandleMissing(w, r)
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
 	if !ok {
 		return
 	}
@@ -274,7 +274,7 @@ func (h *Columns) Move(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, ok := h.extractUserIDOrHandleMissing(w, r)
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
 	if !ok {
 		return
 	}
@@ -326,7 +326,7 @@ func (h *Columns) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, ok := h.extractUserIDOrHandleMissing(w, r)
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
 	if !ok {
 		return
 	}
@@ -342,24 +342,4 @@ func (h *Columns) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-func (h *Columns) extractUserIDOrHandleMissing(w http.ResponseWriter, r *http.Request) (domain.UserID, bool) {
-	valid := true
-
-	userID, ok := r.Context().Value(httpschema.ContextKeyUserID).(domain.UserID)
-	if !ok {
-		valid = false
-	}
-	if userID.IsEmpty() {
-		valid = false
-	}
-
-	if !valid {
-		h.logger.ErrorContext(r.Context(), "BUG: valid UserID not found in context. Middleware should have handled this.")
-		h.responder.InvalidToken(w, []httpschema.Detail{{Field: "Authorization", Issues: []string{"Invalid token"}}})
-		return domain.UserID{}, false
-	}
-
-	return userID, true
 }

--- a/internal/http/handler/handlers.go
+++ b/internal/http/handler/handlers.go
@@ -1,5 +1,13 @@
 package handler
 
+import (
+	"log/slog"
+	"net/http"
+
+	"goroutine/internal/domain"
+	"goroutine/internal/http/httpschema"
+)
+
 type Handlers struct {
 	Auth    *Auth
 	Health  *Health
@@ -14,4 +22,29 @@ func NewHandlers(auth *Auth, health *Health, boards *Boards, columns *Columns) *
 		Boards:  boards,
 		Columns: columns,
 	}
+}
+
+func extractUserIDOrHandleMissing(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	responder *httpschema.ErrorResponder,
+) (domain.UserID, bool) {
+	valid := true
+
+	userID, ok := r.Context().Value(httpschema.ContextKeyUserID).(domain.UserID)
+	if !ok {
+		valid = false
+	}
+	if userID.IsEmpty() {
+		valid = false
+	}
+
+	if !valid {
+		logger.ErrorContext(r.Context(), "BUG: valid UserID not found in context. Middleware should have handled this.")
+		responder.InvalidToken(w, []httpschema.Detail{{Field: "Authorization", Issues: []string{"Invalid token"}}})
+		return domain.UserID{}, false
+	}
+
+	return userID, true
 }

--- a/internal/http/httpschema/code_map_test.go
+++ b/internal/http/httpschema/code_map_test.go
@@ -15,23 +15,23 @@ func TestMapCodeToDescription(t *testing.T) {
 		description string
 	}{
 		{
-			name:        "known code",
+			name:        "Known code",
 			code:        "INVALID_CREDENTIALS",
 			description: "Invalid login or password",
 		},
 		{
-			name:        "known move error code",
+			name:        "Known move error code",
 			code:        "INDEX_OUT_OF_BOUNDS",
 			description: "Index out of bounds",
 		},
 		{
-			name:        "known conflict error code",
+			name:        "Known conflict error code",
 			code:        "USER_ALREADY_EXISTS",
 			description: "User already exists",
 		},
 		// Other cases omitted since they're identical to the known code
 		{
-			name:        "unknown code fallback",
+			name:        "Unknown code fallback",
 			code:        "SOME_NON_EXISTENT_CODE",
 			description: "Unknown error",
 		},

--- a/internal/http/middleware/metrics_test.go
+++ b/internal/http/middleware/metrics_test.go
@@ -49,21 +49,21 @@ func TestMetrics_Collection(t *testing.T) {
 		handlerStatus int
 	}{
 		{
-			name:          "register 200",
+			name:          "Register 200",
 			requestPath:   "/v1/register",
 			abstractPath:  "/v1/register",
 			method:        http.MethodPost,
 			handlerStatus: http.StatusOK,
 		},
 		{
-			name:          "health 403",
+			name:          "Health 403",
 			requestPath:   "/v1/health",
 			abstractPath:  "/v1/health",
 			method:        http.MethodGet,
 			handlerStatus: http.StatusForbidden,
 		},
 		{
-			name:          "board by id path label uses placeholder",
+			name:          "Board by id path label uses placeholder",
 			requestPath:   "/v1/boards/550e8400-e29b-41d4-a716-446655440000",
 			abstractPath:  "/v1/boards/{id}",
 			method:        http.MethodGet,

--- a/internal/repository/board_test.go
+++ b/internal/repository/board_test.go
@@ -165,20 +165,30 @@ func TestBoardRepository_GetMany(t *testing.T) {
 
 		CreateUser(t, pool, userID, "getmany-order@example.com")
 
-		first, err := r.Create(context.Background(), userID, boardName, boardDescription)
-		if err != nil {
-			t.Fatalf("Create first board: %v", err)
-		}
-
 		otherName, err := domain.NewBoardName(boardName.String() + "-2")
 		if err != nil {
 			t.Fatalf("NewBoardName: %v", err)
 		}
-		time.Sleep(5 * time.Millisecond)
-		second, err := r.Create(context.Background(), userID, otherName, boardDescription)
-		if err != nil {
-			t.Fatalf("Create second board: %v", err)
+
+		first := domain.Board{
+			ID:          domain.NewBoardID(),
+			OwnerID:     userID,
+			Name:        boardName,
+			Description: boardDescription,
+			CreatedAt:   testutil.FixedTimeNow(),
+			UpdatedAt:   testutil.FixedTimeNow(),
 		}
+		second := domain.Board{
+			ID:          domain.NewBoardID(),
+			OwnerID:     userID,
+			Name:        otherName,
+			Description: boardDescription,
+			CreatedAt:   testutil.FixedTime5mFromNow(),
+			UpdatedAt:   testutil.FixedTime5mFromNow(),
+		}
+
+		InsertBoard(t, pool, &first)
+		InsertBoard(t, pool, &second)
 
 		got, err := r.GetMany(context.Background(), userID)
 		if err != nil {
@@ -277,8 +287,6 @@ func TestBoardRepository_Delete(t *testing.T) {
 
 	r := repository.NewPgBoard(pool)
 	userID := testutil.ValidUserID()
-	boardName := testutil.ValidBoardName()
-	boardDescription := testutil.ValidBoardDescription()
 
 	t.Run("Success", func(t *testing.T) {
 		testutil.TruncateTable(t, pool, "boards")
@@ -286,19 +294,17 @@ func TestBoardRepository_Delete(t *testing.T) {
 
 		CreateUser(t, pool, userID, "delete@example.com")
 
-		board, err := r.Create(context.Background(), userID, boardName, boardDescription)
-		if err != nil {
-			t.Fatalf("Create: %v", err)
-		}
+		board := testutil.ValidBoard()
+		InsertBoard(t, pool, &board)
 
-		err = r.Delete(context.Background(), board.ID)
+		err := r.Delete(context.Background(), board.ID)
 		if err != nil {
 			t.Errorf("Delete() error = %v", err)
 		}
 
-		_, err = r.GetByID(context.Background(), board.ID)
-		if !errors.Is(err, repository.ErrRowNotFound) {
-			t.Errorf("GetByID after delete: %v, want ErrRowNotFound", err)
+		_, ok := FindBoardByID(t, pool, board.ID)
+		if ok {
+			t.Errorf("expected board %q to be deleted from DB", board.ID)
 		}
 	})
 

--- a/internal/repository/helpers_test.go
+++ b/internal/repository/helpers_test.go
@@ -15,11 +15,22 @@ import (
 func CreateUser(t *testing.T, pool *pgxpool.Pool, id domain.UserID, email string) {
 	t.Helper()
 
+	domainEmail, err := domain.NewEmail(email)
+	if err != nil {
+		t.Fatalf("create user email: %v", err)
+	}
+
+	InsertUser(t, pool, id, domainEmail, "hash")
+}
+
+func InsertUser(t *testing.T, pool *pgxpool.Pool, id domain.UserID, email domain.Email, hash string) {
+	t.Helper()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	const query = `INSERT INTO users (id, email, password_hash) VALUES ($1, $2, $3)`
-	_, err := pool.Exec(ctx, query, id, email, "hash")
+	_, err := pool.Exec(ctx, query, id, email, hash)
 	if err != nil {
 		t.Fatalf("Failed to create user: %v", err)
 	}
@@ -45,6 +56,36 @@ func InsertBoard(t *testing.T, pool *pgxpool.Pool, board *domain.Board) {
 	if err != nil {
 		t.Fatalf("insert board: %v", err)
 	}
+}
+
+func FindBoardByID(t *testing.T, pool *pgxpool.Pool, boardID domain.BoardID) (domain.Board, bool) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const q = `
+		SELECT id, owner_id, name, description, created_at, updated_at
+		FROM boards
+		WHERE id = $1`
+
+	var board domain.Board
+	err := pool.QueryRow(ctx, q, boardID).Scan(
+		&board.ID,
+		&board.OwnerID,
+		&board.Name,
+		&board.Description,
+		&board.CreatedAt,
+		&board.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.Board{}, false
+		}
+		t.Fatalf("find board by id: %v", err)
+	}
+
+	return board, true
 }
 
 func InsertColumn(t *testing.T, pool *pgxpool.Pool, column *domain.Column) {

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -45,7 +45,7 @@ func TestUserRepository_Insert(t *testing.T) {
 	t.Run("Duplicate email", func(t *testing.T) {
 		testutil.TruncateTable(t, pool, "users")
 
-		_ = r.Insert(ctx, email, hash)
+		InsertUser(t, pool, testutil.ValidUserID(), email, hash)
 		err := r.Insert(ctx, email, hash)
 
 		if !errors.Is(err, repository.ErrUniqueViolation) {
@@ -65,14 +65,12 @@ func TestUserRepository_GetByEmail(t *testing.T) {
 
 	email := testutil.ValidEmail()
 	hash := testutil.ValidPasswordHash()
+	userID := testutil.ValidUserID()
 
 	t.Run("Success", func(t *testing.T) {
 		testutil.TruncateTable(t, pool, "users")
 
-		err := r.Insert(ctx, email, hash)
-		if err != nil {
-			t.Fatalf("Failed to insert user for test: %v", err)
-		}
+		InsertUser(t, pool, userID, email, hash)
 
 		gotID, gotHash, err := r.GetByEmail(ctx, email)
 		if err != nil {
@@ -81,8 +79,8 @@ func TestUserRepository_GetByEmail(t *testing.T) {
 		if gotHash != hash {
 			t.Errorf("Expected hash %q, got %q", hash, gotHash)
 		}
-		if gotID.IsEmpty() {
-			t.Errorf("Expected non-empty id, got %v", gotID)
+		if gotID != userID {
+			t.Errorf("Expected id %q, got %q", userID, gotID)
 		}
 	})
 


### PR DESCRIPTION
### Related Issues
Refers to #150

### Summary
- Decouple test suite from implementation details by testing methods without using methods that are tested somewhere else
- Ensure all test names in tables are capitalized
- Factor out common user id extraction handler handler
- Merge latest changes and resolve conflicts

### Verification
- [x] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [x] Unit tests added/updated
- [x] Documentation updated
- [x] No sensitive data committed
