### PR TITLE
refactor(unit,integration): use cmp.Diff instead of reflect.DeepEqual

### DIFF
--- a/internal/domain/board_test.go
+++ b/internal/domain/board_test.go
@@ -2,9 +2,10 @@ package domain_test
 
 import (
 	"errors"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"goroutine/internal/domain"
 )
@@ -80,8 +81,8 @@ func TestName(t *testing.T) {
 				}
 			}
 
-			if !reflect.DeepEqual(gotIssues, tt.wantIssues) {
-				t.Errorf("got issues %v, want %v", gotIssues, tt.wantIssues)
+			if diff := cmp.Diff(tt.wantIssues, gotIssues); diff != "" {
+				t.Errorf("got issues mismatch (-want +got):\n%s", diff)
 			}
 			if name.String() != tt.wantValue {
 				t.Errorf("got value %q, want %q", name, tt.wantValue)
@@ -158,8 +159,8 @@ func TestDescription(t *testing.T) {
 				}
 			}
 
-			if !reflect.DeepEqual(gotIssues, tt.wantIssues) {
-				t.Errorf("got issues %v, want %v", gotIssues, tt.wantIssues)
+			if diff := cmp.Diff(tt.wantIssues, gotIssues); diff != "" {
+				t.Errorf("got issues mismatch (-want +got):\n%s", diff)
 			}
 			if description.String() != tt.wantValue {
 				t.Errorf("got value %q, want %q", description, tt.wantValue)

--- a/internal/domain/column_test.go
+++ b/internal/domain/column_test.go
@@ -3,9 +3,10 @@ package domain_test
 import (
 	"errors"
 	"math"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"goroutine/internal/domain"
 )
@@ -43,8 +44,8 @@ func TestColumnName(t *testing.T) {
 				}
 			}
 
-			if !reflect.DeepEqual(gotIssues, tt.wantIssues) {
-				t.Errorf("got issues %v, want %v", gotIssues, tt.wantIssues)
+			if diff := cmp.Diff(tt.wantIssues, gotIssues); diff != "" {
+				t.Errorf("got issues mismatch (-want +got):\n%s", diff)
 			}
 			if name.String() != tt.wantValue {
 				t.Errorf("got value %q, want %q", name.String(), tt.wantValue)
@@ -115,8 +116,8 @@ func TestColumnPosition(t *testing.T) {
 				}
 			}
 
-			if !reflect.DeepEqual(gotIssues, tt.wantIssues) {
-				t.Errorf("got issues %v, want %v", gotIssues, tt.wantIssues)
+			if diff := cmp.Diff(tt.wantIssues, gotIssues); diff != "" {
+				t.Errorf("got issues mismatch (-want +got):\n%s", diff)
 			}
 			if tt.wantIssues == nil && position.Int64() != tt.wantValue {
 				t.Errorf("got value %d, want %d", position.Int64(), tt.wantValue)

--- a/internal/repository/board_test.go
+++ b/internal/repository/board_test.go
@@ -5,9 +5,10 @@ package repository_test
 import (
 	"context"
 	"errors"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	"goroutine/internal/domain"
 	"goroutine/internal/repository"
@@ -213,8 +214,8 @@ func TestBoardRepository_GetMany(t *testing.T) {
 			t.Fatalf("got %d boards, want 2", len(got))
 		}
 		want := []domain.Board{first, second}
-		if !reflect.DeepEqual(want, got) {
-			t.Errorf("GetMany() = %#v, want %#v", got, want)
+		if diff := cmp.Diff(want, got, testutil.DomainCmpOpts()); diff != "" {
+			t.Errorf("GetMany() mismatch (-want +got):\n%s", diff)
 		}
 	})
 }
@@ -266,8 +267,8 @@ func TestBoardRepository_UpdateByID(t *testing.T) {
 		if !ok {
 			t.Fatalf("updated board %q not found in DB", validBoard.ID)
 		}
-		if !reflect.DeepEqual(got, stored) {
-			t.Errorf("stored board = %#v, want %#v", stored, got)
+		if diff := cmp.Diff(got, stored, testutil.DomainCmpOpts()); diff != "" {
+			t.Errorf("got stored board mismatch (-want +got):\n%s", diff)
 		}
 	}
 

--- a/internal/repository/board_test.go
+++ b/internal/repository/board_test.go
@@ -214,7 +214,7 @@ func TestBoardRepository_GetMany(t *testing.T) {
 			t.Fatalf("got %d boards, want 2", len(got))
 		}
 		want := []domain.Board{first, second}
-		if diff := cmp.Diff(want, got, testutil.DomainCmpOpts()); diff != "" {
+		if diff := cmp.Diff(want, got, testutil.CmpAllowUnexported()); diff != "" {
 			t.Errorf("GetMany() mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -267,7 +267,7 @@ func TestBoardRepository_UpdateByID(t *testing.T) {
 		if !ok {
 			t.Fatalf("updated board %q not found in DB", validBoard.ID)
 		}
-		if diff := cmp.Diff(got, stored, testutil.DomainCmpOpts()); diff != "" {
+		if diff := cmp.Diff(got, stored, testutil.CmpAllowUnexported()); diff != "" {
 			t.Errorf("got stored board mismatch (-want +got):\n%s", diff)
 		}
 	}

--- a/internal/repository/column_test.go
+++ b/internal/repository/column_test.go
@@ -70,7 +70,7 @@ func TestColumnRepository_Create(t *testing.T) {
 		if !ok {
 			t.Fatalf("created column %q not found in DB", column.ID)
 		}
-		if diff := cmp.Diff(column, stored, testutil.DomainCmpOpts()); diff != "" {
+		if diff := cmp.Diff(column, stored, testutil.CmpAllowUnexported()); diff != "" {
 			t.Errorf("got stored column mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -165,7 +165,7 @@ func TestColumnRepository_ListByBoardID(t *testing.T) {
 		}
 
 		want := []domain.Column{first, second}
-		if diff := cmp.Diff(want, got, testutil.DomainCmpOpts()); diff != "" {
+		if diff := cmp.Diff(want, got, testutil.CmpAllowUnexported()); diff != "" {
 			t.Errorf("ListByBoardID() mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -195,7 +195,7 @@ func TestColumnRepository_GetByID(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetByID() error = %v", err)
 		}
-		if diff := cmp.Diff(created, got, testutil.DomainCmpOpts()); diff != "" {
+		if diff := cmp.Diff(created, got, testutil.CmpAllowUnexported()); diff != "" {
 			t.Errorf("GetByID() mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -243,7 +243,7 @@ func TestColumnRepository_UpdateByID(t *testing.T) {
 		if !ok {
 			t.Fatalf("updated column %q not found in DB", want.ID)
 		}
-		if diff := cmp.Diff(got, stored, testutil.DomainCmpOpts()); diff != "" {
+		if diff := cmp.Diff(got, stored, testutil.CmpAllowUnexported()); diff != "" {
 			t.Errorf("got stored column mismatch (-want +got):\n%s", diff)
 		}
 	}

--- a/internal/repository/column_test.go
+++ b/internal/repository/column_test.go
@@ -5,9 +5,10 @@ package repository_test
 import (
 	"context"
 	"errors"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	"goroutine/internal/domain"
 	"goroutine/internal/repository"
@@ -69,8 +70,8 @@ func TestColumnRepository_Create(t *testing.T) {
 		if !ok {
 			t.Fatalf("created column %q not found in DB", column.ID)
 		}
-		if !reflect.DeepEqual(column, stored) {
-			t.Errorf("stored column = %#v, want %#v", stored, column)
+		if diff := cmp.Diff(column, stored, testutil.DomainCmpOpts()); diff != "" {
+			t.Errorf("got stored column mismatch (-want +got):\n%s", diff)
 		}
 	})
 }
@@ -164,8 +165,8 @@ func TestColumnRepository_ListByBoardID(t *testing.T) {
 		}
 
 		want := []domain.Column{first, second}
-		if !reflect.DeepEqual(want, got) {
-			t.Errorf("ListByBoardID() = %#v, want %#v", got, want)
+		if diff := cmp.Diff(want, got, testutil.DomainCmpOpts()); diff != "" {
+			t.Errorf("ListByBoardID() mismatch (-want +got):\n%s", diff)
 		}
 	})
 }
@@ -194,8 +195,8 @@ func TestColumnRepository_GetByID(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetByID() error = %v", err)
 		}
-		if !reflect.DeepEqual(created, got) {
-			t.Errorf("GetByID() = %#v, want %#v", got, created)
+		if diff := cmp.Diff(created, got, testutil.DomainCmpOpts()); diff != "" {
+			t.Errorf("GetByID() mismatch (-want +got):\n%s", diff)
 		}
 	})
 
@@ -242,8 +243,8 @@ func TestColumnRepository_UpdateByID(t *testing.T) {
 		if !ok {
 			t.Fatalf("updated column %q not found in DB", want.ID)
 		}
-		if !reflect.DeepEqual(got, stored) {
-			t.Errorf("stored column = %#v, want %#v", stored, got)
+		if diff := cmp.Diff(got, stored, testutil.DomainCmpOpts()); diff != "" {
+			t.Errorf("got stored column mismatch (-want +got):\n%s", diff)
 		}
 	}
 

--- a/internal/service/board_test.go
+++ b/internal/service/board_test.go
@@ -3,8 +3,9 @@ package service_test
 import (
 	"context"
 	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"goroutine/internal/domain"
 	"goroutine/internal/repository"
@@ -75,8 +76,10 @@ func TestBoard_Create(t *testing.T) {
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantBoard, got) {
-				t.Errorf("Create() board = %#v, want %#v", got, tt.wantBoard)
+			if tt.wantErr == nil {
+				if diff := cmp.Diff(tt.wantBoard, got, testutil.DomainCmpOpts()); diff != "" {
+					t.Errorf("Create() board mismatch (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}
@@ -139,8 +142,10 @@ func TestBoard_GetMany(t *testing.T) {
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantBoards, got) {
-				t.Errorf("GetMany() = %#v, want %#v", got, tt.wantBoards)
+			if tt.wantErr == nil {
+				if diff := cmp.Diff(tt.wantBoards, got, testutil.DomainCmpOpts()); diff != "" {
+					t.Errorf("GetMany() mismatch (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}
@@ -230,8 +235,10 @@ func TestBoard_Get(t *testing.T) {
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantBoard, got) {
-				t.Errorf("Get() board = %#v, want %#v", got, tt.wantBoard)
+			if tt.wantErr == nil {
+				if diff := cmp.Diff(tt.wantBoard, got, testutil.DomainCmpOpts()); diff != "" {
+					t.Errorf("Get() board mismatch (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}
@@ -415,8 +422,10 @@ func TestBoard_UpdateByID(t *testing.T) {
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantBoard, got) {
-				t.Errorf("UpdateByID() board = %#v, want %#v", got, tt.wantBoard)
+			if tt.wantErr == nil {
+				if diff := cmp.Diff(tt.wantBoard, got, testutil.DomainCmpOpts()); diff != "" {
+					t.Errorf("UpdateByID() board mismatch (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/internal/service/board_test.go
+++ b/internal/service/board_test.go
@@ -77,7 +77,7 @@ func TestBoard_Create(t *testing.T) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
 			if tt.wantErr == nil {
-				if diff := cmp.Diff(tt.wantBoard, got, testutil.DomainCmpOpts()); diff != "" {
+				if diff := cmp.Diff(tt.wantBoard, got, testutil.CmpAllowUnexported()); diff != "" {
 					t.Errorf("Create() board mismatch (-want +got):\n%s", diff)
 				}
 			}
@@ -143,7 +143,7 @@ func TestBoard_GetMany(t *testing.T) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
 			if tt.wantErr == nil {
-				if diff := cmp.Diff(tt.wantBoards, got, testutil.DomainCmpOpts()); diff != "" {
+				if diff := cmp.Diff(tt.wantBoards, got, testutil.CmpAllowUnexported()); diff != "" {
 					t.Errorf("GetMany() mismatch (-want +got):\n%s", diff)
 				}
 			}
@@ -236,7 +236,7 @@ func TestBoard_Get(t *testing.T) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
 			if tt.wantErr == nil {
-				if diff := cmp.Diff(tt.wantBoard, got, testutil.DomainCmpOpts()); diff != "" {
+				if diff := cmp.Diff(tt.wantBoard, got, testutil.CmpAllowUnexported()); diff != "" {
 					t.Errorf("Get() board mismatch (-want +got):\n%s", diff)
 				}
 			}
@@ -423,7 +423,7 @@ func TestBoard_UpdateByID(t *testing.T) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
 			if tt.wantErr == nil {
-				if diff := cmp.Diff(tt.wantBoard, got, testutil.DomainCmpOpts()); diff != "" {
+				if diff := cmp.Diff(tt.wantBoard, got, testutil.CmpAllowUnexported()); diff != "" {
 					t.Errorf("UpdateByID() board mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/internal/service/column_test.go
+++ b/internal/service/column_test.go
@@ -131,7 +131,7 @@ func TestColumn_Create(t *testing.T) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
 			if tt.wantErr == nil {
-				if diff := cmp.Diff(tt.wantColumn, got, testutil.DomainCmpOpts()); diff != "" {
+				if diff := cmp.Diff(tt.wantColumn, got, testutil.CmpAllowUnexported()); diff != "" {
 					t.Errorf("Create() column mismatch (-want +got):\n%s", diff)
 				}
 			}
@@ -238,7 +238,7 @@ func TestColumn_List(t *testing.T) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
 			if tt.wantErr == nil {
-				if diff := cmp.Diff(tt.wantColumns, got, testutil.DomainCmpOpts()); diff != "" {
+				if diff := cmp.Diff(tt.wantColumns, got, testutil.CmpAllowUnexported()); diff != "" {
 					t.Errorf("List() columns mismatch (-want +got):\n%s", diff)
 				}
 			}
@@ -443,7 +443,7 @@ func TestColumn_UpdateByID(t *testing.T) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
 			if tt.wantErr == nil {
-				if diff := cmp.Diff(tt.wantColumn, got, testutil.DomainCmpOpts()); diff != "" {
+				if diff := cmp.Diff(tt.wantColumn, got, testutil.CmpAllowUnexported()); diff != "" {
 					t.Errorf("UpdateByID() column mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/internal/service/column_test.go
+++ b/internal/service/column_test.go
@@ -3,8 +3,9 @@ package service_test
 import (
 	"context"
 	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"goroutine/internal/domain"
 	"goroutine/internal/repository"
@@ -129,8 +130,10 @@ func TestColumn_Create(t *testing.T) {
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantColumn, got) {
-				t.Errorf("Create() column = %#v, want %#v", got, tt.wantColumn)
+			if tt.wantErr == nil {
+				if diff := cmp.Diff(tt.wantColumn, got, testutil.DomainCmpOpts()); diff != "" {
+					t.Errorf("Create() column mismatch (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}
@@ -234,8 +237,10 @@ func TestColumn_List(t *testing.T) {
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantColumns, got) {
-				t.Errorf("List() columns = %#v, want %#v", got, tt.wantColumns)
+			if tt.wantErr == nil {
+				if diff := cmp.Diff(tt.wantColumns, got, testutil.DomainCmpOpts()); diff != "" {
+					t.Errorf("List() columns mismatch (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}
@@ -437,8 +442,10 @@ func TestColumn_UpdateByID(t *testing.T) {
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("got error %v, want %v", err, tt.wantErr)
 			}
-			if tt.wantErr == nil && !reflect.DeepEqual(tt.wantColumn, got) {
-				t.Errorf("UpdateByID() column = %#v, want %#v", got, tt.wantColumn)
+			if tt.wantErr == nil {
+				if diff := cmp.Diff(tt.wantColumn, got, testutil.DomainCmpOpts()); diff != "" {
+					t.Errorf("UpdateByID() column mismatch (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/internal/testutil/cmp.go
+++ b/internal/testutil/cmp.go
@@ -1,0 +1,19 @@
+package testutil
+
+import (
+	"github.com/google/go-cmp/cmp"
+
+	"goroutine/internal/domain"
+)
+
+func DomainCmpOpts() cmp.Option {
+	return cmp.AllowUnexported(
+		domain.BoardID{},
+		domain.BoardName{},
+		domain.BoardDescription{},
+		domain.UserID{},
+		domain.ColumnID{},
+		domain.ColumnName{},
+		domain.ColumnPosition{},
+	)
+}

--- a/internal/testutil/cmp.go
+++ b/internal/testutil/cmp.go
@@ -6,7 +6,7 @@ import (
 	"goroutine/internal/domain"
 )
 
-func DomainCmpOpts() cmp.Option {
+func CmpAllowUnexported() cmp.Option {
 	return cmp.AllowUnexported(
 		domain.BoardID{},
 		domain.BoardName{},

--- a/internal/testutil/http.go
+++ b/internal/testutil/http.go
@@ -6,8 +6,9 @@ import (
 	"mime"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func AssertContentType(t *testing.T, rr *httptest.ResponseRecorder, wantMediaType string) {
@@ -89,7 +90,7 @@ func AssertResponseBody(t *testing.T, rr *httptest.ResponseRecorder, want any) {
 		t.Fatalf("json.Unmarshal(want JSON) error = %v\nWant JSON: %q", err, string(wantJSON))
 	}
 
-	if !reflect.DeepEqual(gotDecoded, wantDecoded) {
-		t.Errorf("got response body %s, want %s", string(gotBody), string(wantJSON))
+	if diff := cmp.Diff(wantDecoded, gotDecoded); diff != "" {
+		t.Errorf("got response body mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
### Related Issues
Refers to #150

### Summary
- reflect.DeepEqual compares well, but direct logging of arguments often produces unclear diff when debugging, so this PR uses cmp.Diff

### Verification
- [x] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [x] Unit tests added/updated
- [ ] Documentation updated
- [x] No sensitive data committed
