### PR TITLE
feat: full tasks api

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -650,6 +650,387 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/boards/{boardId}/columns/{columnId}/tasks": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all tasks belonging to the specified column, ordered by position ASC.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "List all tasks in a column",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Column ID",
+                        "name": "columnId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/handler.taskResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "COLUMN_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new task in a column for the current user. Task is appended to the end of the column.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Create a new task",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Column ID",
+                        "name": "columnId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Task details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.createTaskBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.taskResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "COLUMN_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Permanently delete a task from a column for the current user and shift positions to close the gap.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Delete a task by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Column ID",
+                        "name": "columnId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "taskId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "TASK_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Partially update task metadata for the current user. Provided fields are updated; omitted or null fields are ignored.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Update a task by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Column ID",
+                        "name": "columnId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "taskId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Task fields to update",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.updateTaskBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.taskResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "TASK_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}/position": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Move a task within its column or across columns in the same board and shift neighboring tasks accordingly.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Move a task to a new position, possibly to another column",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Column ID",
+                        "name": "columnId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "taskId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Target column and position",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.moveTaskBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.taskPositionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "TASK_NOT_FOUND or COLUMN_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/health": {
             "get": {
                 "description": "Check if the server is alive",
@@ -902,6 +1283,19 @@ const docTemplate = `{
                 }
             }
         },
+        "handler.createTaskBody": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "Cover the new endpoint with tests"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Write tests"
+                }
+            }
+        },
         "handler.loginBody": {
             "type": "object",
             "properties": {
@@ -933,6 +1327,19 @@ const docTemplate = `{
                 }
             }
         },
+        "handler.moveTaskBody": {
+            "type": "object",
+            "properties": {
+                "targetColumnId": {
+                    "type": "string",
+                    "example": "019cc971-e5be-7df9-ae8a-c6e3f29c86a2"
+                },
+                "targetPosition": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
         "handler.registerBody": {
             "type": "object",
             "properties": {
@@ -943,6 +1350,52 @@ const docTemplate = `{
                 "password": {
                     "type": "string",
                     "example": "secret-password"
+                }
+            }
+        },
+        "handler.taskPositionResponse": {
+            "type": "object",
+            "properties": {
+                "columnId": {
+                    "type": "string",
+                    "example": "019cc971-e5be-7df9-ae8a-c6e3f29c86a2"
+                },
+                "position": {
+                    "type": "integer",
+                    "example": 2
+                }
+            }
+        },
+        "handler.taskResponse": {
+            "type": "object",
+            "properties": {
+                "columnId": {
+                    "type": "string",
+                    "example": "019cc971-e5be-7df9-ae8a-c6e3f29c86a2"
+                },
+                "createdAt": {
+                    "type": "string",
+                    "example": "2026-03-07T20:56:50.000+03:00"
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Cover the new endpoint with tests"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "019cc971-e5be-7df9-ae8a-c6e3f29c86a3"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Write tests"
+                },
+                "position": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "example": "2026-03-07T20:56:50.000+03:00"
                 }
             }
         },
@@ -965,6 +1418,19 @@ const docTemplate = `{
                 "name": {
                     "type": "string",
                     "example": "In Progress"
+                }
+            }
+        },
+        "handler.updateTaskBody": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "Cover edge cases"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Rewrite tests"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -642,6 +642,387 @@
                 }
             }
         },
+        "/v1/boards/{boardId}/columns/{columnId}/tasks": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all tasks belonging to the specified column, ordered by position ASC.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "List all tasks in a column",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Column ID",
+                        "name": "columnId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/handler.taskResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "COLUMN_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new task in a column for the current user. Task is appended to the end of the column.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Create a new task",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Column ID",
+                        "name": "columnId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Task details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.createTaskBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/handler.taskResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "COLUMN_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Permanently delete a task from a column for the current user and shift positions to close the gap.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Delete a task by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Column ID",
+                        "name": "columnId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "taskId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "TASK_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Partially update task metadata for the current user. Provided fields are updated; omitted or null fields are ignored.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Update a task by id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Column ID",
+                        "name": "columnId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "taskId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Task fields to update",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.updateTaskBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.taskResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "TASK_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}/position": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Move a task within its column or across columns in the same board and shift neighboring tasks accordingly.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Move a task to a new position, possibly to another column",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Board ID",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Column ID",
+                        "name": "columnId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "taskId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Target column and position",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.moveTaskBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.taskPositionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "VALIDATION_ERROR",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "404": {
+                        "description": "TASK_NOT_FOUND or COLUMN_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.DetailedError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/httpschema.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/health": {
             "get": {
                 "description": "Check if the server is alive",
@@ -894,6 +1275,19 @@
                 }
             }
         },
+        "handler.createTaskBody": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "Cover the new endpoint with tests"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Write tests"
+                }
+            }
+        },
         "handler.loginBody": {
             "type": "object",
             "properties": {
@@ -925,6 +1319,19 @@
                 }
             }
         },
+        "handler.moveTaskBody": {
+            "type": "object",
+            "properties": {
+                "targetColumnId": {
+                    "type": "string",
+                    "example": "019cc971-e5be-7df9-ae8a-c6e3f29c86a2"
+                },
+                "targetPosition": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
         "handler.registerBody": {
             "type": "object",
             "properties": {
@@ -935,6 +1342,52 @@
                 "password": {
                     "type": "string",
                     "example": "secret-password"
+                }
+            }
+        },
+        "handler.taskPositionResponse": {
+            "type": "object",
+            "properties": {
+                "columnId": {
+                    "type": "string",
+                    "example": "019cc971-e5be-7df9-ae8a-c6e3f29c86a2"
+                },
+                "position": {
+                    "type": "integer",
+                    "example": 2
+                }
+            }
+        },
+        "handler.taskResponse": {
+            "type": "object",
+            "properties": {
+                "columnId": {
+                    "type": "string",
+                    "example": "019cc971-e5be-7df9-ae8a-c6e3f29c86a2"
+                },
+                "createdAt": {
+                    "type": "string",
+                    "example": "2026-03-07T20:56:50.000+03:00"
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Cover the new endpoint with tests"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "019cc971-e5be-7df9-ae8a-c6e3f29c86a3"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Write tests"
+                },
+                "position": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "example": "2026-03-07T20:56:50.000+03:00"
                 }
             }
         },
@@ -957,6 +1410,19 @@
                 "name": {
                     "type": "string",
                     "example": "In Progress"
+                }
+            }
+        },
+        "handler.updateTaskBody": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "Cover edge cases"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Rewrite tests"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -63,6 +63,15 @@ definitions:
         example: To Do
         type: string
     type: object
+  handler.createTaskBody:
+    properties:
+      description:
+        example: Cover the new endpoint with tests
+        type: string
+      name:
+        example: Write tests
+        type: string
+    type: object
   handler.loginBody:
     properties:
       email:
@@ -84,6 +93,15 @@ definitions:
         example: 1
         type: integer
     type: object
+  handler.moveTaskBody:
+    properties:
+      targetColumnId:
+        example: 019cc971-e5be-7df9-ae8a-c6e3f29c86a2
+        type: string
+      targetPosition:
+        example: 1
+        type: integer
+    type: object
   handler.registerBody:
     properties:
       email:
@@ -91,6 +109,39 @@ definitions:
         type: string
       password:
         example: secret-password
+        type: string
+    type: object
+  handler.taskPositionResponse:
+    properties:
+      columnId:
+        example: 019cc971-e5be-7df9-ae8a-c6e3f29c86a2
+        type: string
+      position:
+        example: 2
+        type: integer
+    type: object
+  handler.taskResponse:
+    properties:
+      columnId:
+        example: 019cc971-e5be-7df9-ae8a-c6e3f29c86a2
+        type: string
+      createdAt:
+        example: "2026-03-07T20:56:50.000+03:00"
+        type: string
+      description:
+        example: Cover the new endpoint with tests
+        type: string
+      id:
+        example: 019cc971-e5be-7df9-ae8a-c6e3f29c86a3
+        type: string
+      name:
+        example: Write tests
+        type: string
+      position:
+        example: 1
+        type: integer
+      updatedAt:
+        example: "2026-03-07T20:56:50.000+03:00"
         type: string
     type: object
   handler.updateBoardBody:
@@ -106,6 +157,15 @@ definitions:
     properties:
       name:
         example: In Progress
+        type: string
+    type: object
+  handler.updateTaskBody:
+    properties:
+      description:
+        example: Cover edge cases
+        type: string
+      name:
+        example: Rewrite tests
         type: string
     type: object
   handler.whoAmIResponse:
@@ -582,6 +642,260 @@ paths:
       summary: Move a column to a new position
       tags:
       - columns
+  /v1/boards/{boardId}/columns/{columnId}/tasks:
+    get:
+      description: Get all tasks belonging to the specified column, ordered by position
+        ASC.
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardId
+        required: true
+        type: string
+      - description: Column ID
+        in: path
+        name: columnId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/handler.taskResponse'
+            type: array
+        "400":
+          description: VALIDATION_ERROR
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "401":
+          description: 'Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER'
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "404":
+          description: COLUMN_NOT_FOUND
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/httpschema.Error'
+      security:
+      - BearerAuth: []
+      summary: List all tasks in a column
+      tags:
+      - tasks
+    post:
+      consumes:
+      - application/json
+      description: Create a new task in a column for the current user. Task is appended
+        to the end of the column.
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardId
+        required: true
+        type: string
+      - description: Column ID
+        in: path
+        name: columnId
+        required: true
+        type: string
+      - description: Task details
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handler.createTaskBody'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/handler.taskResponse'
+        "400":
+          description: VALIDATION_ERROR
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "401":
+          description: 'Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER'
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "404":
+          description: COLUMN_NOT_FOUND
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/httpschema.Error'
+      security:
+      - BearerAuth: []
+      summary: Create a new task
+      tags:
+      - tasks
+  /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}:
+    delete:
+      consumes:
+      - application/json
+      description: Permanently delete a task from a column for the current user and
+        shift positions to close the gap.
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardId
+        required: true
+        type: string
+      - description: Column ID
+        in: path
+        name: columnId
+        required: true
+        type: string
+      - description: Task ID
+        in: path
+        name: taskId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: VALIDATION_ERROR
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "401":
+          description: 'Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER'
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "404":
+          description: TASK_NOT_FOUND
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/httpschema.Error'
+      security:
+      - BearerAuth: []
+      summary: Delete a task by id
+      tags:
+      - tasks
+    patch:
+      consumes:
+      - application/json
+      description: Partially update task metadata for the current user. Provided fields
+        are updated; omitted or null fields are ignored.
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardId
+        required: true
+        type: string
+      - description: Column ID
+        in: path
+        name: columnId
+        required: true
+        type: string
+      - description: Task ID
+        in: path
+        name: taskId
+        required: true
+        type: string
+      - description: Task fields to update
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handler.updateTaskBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.taskResponse'
+        "400":
+          description: VALIDATION_ERROR
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "401":
+          description: 'Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER'
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "404":
+          description: TASK_NOT_FOUND
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/httpschema.Error'
+      security:
+      - BearerAuth: []
+      summary: Update a task by id
+      tags:
+      - tasks
+  /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}/position:
+    put:
+      consumes:
+      - application/json
+      description: Move a task within its column or across columns in the same board
+        and shift neighboring tasks accordingly.
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardId
+        required: true
+        type: string
+      - description: Column ID
+        in: path
+        name: columnId
+        required: true
+        type: string
+      - description: Task ID
+        in: path
+        name: taskId
+        required: true
+        type: string
+      - description: Target column and position
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handler.moveTaskBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.taskPositionResponse'
+        "400":
+          description: VALIDATION_ERROR
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "401":
+          description: 'Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER'
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "404":
+          description: TASK_NOT_FOUND or COLUMN_NOT_FOUND
+          schema:
+            $ref: '#/definitions/httpschema.DetailedError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/httpschema.Error'
+      security:
+      - BearerAuth: []
+      summary: Move a task to a new position, possibly to another column
+      tags:
+      - tasks
   /v1/health:
     get:
       description: Check if the server is alive

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -29,6 +29,7 @@ func New(logger *slog.Logger, pool *pgxpool.Pool, cfg *config.AppConfig, reg pro
 	userRepo := repository.NewPgUser(pool)
 	boardsRepo := repository.NewPgBoard(pool)
 	columnsRepo := repository.NewPgColumn(pool)
+	tasksRepo := repository.NewPgTask(pool)
 
 	authService := service.NewAuth(userRepo, service.JWTOptions{
 		JWTSecret:     cfg.JWTSecret,
@@ -37,6 +38,11 @@ func New(logger *slog.Logger, pool *pgxpool.Pool, cfg *config.AppConfig, reg pro
 	})
 	boardsService := service.NewBoard(service.BoardRepository(boardsRepo))
 	columnsService := service.NewColumn(service.ColumnRepository(columnsRepo), service.ColumnBoardRepository(boardsRepo))
+	tasksService := service.NewTask(
+		service.TaskRepository(tasksRepo),
+		service.TaskBoardRepository(boardsRepo),
+		service.TaskColumnRepository(columnsRepo),
+	)
 
 	responder := httpschema.MustNewErrorResponder(logger, service.TimeNowRFC3339Millis)
 
@@ -44,6 +50,7 @@ func New(logger *slog.Logger, pool *pgxpool.Pool, cfg *config.AppConfig, reg pro
 	healthHandler := handler.NewHealth(logger)
 	boardsHandler := handler.NewBoards(logger, boardsService, responder)
 	columnsHandler := handler.NewColumns(logger, columnsService, responder)
+	tasksHandler := handler.NewTasks(logger, tasksService, responder)
 
 	metricsMiddleware := middleware.NewMetrics(reg)
 	corsMiddleware := middleware.NewCORS(logger, cfg.AllowedOrigins)
@@ -52,7 +59,7 @@ func New(logger *slog.Logger, pool *pgxpool.Pool, cfg *config.AppConfig, reg pro
 		return fmt.Sprintf("req-%s", uuid.Must(uuid.NewV7()))
 	})
 
-	handlers := &handler.Handlers{Auth: authHandler, Health: healthHandler, Boards: boardsHandler, Columns: columnsHandler}
+	handlers := &handler.Handlers{Auth: authHandler, Health: healthHandler, Boards: boardsHandler, Columns: columnsHandler, Tasks: tasksHandler}
 	middlewares := &middleware.Middlewares{
 		Metrics:   metricsMiddleware,
 		CORS:      corsMiddleware,

--- a/internal/domain/column.go
+++ b/internal/domain/column.go
@@ -85,6 +85,7 @@ func NewColumnPosition(position int64) (ColumnPosition, error) {
 	return ColumnPosition{value: int32(position)}, nil
 }
 
+// TODO: dead code
 func ParseColumnPosition(position string) (ColumnPosition, error) {
 	v, err := strconv.ParseInt(position, 10, 64)
 	if err != nil {

--- a/internal/domain/task.go
+++ b/internal/domain/task.go
@@ -1,0 +1,198 @@
+package domain
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	ErrTaskNameTooShort       = "Name is too short"
+	ErrTaskNameTooLong        = "Name is too long"
+	ErrTaskDescriptionTooLong = "Description is too long"
+	ErrTaskPositionValue      = "Position is invalid"
+)
+
+type Task struct {
+	ID          TaskID
+	ColumnID    ColumnID
+	Name        TaskName
+	Description TaskDescription
+	Position    TaskPosition
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type TaskName struct {
+	value string
+}
+
+func NewTaskName(name string) (TaskName, error) {
+	trimmedName := strings.TrimSpace(name)
+	var issues []string
+	if trimmedName == "" {
+		issues = append(issues, ErrTaskNameTooShort)
+	}
+	if len(trimmedName) > 128 {
+		issues = append(issues, ErrTaskNameTooLong)
+	}
+	if len(issues) > 0 {
+		return TaskName{}, &ErrValidation{Issues: issues}
+	}
+
+	return TaskName{value: trimmedName}, nil
+}
+
+func (n TaskName) IsEmpty() bool {
+	return n.value == ""
+}
+
+func (n TaskName) String() string {
+	return n.value
+}
+
+func (n TaskName) Value() (driver.Value, error) {
+	return n.value, nil
+}
+
+func (n *TaskName) Scan(value any) error {
+	if value == nil {
+		n.value = ""
+		return nil
+	}
+	s, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("unexpected type for TaskName: %T", value)
+	}
+	tn, err := NewTaskName(s)
+	if err != nil {
+		return fmt.Errorf("task name: %w: %v", ErrDataCorrupted, err)
+	}
+	*n = tn
+	return nil
+}
+
+type TaskDescription struct {
+	value string
+}
+
+func NewTaskDescription(description string) (TaskDescription, error) {
+	trimmedDescription := strings.TrimSpace(description)
+	var issues []string
+	if len(trimmedDescription) > 1024 {
+		issues = append(issues, ErrTaskDescriptionTooLong)
+	}
+
+	if len(issues) > 0 {
+		return TaskDescription{}, &ErrValidation{Issues: issues}
+	}
+
+	return TaskDescription{value: trimmedDescription}, nil
+}
+
+func (d TaskDescription) IsEmpty() bool {
+	return d.value == ""
+}
+
+func (d TaskDescription) String() string {
+	return d.value
+}
+
+func (d TaskDescription) Value() (driver.Value, error) {
+	return d.value, nil
+}
+
+func (d *TaskDescription) Scan(value any) error {
+	if value == nil {
+		d.value = ""
+		return nil
+	}
+	s, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("unexpected type for TaskDescription: %T", value)
+	}
+	td, err := NewTaskDescription(s)
+	if err != nil {
+		return fmt.Errorf("task description: %w: %v", ErrDataCorrupted, err)
+	}
+	*d = td
+	return nil
+}
+
+type TaskPosition struct {
+	value int32
+}
+
+func NewTaskPosition(position int64) (TaskPosition, error) {
+	if position <= 0 || position > math.MaxInt32 {
+		return TaskPosition{}, &ErrValidation{Issues: []string{ErrTaskPositionValue}}
+	}
+
+	return TaskPosition{value: int32(position)}, nil
+}
+
+func ParseTaskPosition(position string) (TaskPosition, error) {
+	v, err := strconv.ParseInt(position, 10, 64)
+	if err != nil {
+		return TaskPosition{}, &ErrValidation{Issues: []string{ErrTaskPositionValue}}
+	}
+
+	return NewTaskPosition(v)
+}
+
+func (p TaskPosition) Int64() int64 {
+	return int64(p.value)
+}
+
+func (p TaskPosition) Value() (driver.Value, error) {
+	return p.value, nil
+}
+
+func (p *TaskPosition) Scan(value any) error {
+	if value == nil {
+		p.value = 0
+		return nil
+	}
+
+	v, ok := value.(int64)
+	if !ok {
+		return fmt.Errorf("unexpected type for TaskPosition: %T", value)
+	}
+
+	position, err := NewTaskPosition(v)
+	if err != nil {
+		return fmt.Errorf("task position: %w: %v", ErrDataCorrupted, err)
+	}
+
+	*p = position
+	return nil
+}
+
+func (t Task) String() string {
+	return fmt.Sprintf(
+		"id:          %s\ncolumnId:    %s\nname:        %q\ndescription: %q\nposition:    %d\ncreatedAt:   %s\nupdatedAt:   %s",
+		t.ID.String(),
+		t.ColumnID.String(),
+		t.Name.String(),
+		t.Description.String(),
+		t.Position.Int64(),
+		t.CreatedAt.UTC().Format(time.RFC3339Nano),
+		t.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	)
+}
+
+type (
+	taskTag struct{}
+	TaskID  = UUID[taskTag]
+)
+
+func NewTaskID() TaskID {
+	return NewID[taskTag]()
+}
+
+func ParseTaskID(s string) (TaskID, error) {
+	return ParseID[taskTag](s)
+}

--- a/internal/domain/task.go
+++ b/internal/domain/task.go
@@ -4,7 +4,6 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"math"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -132,15 +131,6 @@ func NewTaskPosition(position int64) (TaskPosition, error) {
 	}
 
 	return TaskPosition{value: int32(position)}, nil
-}
-
-func ParseTaskPosition(position string) (TaskPosition, error) {
-	v, err := strconv.ParseInt(position, 10, 64)
-	if err != nil {
-		return TaskPosition{}, &ErrValidation{Issues: []string{ErrTaskPositionValue}}
-	}
-
-	return NewTaskPosition(v)
 }
 
 func (p TaskPosition) Int64() int64 {

--- a/internal/domain/task_test.go
+++ b/internal/domain/task_test.go
@@ -1,0 +1,287 @@
+package domain_test
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"goroutine/internal/domain"
+)
+
+func TestTaskName(t *testing.T) {
+	t.Parallel()
+
+	borderlineLongName := strings.Repeat("a", 128)
+	tests := []struct {
+		name       string
+		input      string
+		wantIssues []string
+		wantValue  string
+	}{
+		{name: "Valid", input: "Write tests", wantValue: "Write tests"},
+		{name: "Long valid", input: borderlineLongName, wantValue: borderlineLongName},
+		{name: "Too long but valid when trimmed", input: "   " + borderlineLongName + "   ", wantValue: borderlineLongName},
+		{name: "Too long", input: borderlineLongName + "a", wantIssues: []string{domain.ErrTaskNameTooLong}},
+		{name: "Empty", input: "", wantIssues: []string{domain.ErrTaskNameTooShort}},
+		{name: "Whitespace", input: "   ", wantIssues: []string{domain.ErrTaskNameTooShort}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			name, err := domain.NewTaskName(tt.input)
+			var gotIssues []string
+			if err != nil {
+				var ve *domain.ErrValidation
+				if errors.As(err, &ve) {
+					gotIssues = ve.Issues
+				} else {
+					gotIssues = []string{err.Error()}
+				}
+			}
+
+			if diff := cmp.Diff(tt.wantIssues, gotIssues); diff != "" {
+				t.Errorf("got issues mismatch (-want +got):\n%s", diff)
+			}
+			if name.String() != tt.wantValue {
+				t.Errorf("got value %q, want %q", name.String(), tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestTaskDescription(t *testing.T) {
+	t.Parallel()
+
+	borderlineLongDescription := strings.Repeat("a", 1024)
+
+	tests := []struct {
+		name       string
+		input      string
+		wantIssues []string
+		wantValue  string
+	}{
+		{name: "Valid", input: "Write integration tests for tasks", wantValue: "Write integration tests for tasks"},
+		{name: "Long valid", input: borderlineLongDescription, wantValue: borderlineLongDescription},
+		{name: "Too long but valid when trimmed", input: "   " + borderlineLongDescription + "   ", wantValue: borderlineLongDescription},
+		{name: "Too long", input: borderlineLongDescription + "a", wantIssues: []string{domain.ErrTaskDescriptionTooLong}},
+		{name: "Empty", input: "", wantValue: ""},
+		{name: "Whitespace", input: "    ", wantValue: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			description, err := domain.NewTaskDescription(tt.input)
+			var gotIssues []string
+			if err != nil {
+				var ve *domain.ErrValidation
+				if errors.As(err, &ve) {
+					gotIssues = ve.Issues
+				} else {
+					gotIssues = []string{err.Error()}
+				}
+			}
+
+			if diff := cmp.Diff(tt.wantIssues, gotIssues); diff != "" {
+				t.Errorf("got issues mismatch (-want +got):\n%s", diff)
+			}
+			if description.String() != tt.wantValue {
+				t.Errorf("got value %q, want %q", description.String(), tt.wantValue)
+			}
+			if description.IsEmpty() != (tt.wantValue == "") {
+				t.Errorf("got is empty %t, want %t", description.IsEmpty(), tt.wantValue == "")
+			}
+		})
+	}
+}
+
+func TestParseTaskPosition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "Valid", input: "1"},
+		{name: "Zero", input: "0", wantErr: true},
+		{name: "Negative", input: "-1", wantErr: true},
+		{name: "Greater than int32", input: "2147483648", wantErr: true},
+		{name: "Greater than int64", input: "9223372036854775808", wantErr: true},
+		{name: "Not a number", input: "abc", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := domain.ParseTaskPosition(tt.input)
+			if tt.wantErr && err == nil {
+				t.Error("got nil error, want non-nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("got error %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestTaskPosition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		input      int64
+		wantIssues []string
+		wantValue  int64
+	}{
+		{name: "Valid", input: 1, wantValue: 1},
+		{name: "Valid max int32", input: math.MaxInt32, wantValue: math.MaxInt32},
+		{name: "Zero", input: 0, wantIssues: []string{domain.ErrTaskPositionValue}},
+		{name: "Negative", input: -10, wantIssues: []string{domain.ErrTaskPositionValue}},
+		{name: "Overflow", input: math.MaxInt32 + 1, wantIssues: []string{domain.ErrTaskPositionValue}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			position, err := domain.NewTaskPosition(tt.input)
+			var gotIssues []string
+			if err != nil {
+				var ve *domain.ErrValidation
+				if errors.As(err, &ve) {
+					gotIssues = ve.Issues
+				} else {
+					gotIssues = []string{err.Error()}
+				}
+			}
+
+			if diff := cmp.Diff(tt.wantIssues, gotIssues); diff != "" {
+				t.Errorf("got issues mismatch (-want +got):\n%s", diff)
+			}
+			if tt.wantIssues == nil && position.Int64() != tt.wantValue {
+				t.Errorf("got value %d, want %d", position.Int64(), tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestTaskName_Scan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   any
+		wantErr bool
+		errIs   error
+	}{
+		{name: "Valid", input: "Write docs"},
+		{name: "Too long", input: strings.Repeat("a", 129), wantErr: true, errIs: domain.ErrDataCorrupted},
+		{name: "Empty", input: "", wantErr: true, errIs: domain.ErrDataCorrupted},
+		{name: "Nil", input: nil},
+		{name: "Bad type", input: 1, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var name domain.TaskName
+			err := name.Scan(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("got nil error, want non-nil")
+				} else if tt.errIs != nil && !errors.Is(err, tt.errIs) {
+					t.Errorf("got error %v, want %v", err, tt.errIs)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("got error %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestTaskDescription_Scan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   any
+		wantErr bool
+		errIs   error
+	}{
+		{name: "Valid", input: "Description"},
+		{name: "Too long", input: strings.Repeat("a", 1025), wantErr: true, errIs: domain.ErrDataCorrupted},
+		{name: "Nil", input: nil},
+		{name: "Bad type", input: 1, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var description domain.TaskDescription
+			err := description.Scan(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("got nil error, want non-nil")
+				} else if tt.errIs != nil && !errors.Is(err, tt.errIs) {
+					t.Errorf("got error %v, want %v", err, tt.errIs)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("got error %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestTaskPosition_Scan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   any
+		wantErr bool
+		errIs   error
+	}{
+		{name: "Valid int64", input: int64(1)},
+		{name: "Zero", input: int64(0), wantErr: true, errIs: domain.ErrDataCorrupted},
+		{name: "Nil", input: nil},
+		{name: "Int32 is rejected", input: int32(2), wantErr: true},
+		{name: "Bad type", input: "abc", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var position domain.TaskPosition
+			err := position.Scan(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("got nil error, want non-nil")
+				} else if tt.errIs != nil && !errors.Is(err, tt.errIs) {
+					t.Errorf("got error %v, want %v", err, tt.errIs)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("got error %v, want nil", err)
+			}
+		})
+	}
+}

--- a/internal/domain/task_test.go
+++ b/internal/domain/task_test.go
@@ -101,37 +101,6 @@ func TestTaskDescription(t *testing.T) {
 	}
 }
 
-func TestParseTaskPosition(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		input   string
-		wantErr bool
-	}{
-		{name: "Valid", input: "1"},
-		{name: "Zero", input: "0", wantErr: true},
-		{name: "Negative", input: "-1", wantErr: true},
-		{name: "Greater than int32", input: "2147483648", wantErr: true},
-		{name: "Greater than int64", input: "9223372036854775808", wantErr: true},
-		{name: "Not a number", input: "abc", wantErr: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			_, err := domain.ParseTaskPosition(tt.input)
-			if tt.wantErr && err == nil {
-				t.Error("got nil error, want non-nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("got error %v, want nil", err)
-			}
-		})
-	}
-}
-
 func TestTaskPosition(t *testing.T) {
 	t.Parallel()
 

--- a/internal/http/handler/columns_test.go
+++ b/internal/http/handler/columns_test.go
@@ -400,7 +400,7 @@ func TestColumns_UpdateByID(t *testing.T) {
 				}
 			},
 			wantCode: http.StatusNotFound,
-			wantBody: columnNotFoundErrorBody(),
+			wantBody: columnNotFoundByFieldError("columnId"),
 		},
 		{
 			name:      "Internal error",
@@ -563,7 +563,7 @@ func TestColumns_Move(t *testing.T) {
 				}
 			},
 			wantCode: http.StatusNotFound,
-			wantBody: columnNotFoundErrorBody(),
+			wantBody: columnNotFoundByFieldError("columnId"),
 		},
 		{
 			name:      "Internal error",
@@ -684,7 +684,7 @@ func TestColumns_Delete(t *testing.T) {
 				}
 			},
 			wantCode: http.StatusNotFound,
-			wantBody: columnNotFoundErrorBody(),
+			wantBody: columnNotFoundByFieldError("columnId"),
 		},
 		{
 			name: "Internal error",

--- a/internal/http/handler/handlers.go
+++ b/internal/http/handler/handlers.go
@@ -13,14 +13,16 @@ type Handlers struct {
 	Health  *Health
 	Boards  *Boards
 	Columns *Columns
+	Tasks   *Tasks
 }
 
-func NewHandlers(auth *Auth, health *Health, boards *Boards, columns *Columns) *Handlers {
+func NewHandlers(auth *Auth, health *Health, boards *Boards, columns *Columns, tasks *Tasks) *Handlers {
 	return &Handlers{
 		Auth:    auth,
 		Health:  health,
 		Boards:  boards,
 		Columns: columns,
+		Tasks:   tasks,
 	}
 }
 

--- a/internal/http/handler/helpers_test.go
+++ b/internal/http/handler/helpers_test.go
@@ -128,18 +128,7 @@ func (m *MockTaskService) Delete(ctx context.Context, callerID domain.UserID, bo
 	return m.DeleteFunc(ctx, callerID, boardID, columnID, taskID)
 }
 
-func columnNotFoundErrorBody() map[string]any {
-	return map[string]any{
-		"code":      "COLUMN_NOT_FOUND",
-		"message":   "Column not found",
-		"timestamp": testutil.FixedTimeNowStr(),
-		"details": []any{
-			map[string]any{"field": "columnId", "issues": []string{"Column not found"}},
-		},
-	}
-}
-
-func columnNotFoundErrorBodyField(field string) map[string]any {
+func columnNotFoundByFieldError(field string) map[string]any {
 	return map[string]any{
 		"code":      "COLUMN_NOT_FOUND",
 		"message":   "Column not found",

--- a/internal/http/handler/helpers_test.go
+++ b/internal/http/handler/helpers_test.go
@@ -45,6 +45,14 @@ type MockColumnService struct {
 	DeleteFunc     func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error
 }
 
+type MockTaskService struct {
+	CreateFunc     func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error)
+	ListFunc       func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) ([]domain.Task, error)
+	UpdateByIDFunc func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error)
+	MoveFunc       func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, targetColumnID domain.ColumnID, targetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error)
+	DeleteFunc     func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error
+}
+
 func (m *MockBoardService) Get(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
 	AssertFuncNotNil("BoardsService.GetFunc", m.GetFunc)
 	return m.GetFunc(ctx, ownerID, boardID)
@@ -95,6 +103,31 @@ func (m *MockColumnService) Delete(ctx context.Context, callerID domain.UserID, 
 	return m.DeleteFunc(ctx, callerID, boardID, columnID)
 }
 
+func (m *MockTaskService) Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error) {
+	AssertFuncNotNil("TasksService.CreateFunc", m.CreateFunc)
+	return m.CreateFunc(ctx, callerID, boardID, columnID, name, description)
+}
+
+func (m *MockTaskService) List(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) ([]domain.Task, error) {
+	AssertFuncNotNil("TasksService.ListFunc", m.ListFunc)
+	return m.ListFunc(ctx, callerID, boardID, columnID)
+}
+
+func (m *MockTaskService) UpdateByID(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+	AssertFuncNotNil("TasksService.UpdateByIDFunc", m.UpdateByIDFunc)
+	return m.UpdateByIDFunc(ctx, callerID, boardID, columnID, taskID, name, description)
+}
+
+func (m *MockTaskService) Move(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, targetColumnID domain.ColumnID, targetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+	AssertFuncNotNil("TasksService.MoveFunc", m.MoveFunc)
+	return m.MoveFunc(ctx, callerID, boardID, columnID, taskID, targetColumnID, targetPosition)
+}
+
+func (m *MockTaskService) Delete(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error {
+	AssertFuncNotNil("TasksService.DeleteFunc", m.DeleteFunc)
+	return m.DeleteFunc(ctx, callerID, boardID, columnID, taskID)
+}
+
 func columnNotFoundErrorBody() map[string]any {
 	return map[string]any{
 		"code":      "COLUMN_NOT_FOUND",
@@ -102,6 +135,28 @@ func columnNotFoundErrorBody() map[string]any {
 		"timestamp": testutil.FixedTimeNowStr(),
 		"details": []any{
 			map[string]any{"field": "columnId", "issues": []string{"Column not found"}},
+		},
+	}
+}
+
+func columnNotFoundErrorBodyField(field string) map[string]any {
+	return map[string]any{
+		"code":      "COLUMN_NOT_FOUND",
+		"message":   "Column not found",
+		"timestamp": testutil.FixedTimeNowStr(),
+		"details": []any{
+			map[string]any{"field": field, "issues": []string{"Column not found"}},
+		},
+	}
+}
+
+func taskNotFoundErrorBody() map[string]any {
+	return map[string]any{
+		"code":      "TASK_NOT_FOUND",
+		"message":   "Task not found",
+		"timestamp": testutil.FixedTimeNowStr(),
+		"details": []any{
+			map[string]any{"field": "taskId", "issues": []string{"Task not found"}},
 		},
 	}
 }

--- a/internal/http/handler/tasks.go
+++ b/internal/http/handler/tasks.go
@@ -1,0 +1,376 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"goroutine/internal/domain"
+	"goroutine/internal/http/httpschema"
+	"goroutine/internal/service"
+)
+
+type TasksService interface {
+	Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error)
+	List(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) ([]domain.Task, error)
+	UpdateByID(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error)
+	Move(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, targetColumnID domain.ColumnID, targetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error)
+	Delete(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error
+}
+
+type Tasks struct {
+	logger    *slog.Logger
+	service   TasksService
+	responder *httpschema.ErrorResponder
+}
+
+func NewTasks(logger *slog.Logger, svc TasksService, responder *httpschema.ErrorResponder) *Tasks {
+	return &Tasks{logger: logger, service: svc, responder: responder}
+}
+
+type createTaskBody struct {
+	Name        string `json:"name" example:"Write tests"`
+	Description string `json:"description" example:"Cover the new endpoint with tests"`
+}
+
+type updateTaskBody struct {
+	Name        *string `json:"name" example:"Rewrite tests"`
+	Description *string `json:"description" example:"Cover edge cases"`
+}
+
+type moveTaskBody struct {
+	TargetColumnID string `json:"targetColumnId" example:"019cc971-e5be-7df9-ae8a-c6e3f29c86a2"`
+	TargetPosition int64  `json:"targetPosition" example:"1"`
+}
+
+type taskResponse struct {
+	ID          string `json:"id" example:"019cc971-e5be-7df9-ae8a-c6e3f29c86a3"`
+	ColumnID    string `json:"columnId" example:"019cc971-e5be-7df9-ae8a-c6e3f29c86a2"`
+	Name        string `json:"name" example:"Write tests"`
+	Description string `json:"description" example:"Cover the new endpoint with tests"`
+	Position    int64  `json:"position" example:"1"`
+	CreatedAt   string `json:"createdAt" example:"2026-03-07T20:56:50.000+03:00"`
+	UpdatedAt   string `json:"updatedAt" example:"2026-03-07T20:56:50.000+03:00"`
+}
+
+type taskPositionResponse struct {
+	ColumnID string `json:"columnId" example:"019cc971-e5be-7df9-ae8a-c6e3f29c86a2"`
+	Position int64  `json:"position" example:"2"`
+}
+
+func NewTaskResponse(task *domain.Task) taskResponse {
+	return taskResponse{
+		ID:          task.ID.String(),
+		ColumnID:    task.ColumnID.String(),
+		Name:        task.Name.String(),
+		Description: task.Description.String(),
+		Position:    task.Position.Int64(),
+		CreatedAt:   service.FormatRFC3339Millis(task.CreatedAt),
+		UpdatedAt:   service.FormatRFC3339Millis(task.UpdatedAt),
+	}
+}
+
+// Create godoc
+// @Summary Create a new task
+// @Description Create a new task in a column for the current user. Task is appended to the end of the column.
+// @Tags tasks
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param boardId path string true "Board ID"
+// @Param columnId path string true "Column ID"
+// @Param body body createTaskBody true "Task details"
+// @Success 201 {object} taskResponse
+// @Failure 400 {object} httpschema.DetailedError "VALIDATION_ERROR"
+// @Failure 401 {object} httpschema.DetailedError "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER"
+// @Failure 404 {object} httpschema.DetailedError "COLUMN_NOT_FOUND"
+// @Failure 500 {object} httpschema.Error "Internal server error"
+// @Router /v1/boards/{boardId}/columns/{columnId}/tasks [post]
+func (h *Tasks) Create(w http.ResponseWriter, r *http.Request) {
+	boardID, columnID, ok := h.parseBoardAndColumnID(w, r)
+	if !ok {
+		return
+	}
+
+	var body createTaskBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		h.responder.ValidationError(w, []httpschema.Detail{{Field: "body", Issues: []string{"Invalid JSON body"}}})
+		return
+	}
+
+	details := []httpschema.Detail{}
+	name := httpschema.ValidateField("name", body.Name, domain.NewTaskName, &details)
+	description := httpschema.ValidateField("description", body.Description, domain.NewTaskDescription, &details)
+	if len(details) > 0 {
+		h.responder.ValidationError(w, details)
+		return
+	}
+
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
+	if !ok {
+		return
+	}
+
+	task, err := h.service.Create(r.Context(), userID, boardID, columnID, name, description)
+	if err != nil {
+		if errors.Is(err, service.ErrColumnNotFound) {
+			h.responder.ColumnNotFound(w, []httpschema.Detail{{Field: "columnId", Issues: []string{"Column not found"}}})
+			return
+		}
+		h.responder.InternalError(w, r, err)
+		return
+	}
+
+	httpschema.RespondJSON(w, h.logger, http.StatusCreated, NewTaskResponse(&task))
+}
+
+// List godoc
+// @Summary List all tasks in a column
+// @Description Get all tasks belonging to the specified column, ordered by position ASC.
+// @Tags tasks
+// @Produce json
+// @Security BearerAuth
+// @Param boardId path string true "Board ID"
+// @Param columnId path string true "Column ID"
+// @Success 200 {array} taskResponse
+// @Failure 400 {object} httpschema.DetailedError "VALIDATION_ERROR"
+// @Failure 401 {object} httpschema.DetailedError "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER"
+// @Failure 404 {object} httpschema.DetailedError "COLUMN_NOT_FOUND"
+// @Failure 500 {object} httpschema.Error "Internal server error"
+// @Router /v1/boards/{boardId}/columns/{columnId}/tasks [get]
+func (h *Tasks) List(w http.ResponseWriter, r *http.Request) {
+	boardID, columnID, ok := h.parseBoardAndColumnID(w, r)
+	if !ok {
+		return
+	}
+
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
+	if !ok {
+		return
+	}
+
+	tasks, err := h.service.List(r.Context(), userID, boardID, columnID)
+	if err != nil {
+		if errors.Is(err, service.ErrColumnNotFound) {
+			h.responder.ColumnNotFound(w, []httpschema.Detail{{Field: "columnId", Issues: []string{"Column not found"}}})
+			return
+		}
+		h.responder.InternalError(w, r, err)
+		return
+	}
+
+	response := make([]taskResponse, 0, len(tasks))
+	for i := range tasks {
+		response = append(response, NewTaskResponse(&tasks[i]))
+	}
+
+	httpschema.RespondJSON(w, h.logger, http.StatusOK, response)
+}
+
+// UpdateByID godoc
+// @Summary Update a task by id
+// @Description Partially update task metadata for the current user. Provided fields are updated; omitted or null fields are ignored.
+// @Tags tasks
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param boardId path string true "Board ID"
+// @Param columnId path string true "Column ID"
+// @Param taskId path string true "Task ID"
+// @Param body body updateTaskBody true "Task fields to update"
+// @Success 200 {object} taskResponse
+// @Failure 400 {object} httpschema.DetailedError "VALIDATION_ERROR"
+// @Failure 401 {object} httpschema.DetailedError "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER"
+// @Failure 404 {object} httpschema.DetailedError "TASK_NOT_FOUND"
+// @Failure 500 {object} httpschema.Error "Internal server error"
+// @Router /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId} [patch]
+func (h *Tasks) UpdateByID(w http.ResponseWriter, r *http.Request) {
+	boardID, columnID, taskID, ok := h.parseBoardColumnAndTaskID(w, r)
+	if !ok {
+		return
+	}
+
+	var body updateTaskBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		h.responder.ValidationError(w, []httpschema.Detail{{Field: "body", Issues: []string{"Invalid JSON body"}}})
+		return
+	}
+
+	details := []httpschema.Detail{}
+	var name *domain.TaskName
+	if body.Name != nil {
+		value := httpschema.ValidateField("name", *body.Name, domain.NewTaskName, &details)
+		name = &value
+	}
+	var description *domain.TaskDescription
+	if body.Description != nil {
+		value := httpschema.ValidateField("description", *body.Description, domain.NewTaskDescription, &details)
+		description = &value
+	}
+	if len(details) > 0 {
+		h.responder.ValidationError(w, details)
+		return
+	}
+
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
+	if !ok {
+		return
+	}
+
+	task, err := h.service.UpdateByID(r.Context(), userID, boardID, columnID, taskID, name, description)
+	if err != nil {
+		if errors.Is(err, service.ErrTaskNotFound) {
+			h.responder.TaskNotFound(w, []httpschema.Detail{{Field: "taskId", Issues: []string{"Task not found"}}})
+			return
+		}
+		h.responder.InternalError(w, r, err)
+		return
+	}
+
+	httpschema.RespondJSON(w, h.logger, http.StatusOK, NewTaskResponse(&task))
+}
+
+// Move godoc
+// @Summary Move a task to a new position, possibly to another column
+// @Description Move a task within its column or across columns in the same board and shift neighboring tasks accordingly.
+// @Tags tasks
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param boardId path string true "Board ID"
+// @Param columnId path string true "Column ID"
+// @Param taskId path string true "Task ID"
+// @Param body body moveTaskBody true "Target column and position"
+// @Success 200 {object} taskPositionResponse
+// @Failure 400 {object} httpschema.DetailedError "VALIDATION_ERROR"
+// @Failure 401 {object} httpschema.DetailedError "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER"
+// @Failure 404 {object} httpschema.DetailedError "TASK_NOT_FOUND or COLUMN_NOT_FOUND"
+// @Failure 500 {object} httpschema.Error "Internal server error"
+// @Router /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}/position [put]
+func (h *Tasks) Move(w http.ResponseWriter, r *http.Request) {
+	boardID, columnID, taskID, ok := h.parseBoardColumnAndTaskID(w, r)
+	if !ok {
+		return
+	}
+
+	var body moveTaskBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		h.responder.ValidationError(w, []httpschema.Detail{{Field: "body", Issues: []string{"Invalid JSON body"}}})
+		return
+	}
+
+	details := []httpschema.Detail{}
+	targetColumnID, err := domain.ParseColumnID(body.TargetColumnID)
+	if err != nil {
+		details = append(details, httpschema.Detail{Field: "targetColumnId", Issues: []string{"Invalid target column id"}})
+	}
+	targetPosition := httpschema.ValidateField("targetPosition", body.TargetPosition, domain.NewTaskPosition, &details)
+	if len(details) > 0 {
+		h.responder.ValidationError(w, details)
+		return
+	}
+
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
+	if !ok {
+		return
+	}
+
+	newColumnID, newPosition, err := h.service.Move(r.Context(), userID, boardID, columnID, taskID, targetColumnID, targetPosition)
+	if err != nil {
+		if errors.Is(err, service.ErrTaskNotFound) {
+			h.responder.TaskNotFound(w, []httpschema.Detail{{Field: "taskId", Issues: []string{"Task not found"}}})
+			return
+		}
+		if errors.Is(err, service.ErrColumnNotFound) {
+			h.responder.ColumnNotFound(w, []httpschema.Detail{{Field: "targetColumnId", Issues: []string{"Column not found"}}})
+			return
+		}
+		if errors.Is(err, service.ErrIndexOutOfBounds) {
+			h.responder.ValidationError(w, []httpschema.Detail{{Field: "targetPosition", Issues: []string{"Index out of bounds"}}})
+			return
+		}
+		h.responder.InternalError(w, r, err)
+		return
+	}
+
+	httpschema.RespondJSON(w, h.logger, http.StatusOK, taskPositionResponse{
+		ColumnID: newColumnID.String(),
+		Position: newPosition.Int64(),
+	})
+}
+
+// Delete godoc
+// @Summary Delete a task by id
+// @Description Permanently delete a task from a column for the current user and shift positions to close the gap.
+// @Tags tasks
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param boardId path string true "Board ID"
+// @Param columnId path string true "Column ID"
+// @Param taskId path string true "Task ID"
+// @Success 204 "No Content"
+// @Failure 400 {object} httpschema.DetailedError "VALIDATION_ERROR"
+// @Failure 401 {object} httpschema.DetailedError "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER"
+// @Failure 404 {object} httpschema.DetailedError "TASK_NOT_FOUND"
+// @Failure 500 {object} httpschema.Error "Internal server error"
+// @Router /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId} [delete]
+func (h *Tasks) Delete(w http.ResponseWriter, r *http.Request) {
+	boardID, columnID, taskID, ok := h.parseBoardColumnAndTaskID(w, r)
+	if !ok {
+		return
+	}
+
+	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
+	if !ok {
+		return
+	}
+
+	err := h.service.Delete(r.Context(), userID, boardID, columnID, taskID)
+	if err != nil {
+		if errors.Is(err, service.ErrTaskNotFound) {
+			h.responder.TaskNotFound(w, []httpschema.Detail{{Field: "taskId", Issues: []string{"Task not found"}}})
+			return
+		}
+		h.responder.InternalError(w, r, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Tasks) parseBoardAndColumnID(w http.ResponseWriter, r *http.Request) (boardID domain.BoardID, columnID domain.ColumnID, ok bool) {
+	rawBoardID := r.PathValue("boardId")
+	boardID, err := domain.ParseBoardID(rawBoardID)
+	if err != nil {
+		h.responder.ValidationError(w, []httpschema.Detail{{Field: "boardId", Issues: []string{"Invalid board id"}}})
+		return domain.BoardID{}, domain.ColumnID{}, false
+	}
+
+	rawColumnID := r.PathValue("columnId")
+	columnID, err = domain.ParseColumnID(rawColumnID)
+	if err != nil {
+		h.responder.ValidationError(w, []httpschema.Detail{{Field: "columnId", Issues: []string{"Invalid column id"}}})
+		return domain.BoardID{}, domain.ColumnID{}, false
+	}
+
+	return boardID, columnID, true
+}
+
+func (h *Tasks) parseBoardColumnAndTaskID(w http.ResponseWriter, r *http.Request) (boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, ok bool) {
+	boardID, columnID, ok = h.parseBoardAndColumnID(w, r)
+	if !ok {
+		return domain.BoardID{}, domain.ColumnID{}, domain.TaskID{}, false
+	}
+
+	rawTaskID := r.PathValue("taskId")
+	taskID, err := domain.ParseTaskID(rawTaskID)
+	if err != nil {
+		h.responder.ValidationError(w, []httpschema.Detail{{Field: "taskId", Issues: []string{"Invalid task id"}}})
+		return domain.BoardID{}, domain.ColumnID{}, domain.TaskID{}, false
+	}
+
+	return boardID, columnID, taskID, true
+}

--- a/internal/http/handler/tasks_test.go
+++ b/internal/http/handler/tasks_test.go
@@ -181,7 +181,7 @@ func TestTasks_List(t *testing.T) {
 	validColumn := testutil.ValidColumn(validBoard.ID)
 	first := testutil.ValidTask(validColumn.ID)
 	second := testutil.ValidTask(validColumn.ID)
-	second.Position, _ = domain.NewTaskPosition(first.Position.Int64() + 1)
+	second.Position = testutil.MustTaskPosition(t, first.Position.Int64()+1)
 
 	okPath := "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String() + "/tasks"
 
@@ -503,10 +503,7 @@ func TestTasks_Move(t *testing.T) {
 	validColumn := testutil.ValidColumn(validBoard.ID)
 	validTask := testutil.ValidTask(validColumn.ID)
 	targetColumn := testutil.NewValidColumn(t, validBoard.ID, "Done", 2)
-	targetPosition, err := domain.NewTaskPosition(2)
-	if err != nil {
-		t.Fatalf("NewTaskPosition() error = %v", err)
-	}
+	targetPosition := testutil.MustTaskPosition(t, 2)
 
 	okPath := "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String() + "/tasks/" + validTask.ID.String() + "/position"
 

--- a/internal/http/handler/tasks_test.go
+++ b/internal/http/handler/tasks_test.go
@@ -117,7 +117,7 @@ func TestTasks_Create(t *testing.T) {
 				}
 			},
 			wantCode: http.StatusNotFound,
-			wantBody: columnNotFoundErrorBody(),
+			wantBody: columnNotFoundByFieldError("columnId"),
 		},
 		{
 			name:      "Internal error",
@@ -260,7 +260,7 @@ func TestTasks_List(t *testing.T) {
 				}
 			},
 			wantCode: http.StatusNotFound,
-			wantBody: columnNotFoundErrorBody(),
+			wantBody: columnNotFoundByFieldError("columnId"),
 		},
 		{
 			name: "Internal error",
@@ -636,7 +636,7 @@ func TestTasks_Move(t *testing.T) {
 				}
 			},
 			wantCode: http.StatusNotFound,
-			wantBody: columnNotFoundErrorBodyField("targetColumnId"),
+			wantBody: columnNotFoundByFieldError("targetColumnId"),
 		},
 		{
 			name:      "Internal error",

--- a/internal/http/handler/tasks_test.go
+++ b/internal/http/handler/tasks_test.go
@@ -1,0 +1,838 @@
+package handler_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"goroutine/internal/domain"
+	"goroutine/internal/http/handler"
+	"goroutine/internal/http/httpschema"
+	"goroutine/internal/service"
+	"goroutine/internal/testutil"
+)
+
+func TestTasks_Create(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumn := testutil.ValidColumn(validBoard.ID)
+	validTask := testutil.ValidTask(validColumn.ID)
+
+	okPath := "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String() + "/tasks"
+
+	tests := []struct {
+		name             string
+		path             string
+		inputBody        any
+		context          context.Context
+		setupTaskService func(t *testing.T, s *MockTaskService)
+		wantCode         int
+		wantBody         any
+	}{
+		{
+			name: "Success",
+			path: okPath,
+			inputBody: map[string]string{
+				"name":        validTask.Name.String(),
+				"description": validTask.Description.String(),
+			},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error) {
+					if callerID != validBoard.OwnerID {
+						t.Errorf("got caller id %v, want %v", callerID, validBoard.OwnerID)
+					}
+					if boardID != validBoard.ID {
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
+					}
+					if columnID != validColumn.ID {
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
+					}
+					if name != validTask.Name {
+						t.Errorf("got name %v, want %v", name, validTask.Name)
+					}
+					if description != validTask.Description {
+						t.Errorf("got description %v, want %v", description, validTask.Description)
+					}
+					return validTask, nil
+				}
+			},
+			wantCode: http.StatusCreated,
+			wantBody: map[string]any{
+				"id":          validTask.ID.String(),
+				"columnId":    validTask.ColumnID.String(),
+				"name":        validTask.Name.String(),
+				"description": validTask.Description.String(),
+				"position":    validTask.Position.Int64(),
+				"createdAt":   validTask.CreatedAt.Format(timeFormat),
+				"updatedAt":   validTask.UpdatedAt.Format(timeFormat),
+			},
+		},
+		{
+			name:      "Invalid board id",
+			path:      "/v1/boards/not-a-uuid/columns/" + validColumn.ID.String() + "/tasks",
+			inputBody: map[string]string{"name": "Name", "description": "Description"},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("boardId", []string{"Invalid board id"}),
+		},
+		{
+			name:      "Invalid column id",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns/not-a-uuid/tasks",
+			inputBody: map[string]string{"name": "Name", "description": "Description"},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("columnId", []string{"Invalid column id"}),
+		},
+		{
+			name:      "Invalid JSON",
+			path:      okPath,
+			inputBody: "{\"name\":\"broken\"",
+			wantCode:  http.StatusBadRequest,
+			wantBody:  invalidJsonBody(),
+		},
+		{
+			name:      "Invalid name",
+			path:      okPath,
+			inputBody: map[string]string{"name": "   ", "description": "ok"},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("name", []string{"Name is too short"}),
+		},
+		{
+			name:      "Missing context user",
+			path:      okPath,
+			inputBody: map[string]string{"name": "ok", "description": "ok"},
+			context:   context.Background(),
+			wantCode:  http.StatusUnauthorized,
+			wantBody:  unauthorizedTokenBody(),
+		},
+		{
+			name:      "Column not found",
+			path:      okPath,
+			inputBody: map[string]string{"name": "ok", "description": "ok"},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error) {
+					return domain.Task{}, service.ErrColumnNotFound
+				}
+			},
+			wantCode: http.StatusNotFound,
+			wantBody: columnNotFoundErrorBody(),
+		},
+		{
+			name:      "Internal error",
+			path:      okPath,
+			inputBody: map[string]string{"name": "ok", "description": "ok"},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error) {
+					return domain.Task{}, service.ErrInternal
+				}
+			},
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
+		},
+		{
+			name:      "Unexpected error",
+			path:      okPath,
+			inputBody: map[string]string{"name": "ok", "description": "ok"},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.CreateFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error) {
+					return domain.Task{}, errors.New("db exploded")
+				}
+			},
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := buildTaskRequest(t, http.MethodPost, tt.path, tt.inputBody)
+			if tt.context != nil {
+				req = req.WithContext(tt.context)
+			} else {
+				req = req.WithContext(context.WithValue(req.Context(), httpschema.ContextKeyUserID, validBoard.OwnerID))
+			}
+			setTaskPathValues(req, tt.path)
+
+			rr := httptest.NewRecorder()
+			mockTasks := &MockTaskService{}
+			if tt.setupTaskService != nil {
+				tt.setupTaskService(t, mockTasks)
+			}
+
+			logger := testutil.NewTestLogger(t)
+			h := handler.NewTasks(logger, mockTasks, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
+			h.Create(rr, req)
+
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
+			testutil.AssertContentType(t, rr, "application/json")
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
+		})
+	}
+}
+
+func TestTasks_List(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumn := testutil.ValidColumn(validBoard.ID)
+	first := testutil.ValidTask(validColumn.ID)
+	second := testutil.ValidTask(validColumn.ID)
+	second.Position, _ = domain.NewTaskPosition(first.Position.Int64() + 1)
+
+	okPath := "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String() + "/tasks"
+
+	tests := []struct {
+		name             string
+		path             string
+		context          context.Context
+		setupTaskService func(t *testing.T, s *MockTaskService)
+		wantCode         int
+		wantBody         any
+	}{
+		{
+			name: "Success",
+			path: okPath,
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.ListFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) ([]domain.Task, error) {
+					if callerID != validBoard.OwnerID {
+						t.Errorf("got caller id %v, want %v", callerID, validBoard.OwnerID)
+					}
+					if boardID != validBoard.ID {
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
+					}
+					if columnID != validColumn.ID {
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
+					}
+					return []domain.Task{first, second}, nil
+				}
+			},
+			wantCode: http.StatusOK,
+			wantBody: []map[string]any{
+				{
+					"id":          first.ID.String(),
+					"columnId":    first.ColumnID.String(),
+					"name":        first.Name.String(),
+					"description": first.Description.String(),
+					"position":    first.Position.Int64(),
+					"createdAt":   first.CreatedAt.Format(timeFormat),
+					"updatedAt":   first.UpdatedAt.Format(timeFormat),
+				},
+				{
+					"id":          second.ID.String(),
+					"columnId":    second.ColumnID.String(),
+					"name":        second.Name.String(),
+					"description": second.Description.String(),
+					"position":    second.Position.Int64(),
+					"createdAt":   second.CreatedAt.Format(timeFormat),
+					"updatedAt":   second.UpdatedAt.Format(timeFormat),
+				},
+			},
+		},
+		{
+			name:     "Invalid board id",
+			path:     "/v1/boards/not-a-uuid/columns/" + validColumn.ID.String() + "/tasks",
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("boardId", []string{"Invalid board id"}),
+		},
+		{
+			name:     "Invalid column id",
+			path:     "/v1/boards/" + validBoard.ID.String() + "/columns/not-a-uuid/tasks",
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("columnId", []string{"Invalid column id"}),
+		},
+		{
+			name:     "Missing context user",
+			path:     okPath,
+			context:  context.Background(),
+			wantCode: http.StatusUnauthorized,
+			wantBody: unauthorizedTokenBody(),
+		},
+		{
+			name: "Column not found",
+			path: okPath,
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.ListFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) ([]domain.Task, error) {
+					return nil, service.ErrColumnNotFound
+				}
+			},
+			wantCode: http.StatusNotFound,
+			wantBody: columnNotFoundErrorBody(),
+		},
+		{
+			name: "Internal error",
+			path: okPath,
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.ListFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) ([]domain.Task, error) {
+					return nil, service.ErrInternal
+				}
+			},
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, http.NoBody)
+			if tt.context != nil {
+				req = req.WithContext(tt.context)
+			} else {
+				req = req.WithContext(context.WithValue(req.Context(), httpschema.ContextKeyUserID, validBoard.OwnerID))
+			}
+			setTaskPathValues(req, tt.path)
+
+			rr := httptest.NewRecorder()
+			mockTasks := &MockTaskService{}
+			if tt.setupTaskService != nil {
+				tt.setupTaskService(t, mockTasks)
+			}
+
+			logger := testutil.NewTestLogger(t)
+			h := handler.NewTasks(logger, mockTasks, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
+			h.List(rr, req)
+
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
+			testutil.AssertContentType(t, rr, "application/json")
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
+		})
+	}
+}
+
+func TestTasks_UpdateByID(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumn := testutil.ValidColumn(validBoard.ID)
+	validTask := testutil.ValidTask(validColumn.ID)
+	updatedName, err := domain.NewTaskName("Renamed Task")
+	if err != nil {
+		t.Fatalf("NewTaskName() error = %v", err)
+	}
+	updatedDescription, err := domain.NewTaskDescription("Renamed Description")
+	if err != nil {
+		t.Fatalf("NewTaskDescription() error = %v", err)
+	}
+	updatedTask := validTask
+	updatedTask.Name = updatedName
+	updatedTask.Description = updatedDescription
+	updatedTask.UpdatedAt = testutil.FixedTime5mFromNow()
+
+	okPath := "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String() + "/tasks/" + validTask.ID.String()
+
+	tests := []struct {
+		name             string
+		path             string
+		inputBody        any
+		context          context.Context
+		setupTaskService func(t *testing.T, s *MockTaskService)
+		wantCode         int
+		wantBody         any
+	}{
+		{
+			name:      "Success (name and description update)",
+			path:      okPath,
+			inputBody: map[string]string{"name": updatedName.String(), "description": updatedDescription.String()},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.UpdateByIDFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					if callerID != validBoard.OwnerID {
+						t.Errorf("got caller id %v, want %v", callerID, validBoard.OwnerID)
+					}
+					if boardID != validBoard.ID {
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
+					}
+					if columnID != validColumn.ID {
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
+					}
+					if taskID != validTask.ID {
+						t.Errorf("got task id %v, want %v", taskID, validTask.ID)
+					}
+					if name == nil || *name != updatedName {
+						t.Errorf("got name %v, want %v", name, updatedName)
+					}
+					if description == nil || *description != updatedDescription {
+						t.Errorf("got description %v, want %v", description, updatedDescription)
+					}
+					return updatedTask, nil
+				}
+			},
+			wantCode: http.StatusOK,
+			wantBody: map[string]any{
+				"id":          updatedTask.ID.String(),
+				"columnId":    updatedTask.ColumnID.String(),
+				"name":        updatedTask.Name.String(),
+				"description": updatedTask.Description.String(),
+				"position":    updatedTask.Position.Int64(),
+				"createdAt":   updatedTask.CreatedAt.Format(timeFormat),
+				"updatedAt":   updatedTask.UpdatedAt.Format(timeFormat),
+			},
+		},
+		{
+			name:      "Success (empty body no-op)",
+			path:      okPath,
+			inputBody: map[string]any{},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.UpdateByIDFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					if name != nil {
+						t.Errorf("got name %+v, want nil", name)
+					}
+					if description != nil {
+						t.Errorf("got description %+v, want nil", description)
+					}
+					return validTask, nil
+				}
+			},
+			wantCode: http.StatusOK,
+			wantBody: map[string]any{
+				"id":          validTask.ID.String(),
+				"columnId":    validTask.ColumnID.String(),
+				"name":        validTask.Name.String(),
+				"description": validTask.Description.String(),
+				"position":    validTask.Position.Int64(),
+				"createdAt":   validTask.CreatedAt.Format(timeFormat),
+				"updatedAt":   validTask.UpdatedAt.Format(timeFormat),
+			},
+		},
+		{
+			name:      "Invalid board id",
+			path:      "/v1/boards/not-a-uuid/columns/" + validColumn.ID.String() + "/tasks/" + validTask.ID.String(),
+			inputBody: map[string]string{"name": "Renamed"},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("boardId", []string{"Invalid board id"}),
+		},
+		{
+			name:      "Invalid column id",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns/not-a-uuid/tasks/" + validTask.ID.String(),
+			inputBody: map[string]string{"name": "Renamed"},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("columnId", []string{"Invalid column id"}),
+		},
+		{
+			name:      "Invalid task id",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String() + "/tasks/not-a-uuid",
+			inputBody: map[string]string{"name": "Renamed"},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("taskId", []string{"Invalid task id"}),
+		},
+		{
+			name:      "Invalid JSON",
+			path:      okPath,
+			inputBody: "{\"name\":\"broken\"",
+			wantCode:  http.StatusBadRequest,
+			wantBody:  invalidJsonBody(),
+		},
+		{
+			name:      "Invalid name",
+			path:      okPath,
+			inputBody: map[string]string{"name": "   "},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("name", []string{"Name is too short"}),
+		},
+		{
+			name:      "Missing context user",
+			path:      okPath,
+			inputBody: map[string]string{"name": "Renamed"},
+			context:   context.Background(),
+			wantCode:  http.StatusUnauthorized,
+			wantBody:  unauthorizedTokenBody(),
+		},
+		{
+			name:      "Task not found",
+			path:      okPath,
+			inputBody: map[string]string{"name": "Renamed"},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.UpdateByIDFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					return domain.Task{}, service.ErrTaskNotFound
+				}
+			},
+			wantCode: http.StatusNotFound,
+			wantBody: taskNotFoundErrorBody(),
+		},
+		{
+			name:      "Internal error",
+			path:      okPath,
+			inputBody: map[string]string{"name": "Renamed"},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.UpdateByIDFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					return domain.Task{}, service.ErrInternal
+				}
+			},
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := buildTaskRequest(t, http.MethodPatch, tt.path, tt.inputBody)
+			if tt.context != nil {
+				req = req.WithContext(tt.context)
+			} else {
+				req = req.WithContext(context.WithValue(req.Context(), httpschema.ContextKeyUserID, validBoard.OwnerID))
+			}
+			setTaskPathValues(req, tt.path)
+
+			rr := httptest.NewRecorder()
+			mockTasks := &MockTaskService{}
+			if tt.setupTaskService != nil {
+				tt.setupTaskService(t, mockTasks)
+			}
+
+			logger := testutil.NewTestLogger(t)
+			h := handler.NewTasks(logger, mockTasks, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
+			h.UpdateByID(rr, req)
+
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
+			testutil.AssertContentType(t, rr, "application/json")
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
+		})
+	}
+}
+
+func TestTasks_Move(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumn := testutil.ValidColumn(validBoard.ID)
+	validTask := testutil.ValidTask(validColumn.ID)
+	targetColumn := testutil.NewValidColumn(t, validBoard.ID, "Done", 2)
+	targetPosition, err := domain.NewTaskPosition(2)
+	if err != nil {
+		t.Fatalf("NewTaskPosition() error = %v", err)
+	}
+
+	okPath := "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String() + "/tasks/" + validTask.ID.String() + "/position"
+
+	tests := []struct {
+		name             string
+		path             string
+		inputBody        any
+		context          context.Context
+		setupTaskService func(t *testing.T, s *MockTaskService)
+		wantCode         int
+		wantBody         any
+	}{
+		{
+			name: "Success",
+			path: okPath,
+			inputBody: map[string]any{
+				"targetColumnId": targetColumn.ID.String(),
+				"targetPosition": targetPosition.Int64(),
+			},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.MoveFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, gotTargetColumnID domain.ColumnID, gotTargetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					if callerID != validBoard.OwnerID {
+						t.Errorf("got caller id %v, want %v", callerID, validBoard.OwnerID)
+					}
+					if boardID != validBoard.ID {
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
+					}
+					if columnID != validColumn.ID {
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
+					}
+					if taskID != validTask.ID {
+						t.Errorf("got task id %v, want %v", taskID, validTask.ID)
+					}
+					if gotTargetColumnID != targetColumn.ID {
+						t.Errorf("got target column id %v, want %v", gotTargetColumnID, targetColumn.ID)
+					}
+					if gotTargetPosition != targetPosition {
+						t.Errorf("got target position %v, want %v", gotTargetPosition, targetPosition)
+					}
+					return targetColumn.ID, targetPosition, nil
+				}
+			},
+			wantCode: http.StatusOK,
+			wantBody: map[string]any{
+				"columnId": targetColumn.ID.String(),
+				"position": targetPosition.Int64(),
+			},
+		},
+		{
+			name:      "Invalid board id",
+			path:      "/v1/boards/not-a-uuid/columns/" + validColumn.ID.String() + "/tasks/" + validTask.ID.String() + "/position",
+			inputBody: map[string]any{"targetColumnId": targetColumn.ID.String(), "targetPosition": 1},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("boardId", []string{"Invalid board id"}),
+		},
+		{
+			name:      "Invalid column id",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns/not-a-uuid/tasks/" + validTask.ID.String() + "/position",
+			inputBody: map[string]any{"targetColumnId": targetColumn.ID.String(), "targetPosition": 1},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("columnId", []string{"Invalid column id"}),
+		},
+		{
+			name:      "Invalid task id",
+			path:      "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String() + "/tasks/not-a-uuid/position",
+			inputBody: map[string]any{"targetColumnId": targetColumn.ID.String(), "targetPosition": 1},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("taskId", []string{"Invalid task id"}),
+		},
+		{
+			name:      "Invalid JSON",
+			path:      okPath,
+			inputBody: "{\"targetPosition\":",
+			wantCode:  http.StatusBadRequest,
+			wantBody:  invalidJsonBody(),
+		},
+		{
+			name:      "Invalid target column id",
+			path:      okPath,
+			inputBody: map[string]any{"targetColumnId": "not-a-uuid", "targetPosition": 1},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("targetColumnId", []string{"Invalid target column id"}),
+		},
+		{
+			name:      "Invalid target position",
+			path:      okPath,
+			inputBody: map[string]any{"targetColumnId": targetColumn.ID.String(), "targetPosition": 0},
+			wantCode:  http.StatusBadRequest,
+			wantBody:  validationErrorBody("targetPosition", []string{"Position is invalid"}),
+		},
+		{
+			name:      "Missing context user",
+			path:      okPath,
+			inputBody: map[string]any{"targetColumnId": targetColumn.ID.String(), "targetPosition": 1},
+			context:   context.Background(),
+			wantCode:  http.StatusUnauthorized,
+			wantBody:  unauthorizedTokenBody(),
+		},
+		{
+			name:      "Index out of bounds",
+			path:      okPath,
+			inputBody: map[string]any{"targetColumnId": targetColumn.ID.String(), "targetPosition": 10},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.MoveFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, targetColumnID domain.ColumnID, targetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					return domain.ColumnID{}, domain.TaskPosition{}, service.ErrIndexOutOfBounds
+				}
+			},
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("targetPosition", []string{"Index out of bounds"}),
+		},
+		{
+			name:      "Task not found",
+			path:      okPath,
+			inputBody: map[string]any{"targetColumnId": targetColumn.ID.String(), "targetPosition": 1},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.MoveFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, targetColumnID domain.ColumnID, targetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					return domain.ColumnID{}, domain.TaskPosition{}, service.ErrTaskNotFound
+				}
+			},
+			wantCode: http.StatusNotFound,
+			wantBody: taskNotFoundErrorBody(),
+		},
+		{
+			name:      "Target column not found",
+			path:      okPath,
+			inputBody: map[string]any{"targetColumnId": targetColumn.ID.String(), "targetPosition": 1},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.MoveFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, targetColumnID domain.ColumnID, targetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					return domain.ColumnID{}, domain.TaskPosition{}, service.ErrColumnNotFound
+				}
+			},
+			wantCode: http.StatusNotFound,
+			wantBody: columnNotFoundErrorBodyField("targetColumnId"),
+		},
+		{
+			name:      "Internal error",
+			path:      okPath,
+			inputBody: map[string]any{"targetColumnId": targetColumn.ID.String(), "targetPosition": 1},
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.MoveFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, targetColumnID domain.ColumnID, targetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					return domain.ColumnID{}, domain.TaskPosition{}, service.ErrInternal
+				}
+			},
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := buildTaskRequest(t, http.MethodPut, tt.path, tt.inputBody)
+			if tt.context != nil {
+				req = req.WithContext(tt.context)
+			} else {
+				req = req.WithContext(context.WithValue(req.Context(), httpschema.ContextKeyUserID, validBoard.OwnerID))
+			}
+			setTaskPathValues(req, tt.path)
+
+			rr := httptest.NewRecorder()
+			mockTasks := &MockTaskService{}
+			if tt.setupTaskService != nil {
+				tt.setupTaskService(t, mockTasks)
+			}
+
+			logger := testutil.NewTestLogger(t)
+			h := handler.NewTasks(logger, mockTasks, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
+			h.Move(rr, req)
+
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
+			testutil.AssertContentType(t, rr, "application/json")
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
+		})
+	}
+}
+
+func TestTasks_Delete(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumn := testutil.ValidColumn(validBoard.ID)
+	validTask := testutil.ValidTask(validColumn.ID)
+	okPath := "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String() + "/tasks/" + validTask.ID.String()
+
+	tests := []struct {
+		name             string
+		path             string
+		context          context.Context
+		setupTaskService func(t *testing.T, s *MockTaskService)
+		wantCode         int
+		wantBody         any
+	}{
+		{
+			name: "Success",
+			path: okPath,
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.DeleteFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error {
+					if callerID != validBoard.OwnerID {
+						t.Errorf("got caller id %v, want %v", callerID, validBoard.OwnerID)
+					}
+					if boardID != validBoard.ID {
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
+					}
+					if columnID != validColumn.ID {
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
+					}
+					if taskID != validTask.ID {
+						t.Errorf("got task id %v, want %v", taskID, validTask.ID)
+					}
+					return nil
+				}
+			},
+			wantCode: http.StatusNoContent,
+			wantBody: nil,
+		},
+		{
+			name:     "Invalid board id",
+			path:     "/v1/boards/not-a-uuid/columns/" + validColumn.ID.String() + "/tasks/" + validTask.ID.String(),
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("boardId", []string{"Invalid board id"}),
+		},
+		{
+			name:     "Invalid column id",
+			path:     "/v1/boards/" + validBoard.ID.String() + "/columns/not-a-uuid/tasks/" + validTask.ID.String(),
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("columnId", []string{"Invalid column id"}),
+		},
+		{
+			name:     "Invalid task id",
+			path:     "/v1/boards/" + validBoard.ID.String() + "/columns/" + validColumn.ID.String() + "/tasks/not-a-uuid",
+			wantCode: http.StatusBadRequest,
+			wantBody: validationErrorBody("taskId", []string{"Invalid task id"}),
+		},
+		{
+			name:     "Missing context user",
+			path:     okPath,
+			context:  context.Background(),
+			wantCode: http.StatusUnauthorized,
+			wantBody: unauthorizedTokenBody(),
+		},
+		{
+			name: "Task not found",
+			path: okPath,
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.DeleteFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error {
+					return service.ErrTaskNotFound
+				}
+			},
+			wantCode: http.StatusNotFound,
+			wantBody: taskNotFoundErrorBody(),
+		},
+		{
+			name: "Internal error",
+			path: okPath,
+			setupTaskService: func(t *testing.T, s *MockTaskService) {
+				s.DeleteFunc = func(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error {
+					return service.ErrInternal
+				}
+			},
+			wantCode: http.StatusInternalServerError,
+			wantBody: internalErrorBody(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodDelete, tt.path, http.NoBody)
+			if tt.context != nil {
+				req = req.WithContext(tt.context)
+			} else {
+				req = req.WithContext(context.WithValue(req.Context(), httpschema.ContextKeyUserID, validBoard.OwnerID))
+			}
+			setTaskPathValues(req, tt.path)
+
+			rr := httptest.NewRecorder()
+			mockTasks := &MockTaskService{}
+			if tt.setupTaskService != nil {
+				tt.setupTaskService(t, mockTasks)
+			}
+
+			logger := testutil.NewTestLogger(t)
+			h := handler.NewTasks(logger, mockTasks, httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr))
+			h.Delete(rr, req)
+
+			testutil.AssertStatusCode(t, rr, tt.wantCode)
+			if tt.wantCode != http.StatusNoContent {
+				testutil.AssertContentType(t, rr, "application/json")
+			}
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
+		})
+	}
+}
+
+func buildTaskRequest(t *testing.T, method, path string, body any) *http.Request {
+	t.Helper()
+
+	if raw, ok := body.(string); ok {
+		req := httptest.NewRequest(method, path, strings.NewReader(raw))
+		req.Header.Set("Content-Type", "application/json")
+		return req
+	}
+	req, _ := testutil.NewJSONRequestAndRecorder(t, method, path, body)
+	return req
+}
+
+func setTaskPathValues(req *http.Request, path string) {
+	rest := strings.TrimPrefix(path, "/v1/boards/")
+	boardAndRest := strings.SplitN(rest, "/columns/", 2)
+	if len(boardAndRest) != 2 {
+		return
+	}
+	req.SetPathValue("boardId", boardAndRest[0])
+
+	columnAndRest := strings.SplitN(boardAndRest[1], "/tasks", 2)
+	req.SetPathValue("columnId", columnAndRest[0])
+	if len(columnAndRest) != 2 {
+		return
+	}
+
+	taskRest := strings.TrimPrefix(columnAndRest[1], "/")
+	if taskRest == "" {
+		return
+	}
+	taskRest = strings.TrimSuffix(taskRest, "/position")
+	req.SetPathValue("taskId", taskRest)
+}

--- a/internal/http/httpschema/code_map.go
+++ b/internal/http/httpschema/code_map.go
@@ -8,6 +8,7 @@ var codeMap = map[string]string{
 	"NOT_FOUND":             "Resource not found",
 	"BOARD_NOT_FOUND":       "Board not found",
 	"COLUMN_NOT_FOUND":      "Column not found",
+	"TASK_NOT_FOUND":        "Task not found",
 	"INDEX_OUT_OF_BOUNDS":   "Index out of bounds",
 	"INVALID_AUTH_HEADER":   "Invalid authorization header",
 	"USER_NOT_FOUND":        "User not found",

--- a/internal/http/httpschema/error_responder.go
+++ b/internal/http/httpschema/error_responder.go
@@ -37,6 +37,10 @@ func (r *ErrorResponder) ColumnNotFound(w http.ResponseWriter, details []Detail)
 	r.DetailedError(w, http.StatusNotFound, "COLUMN_NOT_FOUND", details)
 }
 
+func (r *ErrorResponder) TaskNotFound(w http.ResponseWriter, details []Detail) {
+	r.DetailedError(w, http.StatusNotFound, "TASK_NOT_FOUND", details)
+}
+
 func (r *ErrorResponder) IndexOutOfBounds(w http.ResponseWriter, details []Detail) {
 	r.DetailedError(w, http.StatusBadRequest, "INDEX_OUT_OF_BOUNDS", details)
 }

--- a/internal/http/route.go
+++ b/internal/http/route.go
@@ -31,6 +31,11 @@ func NewRouter(h *handler.Handlers, m *middleware.Middlewares) http.Handler {
 	mux.Handle("PATCH /v1/boards/{boardId}/columns/{columnId}", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Columns.UpdateByID))))
 	mux.Handle("PUT /v1/boards/{boardId}/columns/{columnId}/position", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Columns.Move))))
 	mux.Handle("DELETE /v1/boards/{boardId}/columns/{columnId}", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Columns.Delete))))
+	mux.Handle("POST /v1/boards/{boardId}/columns/{columnId}/tasks", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Tasks.Create))))
+	mux.Handle("GET /v1/boards/{boardId}/columns/{columnId}/tasks", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Tasks.List))))
+	mux.Handle("PATCH /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Tasks.UpdateByID))))
+	mux.Handle("PUT /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}/position", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Tasks.Move))))
+	mux.Handle("DELETE /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}", m.Metrics.Wrap(m.Auth.Wrap(http.HandlerFunc(h.Tasks.Delete))))
 	mux.Handle("GET "+swaggerBasePath, NewSwaggerHandler(swaggerBasePath, loginPath))
 
 	return m.RequestID.Wrap(m.CORS.Wrap(mux))

--- a/internal/http/route_test.go
+++ b/internal/http/route_test.go
@@ -24,6 +24,7 @@ func TestNewRouter_Full(t *testing.T) {
 		Health:  handler.NewHealth(logger),
 		Boards:  handler.NewBoards(logger, nil, responder),
 		Columns: handler.NewColumns(logger, nil, responder),
+		Tasks:   handler.NewTasks(logger, nil, responder),
 	}
 	middlewares := &middleware.Middlewares{
 		Metrics:   &spyMetricsMiddleware{},
@@ -96,6 +97,26 @@ func TestNewRouter_Full(t *testing.T) {
 		},
 		{
 			entry:   entry{"Delete column endpoint", http.MethodDelete, "/v1/boards/" + UUIDv7() + "/columns/" + UUIDv7()},
+			metrics: true, cors: true, requestID: true,
+		},
+		{
+			entry:   entry{"Create task endpoint", http.MethodPost, "/v1/boards/" + UUIDv7() + "/columns/" + UUIDv7() + "/tasks"},
+			metrics: true, cors: true, requestID: true,
+		},
+		{
+			entry:   entry{"List tasks endpoint", http.MethodGet, "/v1/boards/" + UUIDv7() + "/columns/" + UUIDv7() + "/tasks"},
+			metrics: true, cors: true, requestID: true,
+		},
+		{
+			entry:   entry{"UpdateByID task endpoint", http.MethodPatch, "/v1/boards/" + UUIDv7() + "/columns/" + UUIDv7() + "/tasks/" + UUIDv7()},
+			metrics: true, cors: true, requestID: true,
+		},
+		{
+			entry:   entry{"Move task endpoint", http.MethodPut, "/v1/boards/" + UUIDv7() + "/columns/" + UUIDv7() + "/tasks/" + UUIDv7() + "/position"},
+			metrics: true, cors: true, requestID: true,
+		},
+		{
+			entry:   entry{"Delete task endpoint", http.MethodDelete, "/v1/boards/" + UUIDv7() + "/columns/" + UUIDv7() + "/tasks/" + UUIDv7()},
 			metrics: true, cors: true, requestID: true,
 		},
 		{

--- a/internal/repository/helpers_test.go
+++ b/internal/repository/helpers_test.go
@@ -311,17 +311,6 @@ func mustColumnPosition(t *testing.T, n int64) domain.ColumnPosition {
 	return p
 }
 
-func mustTaskPosition(t *testing.T, n int64) domain.TaskPosition {
-	t.Helper()
-
-	p, err := domain.NewTaskPosition(n)
-	if err != nil {
-		t.Fatalf("NewTaskPosition(%d): %v", n, err)
-	}
-
-	return p
-}
-
 func assertColumnIDAndPosition(t *testing.T, col *domain.Column, wantID domain.ColumnID, wantPos int64) {
 	t.Helper()
 

--- a/internal/repository/helpers_test.go
+++ b/internal/repository/helpers_test.go
@@ -182,6 +182,104 @@ func ListColumnsByBoardID(t *testing.T, pool *pgxpool.Pool, boardID domain.Board
 	return columns
 }
 
+func InsertTask(t *testing.T, pool *pgxpool.Pool, task *domain.Task) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const q = `
+		INSERT INTO tasks (id, column_id, name, description, position, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`
+	_, err := pool.Exec(ctx, q,
+		task.ID,
+		task.ColumnID,
+		task.Name,
+		task.Description,
+		task.Position,
+		task.CreatedAt,
+		task.UpdatedAt,
+	)
+	if err != nil {
+		t.Fatalf("InsertTask() error = %v", err)
+	}
+}
+
+func FindTaskByID(t *testing.T, pool *pgxpool.Pool, taskID domain.TaskID) (domain.Task, bool) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const q = `
+		SELECT id, column_id, name, description, position, created_at, updated_at
+		FROM tasks
+		WHERE id = $1`
+
+	var task domain.Task
+	err := pool.QueryRow(ctx, q, taskID).Scan(
+		&task.ID,
+		&task.ColumnID,
+		&task.Name,
+		&task.Description,
+		&task.Position,
+		&task.CreatedAt,
+		&task.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.Task{}, false
+		}
+		t.Fatalf("FindTaskByID() error = %v", err)
+	}
+
+	return task, true
+}
+
+func ListTasksByColumnID(t *testing.T, pool *pgxpool.Pool, columnID domain.ColumnID) []domain.Task {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const q = `
+		SELECT id, column_id, name, description, position, created_at, updated_at
+		FROM tasks
+		WHERE column_id = $1
+		ORDER BY position ASC`
+
+	rows, err := pool.Query(ctx, q, columnID)
+	if err != nil {
+		t.Fatalf("ListTasksByColumnID() error = %v", err)
+	}
+	defer rows.Close()
+
+	var tasks []domain.Task
+	for rows.Next() {
+		var task domain.Task
+		err := rows.Scan(
+			&task.ID,
+			&task.ColumnID,
+			&task.Name,
+			&task.Description,
+			&task.Position,
+			&task.CreatedAt,
+			&task.UpdatedAt,
+		)
+		if err != nil {
+			t.Fatalf("Task row Scan() error = %v", err)
+		}
+
+		tasks = append(tasks, task)
+	}
+
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err() error = %v", err)
+	}
+
+	return tasks
+}
+
 func insertFixedUserAndBoard(t *testing.T, pool *pgxpool.Pool) domain.Board {
 	t.Helper()
 
@@ -190,6 +288,16 @@ func insertFixedUserAndBoard(t *testing.T, pool *pgxpool.Pool) domain.Board {
 	InsertBoard(t, pool, &board)
 
 	return board
+}
+
+func insertFixedUserBoardAndColumn(t *testing.T, pool *pgxpool.Pool) (domain.Board, domain.Column) {
+	t.Helper()
+
+	board := insertFixedUserAndBoard(t, pool)
+	column := testutil.ValidColumn(board.ID)
+	InsertColumn(t, pool, &column)
+
+	return board, column
 }
 
 func mustColumnPosition(t *testing.T, n int64) domain.ColumnPosition {
@@ -203,6 +311,17 @@ func mustColumnPosition(t *testing.T, n int64) domain.ColumnPosition {
 	return p
 }
 
+func mustTaskPosition(t *testing.T, n int64) domain.TaskPosition {
+	t.Helper()
+
+	p, err := domain.NewTaskPosition(n)
+	if err != nil {
+		t.Fatalf("NewTaskPosition(%d): %v", n, err)
+	}
+
+	return p
+}
+
 func assertColumnIDAndPosition(t *testing.T, col *domain.Column, wantID domain.ColumnID, wantPos int64) {
 	t.Helper()
 
@@ -211,6 +330,17 @@ func assertColumnIDAndPosition(t *testing.T, col *domain.Column, wantID domain.C
 	}
 	if col.Position.Int64() != wantPos {
 		t.Errorf("got position %d, want %d", col.Position.Int64(), wantPos)
+	}
+}
+
+func assertTaskIDAndPosition(t *testing.T, task *domain.Task, wantID domain.TaskID, wantPos int64) {
+	t.Helper()
+
+	if task.ID != wantID {
+		t.Errorf("got id %q, want %q", task.ID, wantID)
+	}
+	if task.Position.Int64() != wantPos {
+		t.Errorf("got position %d, want %d", task.Position.Int64(), wantPos)
 	}
 }
 

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -19,20 +19,21 @@ func NewPgTask(pool *pgxpool.Pool) *PgTask {
 	return &PgTask{pool: pool}
 }
 
-func lockTaskColumns(
+// LockTaskColumns acquires FOR UPDATE row locks on the given columns for boardID.
+func LockTaskColumns(
 	ctx context.Context,
 	tx pgx.Tx,
-	boardID domain.BoardID, // To ensure columns are locked in the same board
+	boardID domain.BoardID, // To ensure columns are locked in the same board.
 	columnIDs ...domain.ColumnID,
 ) error {
 	if len(columnIDs) == 0 {
-		return errors.New("BUG: lockTaskColumns called with no columns. Isn't column ID forgotten?")
+		return errors.New("BUG: LockTaskColumns called with no columns. Isn't column ID forgotten?")
 	}
 
 	seen := make(map[domain.ColumnID]struct{}, len(columnIDs))
 	for _, columnID := range columnIDs {
 		if _, ok := seen[columnID]; ok {
-			return errors.New("BUG: lockTaskColumns called so it locks the same column multiple times")
+			return errors.New("BUG: LockTaskColumns called so it locks the same column multiple times")
 		}
 		seen[columnID] = struct{}{}
 	}
@@ -310,9 +311,9 @@ func (r *PgTask) Move(
 
 	// 1. Lock affected columns so concurrent operations can't interrupt the move.
 	if sameColumn {
-		err = lockTaskColumns(ctx, tx, boardID, currentColumnID)
+		err = LockTaskColumns(ctx, tx, boardID, currentColumnID)
 	} else {
-		err = lockTaskColumns(ctx, tx, boardID, currentColumnID, targetColumnID)
+		err = LockTaskColumns(ctx, tx, boardID, currentColumnID, targetColumnID)
 	}
 	if err != nil {
 		if errors.Is(err, ErrRowNotFound) {
@@ -458,7 +459,7 @@ func (r *PgTask) Delete(
 	}()
 
 	// 1. Lock affected columns so concurrent operations can't interrupt the delete.
-	err = lockTaskColumns(ctx, tx, boardID, columnID)
+	err = LockTaskColumns(ctx, tx, boardID, columnID)
 	if err != nil {
 		if errors.Is(err, ErrRowNotFound) {
 			return ErrRowNotFound

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -19,6 +19,65 @@ func NewPgTask(pool *pgxpool.Pool) *PgTask {
 	return &PgTask{pool: pool}
 }
 
+func lockTaskColumns(
+	ctx context.Context,
+	tx pgx.Tx,
+	boardID domain.BoardID, // To ensure columns are locked in the same board
+	columnIDs ...domain.ColumnID,
+) error {
+	if len(columnIDs) == 0 {
+		return errors.New("BUG: lockTaskColumns called with no columns. Isn't column ID forgotten?")
+	}
+
+	seen := make(map[domain.ColumnID]struct{}, len(columnIDs))
+	for _, columnID := range columnIDs {
+		if _, ok := seen[columnID]; ok {
+			return errors.New("BUG: lockTaskColumns called so it locks the same column multiple times")
+		}
+		seen[columnID] = struct{}{}
+	}
+
+	// Deadlock protection in case same ids are passed in a different order:
+	// if T1 locks A and then waits for B, while T2 already locked B and waits for A,
+	// PostgreSQL will detect a deadlock and abort one transaction. Ordering makes all
+	// callers acquire row locks in the same order.
+	const lockColumnsQuery = `
+		SELECT id
+		FROM columns
+		WHERE board_id = @board_id
+		  AND id = ANY(@column_ids)
+		ORDER BY id
+		FOR UPDATE`
+
+	rows, err := tx.Query(ctx, lockColumnsQuery, pgx.NamedArgs{
+		"board_id":   boardID,
+		"column_ids": columnIDs,
+	})
+	if err != nil {
+		return fmt.Errorf("lock task columns: %w", err)
+	}
+	defer rows.Close()
+
+	locked := 0
+	for rows.Next() {
+		var columnID domain.ColumnID
+		if err = rows.Scan(&columnID); err != nil {
+			return fmt.Errorf("failed to scan locked column row: %w", err)
+		}
+		locked++
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return fmt.Errorf("lock task columns rows final error: %w", err)
+	}
+	if locked != len(columnIDs) {
+		return ErrRowNotFound
+	}
+
+	return nil
+}
+
 func (r *PgTask) Create(
 	ctx context.Context,
 	columnID domain.ColumnID,
@@ -174,16 +233,7 @@ func (r *PgTask) Move(
 	targetPosition domain.TaskPosition,
 ) (domain.ColumnID, domain.TaskPosition, error) {
 	const (
-		// SET position order is not guaranteed, so we disable uniqueness constraint for this transaction.
-
-		// 1. Lock the board row so no concurrent operation can reorder tasks in any of its columns.
-		lockBoardQuery = `
-		SELECT 1
-		FROM boards
-		WHERE id = @board_id
-		FOR UPDATE`
-
-		// 2. Defer the unique constraint until COMMIT for this transaction only.
+		// 2. SET position order is not guaranteed, so we disable uniqueness constraint for this transaction.
 		deferPositionConstraintQuery = `
 		SET CONSTRAINTS tasks_column_id_position_key DEFERRED`
 
@@ -256,15 +306,19 @@ func (r *PgTask) Move(
 		_ = tx.Rollback(ctx)
 	}()
 
-	var locked int
-	err = tx.QueryRow(ctx, lockBoardQuery, pgx.NamedArgs{
-		"board_id": boardID,
-	}).Scan(&locked)
+	sameColumn := currentColumnID == targetColumnID
+
+	// 1. Lock affected columns so concurrent operations can't interrupt the move.
+	if sameColumn {
+		err = lockTaskColumns(ctx, tx, boardID, currentColumnID)
+	} else {
+		err = lockTaskColumns(ctx, tx, boardID, currentColumnID, targetColumnID)
+	}
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, ErrRowNotFound) {
 			return domain.ColumnID{}, domain.TaskPosition{}, ErrRowNotFound
 		}
-		return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move lock board: %v: %w", err, ErrInternal)
+		return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move lock columns: %v: %w", err, ErrInternal)
 	}
 
 	_, err = tx.Exec(ctx, deferPositionConstraintQuery)
@@ -285,7 +339,6 @@ func (r *PgTask) Move(
 	}
 
 	targetPositionInt := targetPosition.Int64()
-	sameColumn := currentColumnID == targetColumnID
 
 	var targetTasksCount int64
 	err = tx.QueryRow(ctx, countTargetTasksQuery, pgx.NamedArgs{
@@ -377,13 +430,6 @@ func (r *PgTask) Delete(
 	taskID domain.TaskID,
 ) error {
 	const (
-		// 1. Lock the board row so no concurrent operation can reorder tasks in the same column.
-		lockBoardQuery = `
-		SELECT 1
-		FROM boards
-		WHERE id = @board_id
-		FOR UPDATE`
-
 		// 2. Defer the unique constraint until COMMIT for this transaction only.
 		deferPositionConstraintQuery = `
 		SET CONSTRAINTS tasks_column_id_position_key DEFERRED`
@@ -411,15 +457,13 @@ func (r *PgTask) Delete(
 		_ = tx.Rollback(ctx)
 	}()
 
-	var locked int
-	err = tx.QueryRow(ctx, lockBoardQuery, pgx.NamedArgs{
-		"board_id": boardID,
-	}).Scan(&locked)
+	// 1. Lock affected columns so concurrent operations can't interrupt the delete.
+	err = lockTaskColumns(ctx, tx, boardID, columnID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, ErrRowNotFound) {
 			return ErrRowNotFound
 		}
-		return fmt.Errorf("task repo: delete lock board: %v: %w", err, ErrInternal)
+		return fmt.Errorf("task repo: delete lock column: %v: %w", err, ErrInternal)
 	}
 
 	_, err = tx.Exec(ctx, deferPositionConstraintQuery)

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -1,0 +1,456 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"goroutine/internal/domain"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type PgTask struct {
+	pool *pgxpool.Pool
+}
+
+func NewPgTask(pool *pgxpool.Pool) *PgTask {
+	return &PgTask{pool: pool}
+}
+
+func (r *PgTask) Create(
+	ctx context.Context,
+	columnID domain.ColumnID,
+	name domain.TaskName,
+	description domain.TaskDescription,
+) (domain.Task, error) {
+	const query = `
+		WITH column_lock AS (
+			SELECT id
+			FROM columns
+			WHERE id = $1
+			FOR UPDATE
+		), next_pos AS (
+			SELECT COALESCE(MAX(position), 0) + 1 AS position
+			FROM tasks
+			WHERE column_id = $1
+		), inserted AS (
+			INSERT INTO tasks (column_id, name, description, position)
+			SELECT $1, $2, $3, next_pos.position
+			FROM column_lock, next_pos
+			RETURNING id, column_id, name, description, position, created_at, updated_at
+		)
+		SELECT id, column_id, name, description, position, created_at, updated_at
+		FROM inserted`
+
+	var task domain.Task
+	err := r.pool.QueryRow(ctx, query, columnID, name, description).Scan(
+		&task.ID,
+		&task.ColumnID,
+		&task.Name,
+		&task.Description,
+		&task.Position,
+		&task.CreatedAt,
+		&task.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.Task{}, ErrRowNotFound
+		}
+		return domain.Task{}, fmt.Errorf("task repo: create: %v: %w", err, ErrInternal)
+	}
+
+	return task, nil
+}
+
+func (r *PgTask) ListByColumnID(ctx context.Context, columnID domain.ColumnID) ([]domain.Task, error) {
+	const query = `
+		SELECT id, column_id, name, description, position, created_at, updated_at
+		FROM tasks
+		WHERE column_id = $1
+		ORDER BY position ASC`
+
+	rows, err := r.pool.Query(ctx, query, columnID)
+	if err != nil {
+		return nil, fmt.Errorf("task repo: list: %v: %w", err, ErrInternal)
+	}
+	defer rows.Close()
+
+	var result []domain.Task
+	for rows.Next() {
+		var task domain.Task
+		err := rows.Scan(
+			&task.ID,
+			&task.ColumnID,
+			&task.Name,
+			&task.Description,
+			&task.Position,
+			&task.CreatedAt,
+			&task.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("task repo: list: scan: %v: %w", err, ErrInternal)
+		}
+		result = append(result, task)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("task repo: list: rows final error: %v: %w", err, ErrInternal)
+	}
+
+	return result, nil
+}
+
+func (r *PgTask) GetByID(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+	const query = `
+		SELECT id, column_id, name, description, position, created_at, updated_at
+		FROM tasks
+		WHERE id = $1`
+
+	var task domain.Task
+	err := r.pool.QueryRow(ctx, query, taskID).Scan(
+		&task.ID,
+		&task.ColumnID,
+		&task.Name,
+		&task.Description,
+		&task.Position,
+		&task.CreatedAt,
+		&task.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.Task{}, ErrRowNotFound
+		}
+		return domain.Task{}, fmt.Errorf("task repo: get by id: %v: %w", err, ErrInternal)
+	}
+
+	return task, nil
+}
+
+func (r *PgTask) UpdateByID(
+	ctx context.Context,
+	columnID domain.ColumnID,
+	taskID domain.TaskID,
+	name *domain.TaskName,
+	description *domain.TaskDescription,
+) (domain.Task, error) {
+	const query = `
+		UPDATE tasks
+		SET
+			name = COALESCE($3, name),
+			description = COALESCE($4, description),
+			updated_at = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
+		WHERE column_id = $1
+		  AND id = $2
+		RETURNING id, column_id, name, description, position, created_at, updated_at`
+
+	var task domain.Task
+	err := r.pool.QueryRow(ctx, query, columnID, taskID, name, description).Scan(
+		&task.ID,
+		&task.ColumnID,
+		&task.Name,
+		&task.Description,
+		&task.Position,
+		&task.CreatedAt,
+		&task.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.Task{}, ErrRowNotFound
+		}
+		return domain.Task{}, fmt.Errorf("task repo: update by id: %v: %w", err, ErrInternal)
+	}
+
+	return task, nil
+}
+
+func (r *PgTask) Move(
+	ctx context.Context,
+	boardID domain.BoardID,
+	currentColumnID domain.ColumnID,
+	taskID domain.TaskID,
+	targetColumnID domain.ColumnID,
+	targetPosition domain.TaskPosition,
+) (domain.ColumnID, domain.TaskPosition, error) {
+	const (
+		// SET position order is not guaranteed, so we disable uniqueness constraint for this transaction.
+
+		// 1. Lock the board row so no concurrent operation can reorder tasks in any of its columns.
+		lockBoardQuery = `
+		SELECT 1
+		FROM boards
+		WHERE id = @board_id
+		FOR UPDATE`
+
+		// 2. Defer the unique constraint until COMMIT for this transaction only.
+		deferPositionConstraintQuery = `
+		SET CONSTRAINTS tasks_column_id_position_key DEFERRED`
+
+		// 3. Read the current position of the task we are moving in its source column.
+		getCurrentPositionQuery = `
+		SELECT position
+		FROM tasks
+		WHERE column_id = @current_column_id
+		  AND id = @task_id`
+
+		// 4. Read how many tasks the target column currently has to validate targetPosition.
+		countTargetTasksQuery = `
+		SELECT COUNT(*)
+		FROM tasks
+		WHERE column_id = @target_column_id`
+
+		// 5a. Same column, moving down: shift neighbors from (current, target] one slot up.
+		//     Example: moving 2 -> 5 means 3,4,5 become 2,3,4.
+		moveNeighborsDownQuery = `
+		UPDATE tasks
+		SET position = position - 1
+		WHERE column_id = @current_column_id
+		  AND position > @current_position
+		  AND position <= @target_position`
+
+		// 5b. Same column, moving up: shift neighbors from [target, current) one slot down.
+		//     Example: moving 5 -> 2 means 2,3,4 become 3,4,5.
+		moveNeighborsUpQuery = `
+		UPDATE tasks
+		SET position = position + 1
+		WHERE column_id = @current_column_id
+		  AND position >= @target_position
+		  AND position < @current_position`
+
+		// 5c. Cross-column compaction of the source column: shift everything below the
+		//     moved task one slot up to close the gap.
+		compactSourceQuery = `
+		UPDATE tasks
+		SET position = position - 1
+		WHERE column_id = @current_column_id
+		  AND position > @current_position`
+
+		// 5d. Cross-column slot opening in the target column: shift positions >= target
+		//     one slot down to make room.
+		openTargetSlotQuery = `
+		UPDATE tasks
+		SET position = position + 1
+		WHERE column_id = @target_column_id
+		  AND position >= @target_position`
+
+		// 6a. Same-column move: place the task at the target position.
+		moveTaskWithinColumnQuery = `
+		UPDATE tasks
+		SET position = @target_position
+		WHERE id = @task_id`
+
+		// 6b. Cross-column move: switch column_id and place the task at the target position.
+		moveTaskAcrossColumnsQuery = `
+		UPDATE tasks
+		SET column_id = @target_column_id,
+		    position = @target_position
+		WHERE id = @task_id`
+	)
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move begin tx: %v: %w", err, ErrInternal)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	var locked int
+	err = tx.QueryRow(ctx, lockBoardQuery, pgx.NamedArgs{
+		"board_id": boardID,
+	}).Scan(&locked)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.ColumnID{}, domain.TaskPosition{}, ErrRowNotFound
+		}
+		return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move lock board: %v: %w", err, ErrInternal)
+	}
+
+	_, err = tx.Exec(ctx, deferPositionConstraintQuery)
+	if err != nil {
+		return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move defer position constraint: %v: %w", err, ErrInternal)
+	}
+
+	var currentPosition int64
+	err = tx.QueryRow(ctx, getCurrentPositionQuery, pgx.NamedArgs{
+		"current_column_id": currentColumnID,
+		"task_id":           taskID,
+	}).Scan(&currentPosition)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.ColumnID{}, domain.TaskPosition{}, ErrRowNotFound
+		}
+		return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move get current position: %v: %w", err, ErrInternal)
+	}
+
+	targetPositionInt := targetPosition.Int64()
+	sameColumn := currentColumnID == targetColumnID
+
+	var targetTasksCount int64
+	err = tx.QueryRow(ctx, countTargetTasksQuery, pgx.NamedArgs{
+		"target_column_id": targetColumnID,
+	}).Scan(&targetTasksCount)
+	if err != nil {
+		return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move count target tasks: %v: %w", err, ErrInternal)
+	}
+
+	if sameColumn {
+		// In the same column, moving the task does not grow the column, so the
+		// upper bound is the current task count.
+		if targetPositionInt > targetTasksCount {
+			return domain.ColumnID{}, domain.TaskPosition{}, ErrIndexOutOfBounds
+		}
+		if targetPositionInt == currentPosition {
+			return currentColumnID, targetPosition, nil
+		}
+
+		moveNeighborsArgs := pgx.NamedArgs{
+			"current_column_id": currentColumnID,
+			"current_position":  currentPosition,
+			"target_position":   targetPositionInt,
+		}
+		if currentPosition < targetPositionInt {
+			_, err = tx.Exec(ctx, moveNeighborsDownQuery, moveNeighborsArgs)
+			if err != nil {
+				return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move neighbors down: %v: %w", err, ErrInternal)
+			}
+		} else {
+			_, err = tx.Exec(ctx, moveNeighborsUpQuery, moveNeighborsArgs)
+			if err != nil {
+				return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move neighbors up: %v: %w", err, ErrInternal)
+			}
+		}
+
+		_, err = tx.Exec(ctx, moveTaskWithinColumnQuery, pgx.NamedArgs{
+			"task_id":         taskID,
+			"target_position": targetPositionInt,
+		})
+		if err != nil {
+			return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move task within column: %v: %w", err, ErrInternal)
+		}
+	} else {
+		// Across columns the target column grows by one, so an append at
+		// targetTasksCount+1 is valid.
+		if targetPositionInt > targetTasksCount+1 {
+			return domain.ColumnID{}, domain.TaskPosition{}, ErrIndexOutOfBounds
+		}
+
+		_, err = tx.Exec(ctx, compactSourceQuery, pgx.NamedArgs{
+			"current_column_id": currentColumnID,
+			"current_position":  currentPosition,
+		})
+		if err != nil {
+			return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move compact source: %v: %w", err, ErrInternal)
+		}
+
+		_, err = tx.Exec(ctx, openTargetSlotQuery, pgx.NamedArgs{
+			"target_column_id": targetColumnID,
+			"target_position":  targetPositionInt,
+		})
+		if err != nil {
+			return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move open target slot: %v: %w", err, ErrInternal)
+		}
+
+		_, err = tx.Exec(ctx, moveTaskAcrossColumnsQuery, pgx.NamedArgs{
+			"task_id":          taskID,
+			"target_column_id": targetColumnID,
+			"target_position":  targetPositionInt,
+		})
+		if err != nil {
+			return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move task across columns: %v: %w", err, ErrInternal)
+		}
+	}
+
+	err = tx.Commit(ctx)
+	if err != nil {
+		return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task repo: move commit: %v: %w", err, ErrInternal)
+	}
+
+	return targetColumnID, targetPosition, nil
+}
+
+func (r *PgTask) Delete(
+	ctx context.Context,
+	boardID domain.BoardID,
+	columnID domain.ColumnID,
+	taskID domain.TaskID,
+) error {
+	const (
+		// 1. Lock the board row so no concurrent operation can reorder tasks in the same column.
+		lockBoardQuery = `
+		SELECT 1
+		FROM boards
+		WHERE id = @board_id
+		FOR UPDATE`
+
+		// 2. Defer the unique constraint until COMMIT for this transaction only.
+		deferPositionConstraintQuery = `
+		SET CONSTRAINTS tasks_column_id_position_key DEFERRED`
+
+		// 3. Delete the target task and remember its position.
+		deleteTaskQuery = `
+		DELETE FROM tasks
+		WHERE column_id = @column_id
+		  AND id = @task_id
+		RETURNING position`
+
+		// 4. Close the gap left by the deleted task.
+		compactTrailingTasksQuery = `
+		UPDATE tasks
+		SET position = position - 1
+		WHERE column_id = @column_id
+		  AND position > @deleted_position`
+	)
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("task repo: delete begin tx: %v: %w", err, ErrInternal)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	var locked int
+	err = tx.QueryRow(ctx, lockBoardQuery, pgx.NamedArgs{
+		"board_id": boardID,
+	}).Scan(&locked)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrRowNotFound
+		}
+		return fmt.Errorf("task repo: delete lock board: %v: %w", err, ErrInternal)
+	}
+
+	_, err = tx.Exec(ctx, deferPositionConstraintQuery)
+	if err != nil {
+		return fmt.Errorf("task repo: delete defer position constraint: %v: %w", err, ErrInternal)
+	}
+
+	var deletedPosition int64
+	err = tx.QueryRow(ctx, deleteTaskQuery, pgx.NamedArgs{
+		"column_id": columnID,
+		"task_id":   taskID,
+	}).Scan(&deletedPosition)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrRowNotFound
+		}
+		return fmt.Errorf("task repo: delete task: %v: %w", err, ErrInternal)
+	}
+
+	_, err = tx.Exec(ctx, compactTrailingTasksQuery, pgx.NamedArgs{
+		"column_id":        columnID,
+		"deleted_position": deletedPosition,
+	})
+	if err != nil {
+		return fmt.Errorf("task repo: delete compact trailing tasks: %v: %w", err, ErrInternal)
+	}
+
+	err = tx.Commit(ctx)
+	if err != nil {
+		return fmt.Errorf("task repo: delete commit: %v: %w", err, ErrInternal)
+	}
+
+	return nil
+}

--- a/internal/repository/task_test.go
+++ b/internal/repository/task_test.go
@@ -269,7 +269,7 @@ func TestTaskRepository_Move(t *testing.T) {
 		InsertTask(t, pool, &second)
 		InsertTask(t, pool, &third)
 
-		targetPosition := mustTaskPosition(t, 3)
+		targetPosition := testutil.MustTaskPosition(t, 3)
 
 		gotColumn, gotPosition, err := r.Move(context.Background(), board.ID, column.ID, first.ID, column.ID, targetPosition)
 		if err != nil {
@@ -304,7 +304,7 @@ func TestTaskRepository_Move(t *testing.T) {
 		InsertTask(t, pool, &second)
 		InsertTask(t, pool, &third)
 
-		targetPosition := mustTaskPosition(t, 1)
+		targetPosition := testutil.MustTaskPosition(t, 1)
 
 		gotColumn, gotPosition, err := r.Move(context.Background(), board.ID, column.ID, third.ID, column.ID, targetPosition)
 		if err != nil {
@@ -337,7 +337,7 @@ func TestTaskRepository_Move(t *testing.T) {
 		InsertTask(t, pool, &first)
 		InsertTask(t, pool, &second)
 
-		targetPosition := mustTaskPosition(t, 2)
+		targetPosition := testutil.MustTaskPosition(t, 2)
 
 		gotColumn, gotPosition, err := r.Move(context.Background(), board.ID, column.ID, second.ID, column.ID, targetPosition)
 		if err != nil {
@@ -371,7 +371,7 @@ func TestTaskRepository_Move(t *testing.T) {
 		InsertTask(t, pool, &second)
 		InsertTask(t, pool, &third)
 
-		targetPosition := mustTaskPosition(t, 4)
+		targetPosition := testutil.MustTaskPosition(t, 4)
 
 		_, _, err := r.Move(context.Background(), board.ID, column.ID, second.ID, column.ID, targetPosition)
 		if !errors.Is(err, repository.ErrIndexOutOfBounds) {
@@ -407,7 +407,7 @@ func TestTaskRepository_Move(t *testing.T) {
 		InsertTask(t, pool, &b1)
 		InsertTask(t, pool, &b2)
 
-		targetPosition := mustTaskPosition(t, 2)
+		targetPosition := testutil.MustTaskPosition(t, 2)
 
 		gotColumn, gotPosition, err := r.Move(context.Background(), board.ID, columnA.ID, a2.ID, columnB.ID, targetPosition)
 		if err != nil {
@@ -457,7 +457,7 @@ func TestTaskRepository_Move(t *testing.T) {
 		InsertTask(t, pool, &a1)
 		InsertTask(t, pool, &b1)
 
-		targetPosition := mustTaskPosition(t, 2)
+		targetPosition := testutil.MustTaskPosition(t, 2)
 
 		gotColumn, gotPosition, err := r.Move(context.Background(), board.ID, columnA.ID, a1.ID, columnB.ID, targetPosition)
 		if err != nil {
@@ -496,7 +496,7 @@ func TestTaskRepository_Move(t *testing.T) {
 		InsertTask(t, pool, &a1)
 		InsertTask(t, pool, &b1)
 
-		targetPosition := mustTaskPosition(t, 3)
+		targetPosition := testutil.MustTaskPosition(t, 3)
 
 		_, _, err := r.Move(context.Background(), board.ID, columnA.ID, a1.ID, columnB.ID, targetPosition)
 		if !errors.Is(err, repository.ErrIndexOutOfBounds) {
@@ -521,7 +521,7 @@ func TestTaskRepository_Move(t *testing.T) {
 
 		board, column := insertFixedUserBoardAndColumn(t, pool)
 
-		targetPosition := mustTaskPosition(t, 1)
+		targetPosition := testutil.MustTaskPosition(t, 1)
 
 		_, _, err := r.Move(context.Background(), board.ID, column.ID, domain.NewTaskID(), column.ID, targetPosition)
 		assertErrRowNotFound(t, err)
@@ -535,7 +535,7 @@ func TestTaskRepository_Move(t *testing.T) {
 		created := testutil.ValidTask(column.ID)
 		InsertTask(t, pool, &created)
 
-		targetPosition := mustTaskPosition(t, 1)
+		targetPosition := testutil.MustTaskPosition(t, 1)
 
 		_, _, err := r.Move(context.Background(), domain.NewBoardID(), column.ID, created.ID, column.ID, targetPosition)
 		assertErrRowNotFound(t, err)

--- a/internal/repository/task_test.go
+++ b/internal/repository/task_test.go
@@ -1,0 +1,609 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"goroutine/internal/domain"
+	"goroutine/internal/repository"
+	"goroutine/internal/testutil"
+)
+
+func TestTaskRepository_Create(t *testing.T) {
+	pool, r := taskRepoPrelude(t)
+
+	t.Run("Success", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		_, column := insertFixedUserBoardAndColumn(t, pool)
+
+		validTask := testutil.ValidTask(column.ID)
+
+		task, err := r.Create(
+			context.Background(),
+			column.ID,
+			validTask.Name,
+			validTask.Description,
+		)
+		if err != nil {
+			t.Fatalf("Create() error = %v", err)
+		}
+
+		if task.ID.IsEmpty() {
+			t.Error("got empty task id, want generated id")
+		}
+		if task.ColumnID != column.ID {
+			t.Errorf("got columnID %q, want %q", task.ColumnID, column.ID)
+		}
+		if task.Name != validTask.Name {
+			t.Errorf("got name %q, want %q", task.Name, validTask.Name)
+		}
+		if task.Description != validTask.Description {
+			t.Errorf("got description %q, want %q", task.Description, validTask.Description)
+		}
+		if task.Position.Int64() != 1 {
+			t.Errorf("got position %d, want 1", task.Position.Int64())
+		}
+		if task.CreatedAt.IsZero() {
+			t.Errorf("got zero createdAt, want set value")
+		}
+		if task.UpdatedAt.IsZero() {
+			t.Errorf("got zero updatedAt, want set value")
+		}
+		if !task.CreatedAt.Equal(task.UpdatedAt) {
+			t.Errorf("got createdAt=%v updatedAt=%v, want equal", task.CreatedAt, task.UpdatedAt)
+		}
+		AssertTimestampPrecisionAtLeastMillis(t, pool, "tasks", "created_at", "updated_at")
+
+		stored, ok := FindTaskByID(t, pool, task.ID)
+		if !ok {
+			t.Fatalf("created task %q not found in DB", task.ID)
+		}
+		if diff := cmp.Diff(task, stored, testutil.CmpAllowUnexported()); diff != "" {
+			t.Errorf("got stored task mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestTaskRepository_Create_AppendsPosition(t *testing.T) {
+	pool, r := taskRepoPrelude(t)
+
+	testutil.TruncateAllTables(t, pool)
+
+	_, column := insertFixedUserBoardAndColumn(t, pool)
+
+	existing := testutil.ValidTask(column.ID)
+	InsertTask(t, pool, &existing)
+
+	toCreate := testutil.NewValidTask(t, column.ID, "Second", "Second description", 2)
+
+	second, err := r.Create(
+		context.Background(),
+		column.ID,
+		toCreate.Name,
+		toCreate.Description,
+	)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if second.Position.Int64() != 2 {
+		t.Errorf("got second position %d, want 2", second.Position.Int64())
+	}
+}
+
+func TestTaskRepository_ListByColumnID(t *testing.T) {
+	pool, r := taskRepoPrelude(t)
+
+	t.Run("Success empty", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		_, column := insertFixedUserBoardAndColumn(t, pool)
+
+		tasks, err := r.ListByColumnID(context.Background(), column.ID)
+		if err != nil {
+			t.Fatalf("ListByColumnID() error = %v", err)
+		}
+		if len(tasks) != 0 {
+			t.Fatalf("got %d tasks, want 0", len(tasks))
+		}
+	})
+
+	t.Run("Success ordered and filtered by column", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		board, columnA := insertFixedUserBoardAndColumn(t, pool)
+		columnB := testutil.NewValidColumn(t, board.ID, "In Progress", 2)
+		InsertColumn(t, pool, &columnB)
+
+		first := testutil.ValidTask(columnA.ID)
+		second := testutil.NewValidTask(t, columnA.ID, "Second", "second", 2)
+		otherColumnTask := testutil.NewValidTask(t, columnB.ID, "Other", "other", 1)
+
+		InsertTask(t, pool, &first)
+		InsertTask(t, pool, &second)
+		InsertTask(t, pool, &otherColumnTask)
+
+		got, err := r.ListByColumnID(context.Background(), columnA.ID)
+		if err != nil {
+			t.Fatalf("ListByColumnID() error = %v", err)
+		}
+
+		want := []domain.Task{first, second}
+		if diff := cmp.Diff(want, got, testutil.CmpAllowUnexported()); diff != "" {
+			t.Errorf("ListByColumnID() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestTaskRepository_GetByID(t *testing.T) {
+	pool, r := taskRepoPrelude(t)
+
+	t.Run("Success", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		_, column := insertFixedUserBoardAndColumn(t, pool)
+
+		created := testutil.ValidTask(column.ID)
+		InsertTask(t, pool, &created)
+
+		got, err := r.GetByID(context.Background(), created.ID)
+		if err != nil {
+			t.Fatalf("GetByID() error = %v", err)
+		}
+		if diff := cmp.Diff(created, got, testutil.CmpAllowUnexported()); diff != "" {
+			t.Errorf("GetByID() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("Not found", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		_, err := r.GetByID(context.Background(), domain.NewTaskID())
+		assertErrRowNotFound(t, err)
+	})
+}
+
+func TestTaskRepository_UpdateByID(t *testing.T) {
+	pool, r := taskRepoPrelude(t)
+
+	assertUpdatedTask := func(t *testing.T, got domain.Task, want domain.Task) {
+		t.Helper()
+
+		if got.ID != want.ID {
+			t.Errorf("got id %q, want %q", got.ID, want.ID)
+		}
+		if got.ColumnID != want.ColumnID {
+			t.Errorf("got columnID %q, want %q", got.ColumnID, want.ColumnID)
+		}
+		if got.Name != want.Name {
+			t.Errorf("got name %q, want %q", got.Name, want.Name)
+		}
+		if got.Description != want.Description {
+			t.Errorf("got description %q, want %q", got.Description, want.Description)
+		}
+		if got.Position != want.Position {
+			t.Errorf("got position %d, want %d", got.Position.Int64(), want.Position.Int64())
+		}
+		if !got.CreatedAt.Truncate(time.Millisecond).Equal(want.CreatedAt.Truncate(time.Millisecond)) {
+			t.Errorf("got createdAt %v, want %v (at millisecond precision)", got.CreatedAt, want.CreatedAt)
+		}
+		if !got.UpdatedAt.After(want.UpdatedAt) {
+			t.Errorf("got updatedAt %v, want after %v", got.UpdatedAt, want.UpdatedAt)
+		}
+		AssertTimestampPrecisionAtLeastMillis(t, pool, "tasks", "created_at", "updated_at")
+
+		stored, ok := FindTaskByID(t, pool, want.ID)
+		if !ok {
+			t.Fatalf("updated task %q not found in DB", want.ID)
+		}
+		if diff := cmp.Diff(got, stored, testutil.CmpAllowUnexported()); diff != "" {
+			t.Errorf("got stored task mismatch (-want +got):\n%s", diff)
+		}
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		_, column := insertFixedUserBoardAndColumn(t, pool)
+
+		created := testutil.ValidTask(column.ID)
+		createdAtBeforeUpdate := time.Now().UTC()
+		updatedAtBeforeUpdate := createdAtBeforeUpdate
+		created.CreatedAt = createdAtBeforeUpdate
+		created.UpdatedAt = updatedAtBeforeUpdate
+		InsertTask(t, pool, &created)
+
+		want := testutil.UpdateValidTask(t, &created, "Renamed", "Renamed description", testutil.FixedTime5mFromNow())
+		updated, err := r.UpdateByID(context.Background(), column.ID, created.ID, &want.Name, &want.Description)
+		if err != nil {
+			t.Fatalf("UpdateByID() error = %v", err)
+		}
+
+		assertUpdatedTask(t, updated, want)
+	})
+
+	t.Run("Not found by task id", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		_, column := insertFixedUserBoardAndColumn(t, pool)
+
+		updatedName, _ := domain.NewTaskName("Renamed")
+		_, err := r.UpdateByID(context.Background(), column.ID, domain.NewTaskID(), &updatedName, nil)
+		assertErrRowNotFound(t, err)
+	})
+
+	t.Run("Not found by column id", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		_, column := insertFixedUserBoardAndColumn(t, pool)
+
+		created := testutil.ValidTask(column.ID)
+		InsertTask(t, pool, &created)
+
+		want := testutil.UpdateValidTask(t, &created, "Renamed", "Renamed description", testutil.FixedTime5mFromNow())
+		_, err := r.UpdateByID(context.Background(), domain.NewColumnID(), created.ID, &want.Name, &want.Description)
+		assertErrRowNotFound(t, err)
+	})
+}
+
+func TestTaskRepository_Move(t *testing.T) {
+	pool, r := taskRepoPrelude(t)
+
+	t.Run("Success move down within column", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		board, column := insertFixedUserBoardAndColumn(t, pool)
+
+		first := testutil.ValidTask(column.ID)
+		second := testutil.NewValidTask(t, column.ID, "Second", "second", 2)
+		third := testutil.NewValidTask(t, column.ID, "Third", "third", 3)
+
+		InsertTask(t, pool, &first)
+		InsertTask(t, pool, &second)
+		InsertTask(t, pool, &third)
+
+		targetPosition := mustTaskPosition(t, 3)
+
+		gotColumn, gotPosition, err := r.Move(context.Background(), board.ID, column.ID, first.ID, column.ID, targetPosition)
+		if err != nil {
+			t.Fatalf("Move() error = %v", err)
+		}
+		if gotColumn != column.ID {
+			t.Fatalf("Move() column = %v, want %v", gotColumn, column.ID)
+		}
+		if gotPosition != targetPosition {
+			t.Fatalf("Move() position = %v, want %v", gotPosition, targetPosition)
+		}
+
+		got := ListTasksByColumnID(t, pool, column.ID)
+		if len(got) != 3 {
+			t.Fatalf("got %d tasks after move, want 3", len(got))
+		}
+		assertTaskIDAndPosition(t, &got[0], second.ID, 1)
+		assertTaskIDAndPosition(t, &got[1], third.ID, 2)
+		assertTaskIDAndPosition(t, &got[2], first.ID, 3)
+	})
+
+	t.Run("Success move up within column", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		board, column := insertFixedUserBoardAndColumn(t, pool)
+
+		first := testutil.ValidTask(column.ID)
+		second := testutil.NewValidTask(t, column.ID, "Second", "second", 2)
+		third := testutil.NewValidTask(t, column.ID, "Third", "third", 3)
+
+		InsertTask(t, pool, &first)
+		InsertTask(t, pool, &second)
+		InsertTask(t, pool, &third)
+
+		targetPosition := mustTaskPosition(t, 1)
+
+		gotColumn, gotPosition, err := r.Move(context.Background(), board.ID, column.ID, third.ID, column.ID, targetPosition)
+		if err != nil {
+			t.Fatalf("Move() error = %v", err)
+		}
+		if gotColumn != column.ID {
+			t.Fatalf("Move() column = %v, want %v", gotColumn, column.ID)
+		}
+		if gotPosition != targetPosition {
+			t.Fatalf("Move() position = %v, want %v", gotPosition, targetPosition)
+		}
+
+		got := ListTasksByColumnID(t, pool, column.ID)
+		if len(got) != 3 {
+			t.Fatalf("got %d tasks after move, want 3", len(got))
+		}
+		assertTaskIDAndPosition(t, &got[0], third.ID, 1)
+		assertTaskIDAndPosition(t, &got[1], first.ID, 2)
+		assertTaskIDAndPosition(t, &got[2], second.ID, 3)
+	})
+
+	t.Run("Success no-op", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		board, column := insertFixedUserBoardAndColumn(t, pool)
+
+		first := testutil.ValidTask(column.ID)
+		second := testutil.NewValidTask(t, column.ID, "Second", "second", 2)
+
+		InsertTask(t, pool, &first)
+		InsertTask(t, pool, &second)
+
+		targetPosition := mustTaskPosition(t, 2)
+
+		gotColumn, gotPosition, err := r.Move(context.Background(), board.ID, column.ID, second.ID, column.ID, targetPosition)
+		if err != nil {
+			t.Fatalf("Move() error = %v", err)
+		}
+		if gotColumn != column.ID {
+			t.Fatalf("Move() column = %v, want %v", gotColumn, column.ID)
+		}
+		if gotPosition != targetPosition {
+			t.Fatalf("Move() position = %v, want %v", gotPosition, targetPosition)
+		}
+
+		got := ListTasksByColumnID(t, pool, column.ID)
+		if len(got) != 2 {
+			t.Fatalf("got %d tasks after no-op move, want 2", len(got))
+		}
+		assertTaskIDAndPosition(t, &got[0], first.ID, 1)
+		assertTaskIDAndPosition(t, &got[1], second.ID, 2)
+	})
+
+	t.Run("Index out of bounds within column", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		board, column := insertFixedUserBoardAndColumn(t, pool)
+
+		first := testutil.ValidTask(column.ID)
+		second := testutil.NewValidTask(t, column.ID, "Second", "second", 2)
+		third := testutil.NewValidTask(t, column.ID, "Third", "third", 3)
+
+		InsertTask(t, pool, &first)
+		InsertTask(t, pool, &second)
+		InsertTask(t, pool, &third)
+
+		targetPosition := mustTaskPosition(t, 4)
+
+		_, _, err := r.Move(context.Background(), board.ID, column.ID, second.ID, column.ID, targetPosition)
+		if !errors.Is(err, repository.ErrIndexOutOfBounds) {
+			t.Fatalf("Move() error = %v, want ErrIndexOutOfBounds", err)
+		}
+
+		got := ListTasksByColumnID(t, pool, column.ID)
+		if len(got) != 3 {
+			t.Fatalf("got %d tasks after failed move, want 3", len(got))
+		}
+		assertTaskIDAndPosition(t, &got[0], first.ID, 1)
+		assertTaskIDAndPosition(t, &got[1], second.ID, 2)
+		assertTaskIDAndPosition(t, &got[2], third.ID, 3)
+	})
+
+	t.Run("Success move across columns into middle", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		board, columnA := insertFixedUserBoardAndColumn(t, pool)
+		columnB := testutil.NewValidColumn(t, board.ID, "In Progress", 2)
+		InsertColumn(t, pool, &columnB)
+
+		a1 := testutil.ValidTask(columnA.ID)
+		a2 := testutil.NewValidTask(t, columnA.ID, "A2", "a2", 2)
+		a3 := testutil.NewValidTask(t, columnA.ID, "A3", "a3", 3)
+
+		b1 := testutil.NewValidTask(t, columnB.ID, "B1", "b1", 1)
+		b2 := testutil.NewValidTask(t, columnB.ID, "B2", "b2", 2)
+
+		InsertTask(t, pool, &a1)
+		InsertTask(t, pool, &a2)
+		InsertTask(t, pool, &a3)
+		InsertTask(t, pool, &b1)
+		InsertTask(t, pool, &b2)
+
+		targetPosition := mustTaskPosition(t, 2)
+
+		gotColumn, gotPosition, err := r.Move(context.Background(), board.ID, columnA.ID, a2.ID, columnB.ID, targetPosition)
+		if err != nil {
+			t.Fatalf("Move() error = %v", err)
+		}
+		if gotColumn != columnB.ID {
+			t.Fatalf("Move() column = %v, want %v", gotColumn, columnB.ID)
+		}
+		if gotPosition != targetPosition {
+			t.Fatalf("Move() position = %v, want %v", gotPosition, targetPosition)
+		}
+
+		gotA := ListTasksByColumnID(t, pool, columnA.ID)
+		if len(gotA) != 2 {
+			t.Fatalf("got %d tasks in source column after move, want 2", len(gotA))
+		}
+		assertTaskIDAndPosition(t, &gotA[0], a1.ID, 1)
+		assertTaskIDAndPosition(t, &gotA[1], a3.ID, 2)
+
+		gotB := ListTasksByColumnID(t, pool, columnB.ID)
+		if len(gotB) != 3 {
+			t.Fatalf("got %d tasks in target column after move, want 3", len(gotB))
+		}
+		assertTaskIDAndPosition(t, &gotB[0], b1.ID, 1)
+		assertTaskIDAndPosition(t, &gotB[1], a2.ID, 2)
+		assertTaskIDAndPosition(t, &gotB[2], b2.ID, 3)
+
+		movedTask, ok := FindTaskByID(t, pool, a2.ID)
+		if !ok {
+			t.Fatalf("moved task %q not found in DB", a2.ID)
+		}
+		if movedTask.ColumnID != columnB.ID {
+			t.Errorf("got moved columnID %q, want %q", movedTask.ColumnID, columnB.ID)
+		}
+	})
+
+	t.Run("Success move across columns to append", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		board, columnA := insertFixedUserBoardAndColumn(t, pool)
+		columnB := testutil.NewValidColumn(t, board.ID, "Done", 2)
+		InsertColumn(t, pool, &columnB)
+
+		a1 := testutil.ValidTask(columnA.ID)
+		b1 := testutil.NewValidTask(t, columnB.ID, "B1", "b1", 1)
+
+		InsertTask(t, pool, &a1)
+		InsertTask(t, pool, &b1)
+
+		targetPosition := mustTaskPosition(t, 2)
+
+		gotColumn, gotPosition, err := r.Move(context.Background(), board.ID, columnA.ID, a1.ID, columnB.ID, targetPosition)
+		if err != nil {
+			t.Fatalf("Move() error = %v", err)
+		}
+		if gotColumn != columnB.ID {
+			t.Fatalf("Move() column = %v, want %v", gotColumn, columnB.ID)
+		}
+		if gotPosition != targetPosition {
+			t.Fatalf("Move() position = %v, want %v", gotPosition, targetPosition)
+		}
+
+		gotA := ListTasksByColumnID(t, pool, columnA.ID)
+		if len(gotA) != 0 {
+			t.Fatalf("got %d tasks in source column after move, want 0", len(gotA))
+		}
+
+		gotB := ListTasksByColumnID(t, pool, columnB.ID)
+		if len(gotB) != 2 {
+			t.Fatalf("got %d tasks in target column after move, want 2", len(gotB))
+		}
+		assertTaskIDAndPosition(t, &gotB[0], b1.ID, 1)
+		assertTaskIDAndPosition(t, &gotB[1], a1.ID, 2)
+	})
+
+	t.Run("Index out of bounds across columns", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		board, columnA := insertFixedUserBoardAndColumn(t, pool)
+		columnB := testutil.NewValidColumn(t, board.ID, "Done", 2)
+		InsertColumn(t, pool, &columnB)
+
+		a1 := testutil.ValidTask(columnA.ID)
+		b1 := testutil.NewValidTask(t, columnB.ID, "B1", "b1", 1)
+
+		InsertTask(t, pool, &a1)
+		InsertTask(t, pool, &b1)
+
+		targetPosition := mustTaskPosition(t, 3)
+
+		_, _, err := r.Move(context.Background(), board.ID, columnA.ID, a1.ID, columnB.ID, targetPosition)
+		if !errors.Is(err, repository.ErrIndexOutOfBounds) {
+			t.Fatalf("Move() error = %v, want ErrIndexOutOfBounds", err)
+		}
+
+		gotA := ListTasksByColumnID(t, pool, columnA.ID)
+		if len(gotA) != 1 {
+			t.Fatalf("got %d tasks in source column after failed move, want 1", len(gotA))
+		}
+		assertTaskIDAndPosition(t, &gotA[0], a1.ID, 1)
+
+		gotB := ListTasksByColumnID(t, pool, columnB.ID)
+		if len(gotB) != 1 {
+			t.Fatalf("got %d tasks in target column after failed move, want 1", len(gotB))
+		}
+		assertTaskIDAndPosition(t, &gotB[0], b1.ID, 1)
+	})
+
+	t.Run("Not found by task id", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		board, column := insertFixedUserBoardAndColumn(t, pool)
+
+		targetPosition := mustTaskPosition(t, 1)
+
+		_, _, err := r.Move(context.Background(), board.ID, column.ID, domain.NewTaskID(), column.ID, targetPosition)
+		assertErrRowNotFound(t, err)
+	})
+
+	t.Run("Not found by board id", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		_, column := insertFixedUserBoardAndColumn(t, pool)
+
+		created := testutil.ValidTask(column.ID)
+		InsertTask(t, pool, &created)
+
+		targetPosition := mustTaskPosition(t, 1)
+
+		_, _, err := r.Move(context.Background(), domain.NewBoardID(), column.ID, created.ID, column.ID, targetPosition)
+		assertErrRowNotFound(t, err)
+	})
+}
+
+func TestTaskRepository_Delete(t *testing.T) {
+	pool, r := taskRepoPrelude(t)
+
+	t.Run("Success shift positions", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		board, column := insertFixedUserBoardAndColumn(t, pool)
+
+		first := testutil.ValidTask(column.ID)
+		second := testutil.NewValidTask(t, column.ID, "Second", "second", 2)
+		third := testutil.NewValidTask(t, column.ID, "Third", "third", 3)
+
+		InsertTask(t, pool, &first)
+		InsertTask(t, pool, &second)
+		InsertTask(t, pool, &third)
+
+		err := r.Delete(context.Background(), board.ID, column.ID, second.ID)
+		if err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+
+		got := ListTasksByColumnID(t, pool, column.ID)
+
+		if len(got) != 2 {
+			t.Fatalf("got %d tasks after delete, want 2", len(got))
+		}
+		assertTaskIDAndPosition(t, &got[0], first.ID, 1)
+		assertTaskIDAndPosition(t, &got[1], third.ID, 2)
+
+		_, ok := FindTaskByID(t, pool, second.ID)
+		if ok {
+			t.Error("got deleted task in DB, want absent")
+		}
+	})
+
+	t.Run("Not found by task id", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		board, column := insertFixedUserBoardAndColumn(t, pool)
+
+		err := r.Delete(context.Background(), board.ID, column.ID, domain.NewTaskID())
+		assertErrRowNotFound(t, err)
+	})
+
+	t.Run("Not found by board id", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		_, column := insertFixedUserBoardAndColumn(t, pool)
+
+		created := testutil.ValidTask(column.ID)
+		InsertTask(t, pool, &created)
+
+		err := r.Delete(context.Background(), domain.NewBoardID(), column.ID, created.ID)
+		assertErrRowNotFound(t, err)
+	})
+}
+
+func taskRepoPrelude(t *testing.T) (*pgxpool.Pool, *repository.PgTask) {
+	t.Helper()
+
+	pool := testutil.SetupTestDB(t, "../../migrations")
+	t.Cleanup(func() { pool.Close() })
+
+	return pool, repository.NewPgTask(pool)
+}

--- a/internal/repository/task_test.go
+++ b/internal/repository/task_test.go
@@ -5,10 +5,13 @@ package repository_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"goroutine/internal/domain"
@@ -597,6 +600,86 @@ func TestTaskRepository_Delete(t *testing.T) {
 		err := r.Delete(context.Background(), domain.NewBoardID(), column.ID, created.ID)
 		assertErrRowNotFound(t, err)
 	})
+}
+
+func TestLockTaskColumns_BlocksSecondTransaction(t *testing.T) {
+	pool, _ := taskRepoPrelude(t)
+	testutil.TruncateAllTables(t, pool)
+
+	board, column := insertFixedUserBoardAndColumn(t, pool)
+
+	beginTx := func(id string) pgx.Tx {
+		tx, err := pool.Begin(context.Background())
+		if err != nil {
+			t.Fatalf("pool.Begin() tx%s error = %v", id, err)
+		}
+		return tx
+	}
+
+	setLockTimeoutMs := func(tx pgx.Tx, id string, ms int) {
+		_, err := tx.Exec(context.Background(), fmt.Sprintf(`SET LOCAL lock_timeout = '%dms'`, ms))
+		if err != nil {
+			t.Fatalf("tx%s SET LOCAL lock_timeout error = %v", id, err)
+		}
+	}
+
+	rollbackTx := func(tx pgx.Tx, id string) {
+		err := tx.Rollback(context.Background())
+		if err != nil {
+			t.Fatalf("tx%s Rollback() error = %v", id, err)
+		}
+	}
+
+	lockTaskColumns := func(tx pgx.Tx) error {
+		return repository.LockTaskColumns(context.Background(), tx, board.ID, column.ID)
+	}
+
+	tx1 := beginTx("1")
+
+	// 1. LockTaskColumns runs SELECT ... FOR UPDATE on the columns row for this board/column;
+	//    that row lock blocks any other transaction from locking the same row until tx1 ends.
+	err := lockTaskColumns(tx1)
+	if err != nil {
+		t.Fatalf("LockTaskColumns() tx1 error = %v", err)
+	}
+
+	tx2 := beginTx("2")
+
+	// 2. tx2: the next LockTaskColumns will try the same FOR UPDATE on the same row. While tx1
+	//    still holds the lock, PostgreSQL would wait forever; SET LOCAL lock_timeout limits that
+	//    wait to ~100ms, then the statement fails with a lock timeout instead of hanging the test.
+	setLockTimeoutMs(tx2, "2", 100)
+
+	// 3. tx2 must fail to acquire the same lock while tx1 still holds it.
+	err = lockTaskColumns(tx2)
+	if err == nil {
+		t.Fatal("second LockTaskColumns() unexpectedly succeeded while tx1 still held the lock")
+	}
+
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		t.Fatalf("second LockTaskColumns: want wrapped *pgconn.PgError, got %T: %v", err, err)
+	}
+	if pgErr.Code != "55P03" {
+		t.Fatalf("second LockTaskColumns: want SQLSTATE 55P03 (lock_not_available because of lock timeout), got %v", err)
+	}
+
+	// 4. Roll back tx2 after the lock wait timeout.
+	rollbackTx(tx2, "2")
+	// 5. Roll back tx1 to release the original lock.
+	rollbackTx(tx1, "1")
+
+	// 6. Start tx3 after the lock has been released.
+	tx3 := beginTx("3")
+
+	// 7. tx3 should now acquire the same lock successfully.
+	err = lockTaskColumns(tx3)
+	if err != nil {
+		t.Fatalf("third LockTaskColumns() after release error = %v", err)
+	}
+
+	// 8. Clean up tx3.
+	rollbackTx(tx3, "3")
 }
 
 func taskRepoPrelude(t *testing.T) (*pgxpool.Pool, *repository.PgTask) {

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -6,6 +6,7 @@ var (
 	ErrInternal             = errors.New("internal error happened")
 	ErrBoardNotFound        = errors.New("board not found")
 	ErrColumnNotFound       = errors.New("column not found")
+	ErrTaskNotFound         = errors.New("task not found")
 	ErrIndexOutOfBounds     = errors.New("index out of bounds")
 	ErrUserAlreadyExists    = errors.New("user already exists")
 	ErrInvalidCredentials   = errors.New("invalid email or password")

--- a/internal/service/helpers_test.go
+++ b/internal/service/helpers_test.go
@@ -113,3 +113,65 @@ func (m *MockColumnRepository) Delete(ctx context.Context, boardID domain.BoardI
 	AssertFuncNotNil("ColumnRepository.DeleteFunc", m.DeleteFunc)
 	return m.DeleteFunc(ctx, boardID, columnID)
 }
+
+type MockTaskRepository struct {
+	CreateFunc         func(ctx context.Context, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error)
+	ListByColumnIDFunc func(ctx context.Context, columnID domain.ColumnID) ([]domain.Task, error)
+	GetByIDFunc        func(ctx context.Context, taskID domain.TaskID) (domain.Task, error)
+	UpdateByIDFunc     func(ctx context.Context, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error)
+	MoveFunc           func(ctx context.Context, boardID domain.BoardID, currentColumnID domain.ColumnID, taskID domain.TaskID, targetColumnID domain.ColumnID, targetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error)
+	DeleteFunc         func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error
+}
+
+func (m *MockTaskRepository) Create(
+	ctx context.Context,
+	columnID domain.ColumnID,
+	name domain.TaskName,
+	description domain.TaskDescription,
+) (domain.Task, error) {
+	AssertFuncNotNil("TaskRepository.CreateFunc", m.CreateFunc)
+	return m.CreateFunc(ctx, columnID, name, description)
+}
+
+func (m *MockTaskRepository) ListByColumnID(ctx context.Context, columnID domain.ColumnID) ([]domain.Task, error) {
+	AssertFuncNotNil("TaskRepository.ListByColumnIDFunc", m.ListByColumnIDFunc)
+	return m.ListByColumnIDFunc(ctx, columnID)
+}
+
+func (m *MockTaskRepository) GetByID(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+	AssertFuncNotNil("TaskRepository.GetByIDFunc", m.GetByIDFunc)
+	return m.GetByIDFunc(ctx, taskID)
+}
+
+func (m *MockTaskRepository) UpdateByID(
+	ctx context.Context,
+	columnID domain.ColumnID,
+	taskID domain.TaskID,
+	name *domain.TaskName,
+	description *domain.TaskDescription,
+) (domain.Task, error) {
+	AssertFuncNotNil("TaskRepository.UpdateByIDFunc", m.UpdateByIDFunc)
+	return m.UpdateByIDFunc(ctx, columnID, taskID, name, description)
+}
+
+func (m *MockTaskRepository) Move(
+	ctx context.Context,
+	boardID domain.BoardID,
+	currentColumnID domain.ColumnID,
+	taskID domain.TaskID,
+	targetColumnID domain.ColumnID,
+	targetPosition domain.TaskPosition,
+) (domain.ColumnID, domain.TaskPosition, error) {
+	AssertFuncNotNil("TaskRepository.MoveFunc", m.MoveFunc)
+	return m.MoveFunc(ctx, boardID, currentColumnID, taskID, targetColumnID, targetPosition)
+}
+
+func (m *MockTaskRepository) Delete(
+	ctx context.Context,
+	boardID domain.BoardID,
+	columnID domain.ColumnID,
+	taskID domain.TaskID,
+) error {
+	AssertFuncNotNil("TaskRepository.DeleteFunc", m.DeleteFunc)
+	return m.DeleteFunc(ctx, boardID, columnID, taskID)
+}

--- a/internal/service/task.go
+++ b/internal/service/task.go
@@ -1,0 +1,293 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"goroutine/internal/domain"
+	"goroutine/internal/repository"
+)
+
+type TaskRepository interface {
+	Create(ctx context.Context, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error)
+	ListByColumnID(ctx context.Context, columnID domain.ColumnID) ([]domain.Task, error)
+	GetByID(ctx context.Context, taskID domain.TaskID) (domain.Task, error)
+	UpdateByID(ctx context.Context, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error)
+	Move(ctx context.Context, boardID domain.BoardID, currentColumnID domain.ColumnID, taskID domain.TaskID, targetColumnID domain.ColumnID, targetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error)
+	Delete(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error
+}
+
+type TaskBoardRepository interface {
+	GetByID(ctx context.Context, id domain.BoardID) (domain.Board, error)
+}
+
+type TaskColumnRepository interface {
+	GetByID(ctx context.Context, id domain.ColumnID) (domain.Column, error)
+}
+
+type Task struct {
+	taskRepository   TaskRepository
+	boardRepository  TaskBoardRepository
+	columnRepository TaskColumnRepository
+}
+
+func NewTask(taskRepo TaskRepository, boardRepo TaskBoardRepository, columnRepo TaskColumnRepository) *Task {
+	return &Task{
+		taskRepository:   taskRepo,
+		boardRepository:  boardRepo,
+		columnRepository: columnRepo,
+	}
+}
+
+func (s *Task) Create(
+	ctx context.Context,
+	callerID domain.UserID,
+	boardID domain.BoardID,
+	columnID domain.ColumnID,
+	name domain.TaskName,
+	description domain.TaskDescription,
+) (domain.Task, error) {
+	board, err := s.boardRepository.GetByID(ctx, boardID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return domain.Task{}, ErrColumnNotFound
+		}
+		return domain.Task{}, fmt.Errorf("task service: create get board: %v: %w", err, ErrInternal)
+	}
+	if board.OwnerID != callerID {
+		return domain.Task{}, ErrColumnNotFound
+	}
+
+	column, err := s.columnRepository.GetByID(ctx, columnID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return domain.Task{}, ErrColumnNotFound
+		}
+		return domain.Task{}, fmt.Errorf("task service: create get column: %v: %w", err, ErrInternal)
+	}
+	if column.BoardID != boardID {
+		return domain.Task{}, ErrColumnNotFound
+	}
+
+	task, err := s.taskRepository.Create(ctx, columnID, name, description)
+	if err != nil {
+		return domain.Task{}, fmt.Errorf("task service: create: %v: %w", err, ErrInternal)
+	}
+
+	return task, nil
+}
+
+func (s *Task) List(
+	ctx context.Context,
+	callerID domain.UserID,
+	boardID domain.BoardID,
+	columnID domain.ColumnID,
+) ([]domain.Task, error) {
+	board, err := s.boardRepository.GetByID(ctx, boardID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return nil, ErrColumnNotFound
+		}
+		return nil, fmt.Errorf("task service: list get board: %v: %w", err, ErrInternal)
+	}
+	if board.OwnerID != callerID {
+		return nil, ErrColumnNotFound
+	}
+
+	column, err := s.columnRepository.GetByID(ctx, columnID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return nil, ErrColumnNotFound
+		}
+		return nil, fmt.Errorf("task service: list get column: %v: %w", err, ErrInternal)
+	}
+	if column.BoardID != boardID {
+		return nil, ErrColumnNotFound
+	}
+
+	tasks, err := s.taskRepository.ListByColumnID(ctx, columnID)
+	if err != nil {
+		return nil, fmt.Errorf("task service: list: %v: %w", err, ErrInternal)
+	}
+
+	return tasks, nil
+}
+
+func (s *Task) UpdateByID(
+	ctx context.Context,
+	callerID domain.UserID,
+	boardID domain.BoardID,
+	columnID domain.ColumnID,
+	taskID domain.TaskID,
+	name *domain.TaskName,
+	description *domain.TaskDescription,
+) (domain.Task, error) {
+	board, err := s.boardRepository.GetByID(ctx, boardID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return domain.Task{}, ErrTaskNotFound
+		}
+		return domain.Task{}, fmt.Errorf("task service: update get board: %v: %w", err, ErrInternal)
+	}
+	if board.OwnerID != callerID {
+		return domain.Task{}, ErrTaskNotFound
+	}
+
+	column, err := s.columnRepository.GetByID(ctx, columnID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return domain.Task{}, ErrTaskNotFound
+		}
+		return domain.Task{}, fmt.Errorf("task service: update get column: %v: %w", err, ErrInternal)
+	}
+	if column.BoardID != boardID {
+		return domain.Task{}, ErrTaskNotFound
+	}
+
+	task, err := s.taskRepository.GetByID(ctx, taskID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return domain.Task{}, ErrTaskNotFound
+		}
+		return domain.Task{}, fmt.Errorf("task service: update get task: %v: %w", err, ErrInternal)
+	}
+	if task.ColumnID != columnID {
+		return domain.Task{}, ErrTaskNotFound
+	}
+
+	if name == nil && description == nil {
+		return task, nil
+	}
+
+	updated, err := s.taskRepository.UpdateByID(ctx, columnID, taskID, name, description)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return domain.Task{}, ErrTaskNotFound
+		}
+		return domain.Task{}, fmt.Errorf("task service: update by id: %v: %w", err, ErrInternal)
+	}
+
+	return updated, nil
+}
+
+func (s *Task) Delete(
+	ctx context.Context,
+	callerID domain.UserID,
+	boardID domain.BoardID,
+	columnID domain.ColumnID,
+	taskID domain.TaskID,
+) error {
+	board, err := s.boardRepository.GetByID(ctx, boardID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return ErrTaskNotFound
+		}
+		return fmt.Errorf("task service: delete get board: %v: %w", err, ErrInternal)
+	}
+	if board.OwnerID != callerID {
+		return ErrTaskNotFound
+	}
+
+	column, err := s.columnRepository.GetByID(ctx, columnID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return ErrTaskNotFound
+		}
+		return fmt.Errorf("task service: delete get column: %v: %w", err, ErrInternal)
+	}
+	if column.BoardID != boardID {
+		return ErrTaskNotFound
+	}
+
+	task, err := s.taskRepository.GetByID(ctx, taskID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return ErrTaskNotFound
+		}
+		return fmt.Errorf("task service: delete get task: %v: %w", err, ErrInternal)
+	}
+	if task.ColumnID != columnID {
+		return ErrTaskNotFound
+	}
+
+	err = s.taskRepository.Delete(ctx, boardID, columnID, taskID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return ErrTaskNotFound
+		}
+		return fmt.Errorf("task service: delete: %v: %w", err, ErrInternal)
+	}
+
+	return nil
+}
+
+func (s *Task) Move(
+	ctx context.Context,
+	callerID domain.UserID,
+	boardID domain.BoardID,
+	columnID domain.ColumnID,
+	taskID domain.TaskID,
+	targetColumnID domain.ColumnID,
+	targetPosition domain.TaskPosition,
+) (domain.ColumnID, domain.TaskPosition, error) {
+	board, err := s.boardRepository.GetByID(ctx, boardID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return domain.ColumnID{}, domain.TaskPosition{}, ErrTaskNotFound
+		}
+		return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task service: move get board: %v: %w", err, ErrInternal)
+	}
+	if board.OwnerID != callerID {
+		return domain.ColumnID{}, domain.TaskPosition{}, ErrTaskNotFound
+	}
+
+	column, err := s.columnRepository.GetByID(ctx, columnID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return domain.ColumnID{}, domain.TaskPosition{}, ErrTaskNotFound
+		}
+		return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task service: move get column: %v: %w", err, ErrInternal)
+	}
+	if column.BoardID != boardID {
+		return domain.ColumnID{}, domain.TaskPosition{}, ErrTaskNotFound
+	}
+
+	task, err := s.taskRepository.GetByID(ctx, taskID)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return domain.ColumnID{}, domain.TaskPosition{}, ErrTaskNotFound
+		}
+		return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task service: move get task: %v: %w", err, ErrInternal)
+	}
+	if task.ColumnID != columnID {
+		return domain.ColumnID{}, domain.TaskPosition{}, ErrTaskNotFound
+	}
+
+	if targetColumnID != columnID {
+		var targetColumn domain.Column
+		targetColumn, err = s.columnRepository.GetByID(ctx, targetColumnID)
+		if err != nil {
+			if errors.Is(err, repository.ErrRowNotFound) {
+				return domain.ColumnID{}, domain.TaskPosition{}, ErrColumnNotFound
+			}
+			return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task service: move get target column: %v: %w", err, ErrInternal)
+		}
+		if targetColumn.BoardID != boardID {
+			return domain.ColumnID{}, domain.TaskPosition{}, ErrColumnNotFound
+		}
+	}
+
+	newColumnID, newPosition, err := s.taskRepository.Move(ctx, boardID, columnID, taskID, targetColumnID, targetPosition)
+	if err != nil {
+		if errors.Is(err, repository.ErrRowNotFound) {
+			return domain.ColumnID{}, domain.TaskPosition{}, ErrTaskNotFound
+		}
+		if errors.Is(err, repository.ErrIndexOutOfBounds) {
+			return domain.ColumnID{}, domain.TaskPosition{}, ErrIndexOutOfBounds
+		}
+		return domain.ColumnID{}, domain.TaskPosition{}, fmt.Errorf("task service: move: %v: %w", err, ErrInternal)
+	}
+
+	return newColumnID, newPosition, nil
+}

--- a/internal/service/task_test.go
+++ b/internal/service/task_test.go
@@ -1,0 +1,1167 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"goroutine/internal/domain"
+	"goroutine/internal/repository"
+	"goroutine/internal/service"
+	"goroutine/internal/testutil"
+)
+
+func TestTask_Create(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumn := testutil.ValidColumn(validBoard.ID)
+	validName, err := domain.NewTaskName("Write tests")
+	if err != nil {
+		t.Fatalf("NewTaskName() error = %v", err)
+	}
+	validDescription, err := domain.NewTaskDescription("Cover the new endpoint")
+	if err != nil {
+		t.Fatalf("NewTaskDescription() error = %v", err)
+	}
+	validTask := testutil.ValidTask(validColumn.ID)
+	validTask.Name = validName
+	validTask.Description = validDescription
+
+	tests := []struct {
+		name            string
+		callerID        domain.UserID
+		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
+		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
+		setupTaskRepo   func(t *testing.T, r *MockTaskRepository)
+		wantErr         error
+		wantTask        domain.Task
+	}{
+		{
+			name:     "Success",
+			callerID: validBoard.OwnerID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					if id != validBoard.ID {
+						t.Errorf("got board id %v, want %v", id, validBoard.ID)
+					}
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					if columnID != validColumn.ID {
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
+					}
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.CreateFunc = func(ctx context.Context, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error) {
+					if columnID != validColumn.ID {
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
+					}
+					if name != validName {
+						t.Errorf("got name %v, want %v", name, validName)
+					}
+					if description != validDescription {
+						t.Errorf("got description %v, want %v", description, validDescription)
+					}
+					return validTask, nil
+				}
+			},
+			wantTask: validTask,
+		},
+		{
+			name:     "Board not found",
+			callerID: validBoard.OwnerID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return domain.Board{}, repository.ErrRowNotFound
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Column{}, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.CreateFunc = func(ctx context.Context, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+			},
+			wantErr: service.ErrColumnNotFound,
+		},
+		{
+			name:     "Caller has no access",
+			callerID: domain.NewUserID(),
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Column{}, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.CreateFunc = func(ctx context.Context, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+			},
+			wantErr: service.ErrColumnNotFound,
+		},
+		{
+			name:     "Column not found",
+			callerID: validBoard.OwnerID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return domain.Column{}, repository.ErrRowNotFound
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.CreateFunc = func(ctx context.Context, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+			},
+			wantErr: service.ErrColumnNotFound,
+		},
+		{
+			name:     "Column belongs to another board",
+			callerID: validBoard.OwnerID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					otherBoardColumn := validColumn
+					otherBoardColumn.BoardID = domain.NewBoardID()
+					return otherBoardColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.CreateFunc = func(ctx context.Context, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+			},
+			wantErr: service.ErrColumnNotFound,
+		},
+		{
+			name:     "Create internal error",
+			callerID: validBoard.OwnerID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.CreateFunc = func(ctx context.Context, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error) {
+					return domain.Task{}, errors.New("insert failed")
+				}
+			},
+			wantErr: service.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			boardRepo := &MockBoardRepository{}
+			columnRepo := &MockColumnRepository{}
+			taskRepo := &MockTaskRepository{}
+			tt.setupBoardRepo(t, boardRepo)
+			tt.setupColumnRepo(t, columnRepo)
+			tt.setupTaskRepo(t, taskRepo)
+
+			s := service.NewTask(taskRepo, boardRepo, columnRepo)
+			got, err := s.Create(context.Background(), tt.callerID, validBoard.ID, validColumn.ID, validName, validDescription)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil {
+				if diff := cmp.Diff(tt.wantTask, got, testutil.CmpAllowUnexported()); diff != "" {
+					t.Errorf("Create() task mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestTask_List(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumn := testutil.ValidColumn(validBoard.ID)
+	first := testutil.ValidTask(validColumn.ID)
+	second := testutil.NewValidTask(t, validColumn.ID, "Second", "second", 2)
+
+	tests := []struct {
+		name            string
+		callerID        domain.UserID
+		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
+		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
+		setupTaskRepo   func(t *testing.T, r *MockTaskRepository)
+		wantErr         error
+		wantTasks       []domain.Task
+	}{
+		{
+			name:     "Success",
+			callerID: validBoard.OwnerID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.ListByColumnIDFunc = func(ctx context.Context, columnID domain.ColumnID) ([]domain.Task, error) {
+					if columnID != validColumn.ID {
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
+					}
+					return []domain.Task{first, second}, nil
+				}
+			},
+			wantTasks: []domain.Task{first, second},
+		},
+		{
+			name:     "Board not found",
+			callerID: validBoard.OwnerID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return domain.Board{}, repository.ErrRowNotFound
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Column{}, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.ListByColumnIDFunc = func(ctx context.Context, columnID domain.ColumnID) ([]domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return nil, nil
+				}
+			},
+			wantErr: service.ErrColumnNotFound,
+		},
+		{
+			name:     "No access",
+			callerID: domain.NewUserID(),
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Column{}, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.ListByColumnIDFunc = func(ctx context.Context, columnID domain.ColumnID) ([]domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return nil, nil
+				}
+			},
+			wantErr: service.ErrColumnNotFound,
+		},
+		{
+			name:     "Column not found",
+			callerID: validBoard.OwnerID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return domain.Column{}, repository.ErrRowNotFound
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.ListByColumnIDFunc = func(ctx context.Context, columnID domain.ColumnID) ([]domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return nil, nil
+				}
+			},
+			wantErr: service.ErrColumnNotFound,
+		},
+		{
+			name:     "Column belongs to another board",
+			callerID: validBoard.OwnerID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					otherBoardColumn := validColumn
+					otherBoardColumn.BoardID = domain.NewBoardID()
+					return otherBoardColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.ListByColumnIDFunc = func(ctx context.Context, columnID domain.ColumnID) ([]domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return nil, nil
+				}
+			},
+			wantErr: service.ErrColumnNotFound,
+		},
+		{
+			name:     "Repository error",
+			callerID: validBoard.OwnerID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.ListByColumnIDFunc = func(ctx context.Context, columnID domain.ColumnID) ([]domain.Task, error) {
+					return nil, errors.New("db failed")
+				}
+			},
+			wantErr: service.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			boardRepo := &MockBoardRepository{}
+			columnRepo := &MockColumnRepository{}
+			taskRepo := &MockTaskRepository{}
+			tt.setupBoardRepo(t, boardRepo)
+			tt.setupColumnRepo(t, columnRepo)
+			tt.setupTaskRepo(t, taskRepo)
+
+			s := service.NewTask(taskRepo, boardRepo, columnRepo)
+			got, err := s.List(context.Background(), tt.callerID, validBoard.ID, validColumn.ID)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil {
+				if diff := cmp.Diff(tt.wantTasks, got, testutil.CmpAllowUnexported()); diff != "" {
+					t.Errorf("List() tasks mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestTask_UpdateByID(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumn := testutil.ValidColumn(validBoard.ID)
+	validTask := testutil.ValidTask(validColumn.ID)
+	updatedName, err := domain.NewTaskName("Renamed")
+	if err != nil {
+		t.Fatalf("NewTaskName() error = %v", err)
+	}
+	updatedDescription, err := domain.NewTaskDescription("Renamed description")
+	if err != nil {
+		t.Fatalf("NewTaskDescription() error = %v", err)
+	}
+	updatedTask := validTask
+	updatedTask.Name = updatedName
+	updatedTask.Description = updatedDescription
+	updatedTask.UpdatedAt = testutil.FixedTimeNow()
+
+	tests := []struct {
+		name             string
+		callerID         domain.UserID
+		taskID           domain.TaskID
+		patchName        *domain.TaskName
+		patchDescription *domain.TaskDescription
+		setupBoardRepo   func(t *testing.T, r *MockBoardRepository)
+		setupColumnRepo  func(t *testing.T, r *MockColumnRepository)
+		setupTaskRepo    func(t *testing.T, r *MockTaskRepository)
+		wantErr          error
+		wantTask         domain.Task
+	}{
+		{
+			name:             "Success",
+			callerID:         validBoard.OwnerID,
+			taskID:           validTask.ID,
+			patchName:        &updatedName,
+			patchDescription: &updatedDescription,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					if taskID != validTask.ID {
+						t.Errorf("got task id %v, want %v", taskID, validTask.ID)
+					}
+					return validTask, nil
+				}
+				r.UpdateByIDFunc = func(ctx context.Context, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					if columnID != validColumn.ID {
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
+					}
+					if taskID != validTask.ID {
+						t.Errorf("got task id %v, want %v", taskID, validTask.ID)
+					}
+					if name == nil || *name != updatedName {
+						t.Errorf("got name %v, want %v", name, updatedName)
+					}
+					if description == nil || *description != updatedDescription {
+						t.Errorf("got description %v, want %v", description, updatedDescription)
+					}
+					return updatedTask, nil
+				}
+			},
+			wantTask: updatedTask,
+		},
+		{
+			name:     "Success no-op patch",
+			callerID: validBoard.OwnerID,
+			taskID:   validTask.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return validTask, nil
+				}
+				r.UpdateByIDFunc = func(ctx context.Context, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+			},
+			wantTask: validTask,
+		},
+		{
+			name:     "Board not found",
+			callerID: validBoard.OwnerID,
+			taskID:   validTask.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return domain.Board{}, repository.ErrRowNotFound
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Column{}, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+				r.UpdateByIDFunc = func(ctx context.Context, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+			},
+			wantErr: service.ErrTaskNotFound,
+		},
+		{
+			name:     "Caller has no access",
+			callerID: domain.NewUserID(),
+			taskID:   validTask.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Column{}, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+				r.UpdateByIDFunc = func(ctx context.Context, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+			},
+			wantErr: service.ErrTaskNotFound,
+		},
+		{
+			name:     "Column not found",
+			callerID: validBoard.OwnerID,
+			taskID:   validTask.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return domain.Column{}, repository.ErrRowNotFound
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+				r.UpdateByIDFunc = func(ctx context.Context, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+			},
+			wantErr: service.ErrTaskNotFound,
+		},
+		{
+			name:     "Column belongs to another board",
+			callerID: validBoard.OwnerID,
+			taskID:   validTask.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					otherBoardColumn := validColumn
+					otherBoardColumn.BoardID = domain.NewBoardID()
+					return otherBoardColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+				r.UpdateByIDFunc = func(ctx context.Context, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+			},
+			wantErr: service.ErrTaskNotFound,
+		},
+		{
+			name:     "Task not found",
+			callerID: validBoard.OwnerID,
+			taskID:   validTask.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return domain.Task{}, repository.ErrRowNotFound
+				}
+				r.UpdateByIDFunc = func(ctx context.Context, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+			},
+			wantErr: service.ErrTaskNotFound,
+		},
+		{
+			name:     "Task does not belong to column",
+			callerID: validBoard.OwnerID,
+			taskID:   validTask.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					otherColumnTask := validTask
+					otherColumnTask.ColumnID = domain.NewColumnID()
+					return otherColumnTask, nil
+				}
+				r.UpdateByIDFunc = func(ctx context.Context, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+			},
+			wantErr: service.ErrTaskNotFound,
+		},
+		{
+			name:      "Update internal error",
+			callerID:  validBoard.OwnerID,
+			taskID:    validTask.ID,
+			patchName: &updatedName,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return validTask, nil
+				}
+				r.UpdateByIDFunc = func(ctx context.Context, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
+					return domain.Task{}, errors.New("update failed")
+				}
+			},
+			wantErr: service.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			boardRepo := &MockBoardRepository{}
+			columnRepo := &MockColumnRepository{}
+			taskRepo := &MockTaskRepository{}
+			tt.setupBoardRepo(t, boardRepo)
+			tt.setupColumnRepo(t, columnRepo)
+			tt.setupTaskRepo(t, taskRepo)
+
+			s := service.NewTask(taskRepo, boardRepo, columnRepo)
+			got, err := s.UpdateByID(context.Background(), tt.callerID, validBoard.ID, validColumn.ID, tt.taskID, tt.patchName, tt.patchDescription)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil {
+				if diff := cmp.Diff(tt.wantTask, got, testutil.CmpAllowUnexported()); diff != "" {
+					t.Errorf("UpdateByID() task mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestTask_Move(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumn := testutil.ValidColumn(validBoard.ID)
+	targetColumn := testutil.NewValidColumn(t, validBoard.ID, "Done", 2)
+	validTask := testutil.ValidTask(validColumn.ID)
+	targetPosition, err := domain.NewTaskPosition(2)
+	if err != nil {
+		t.Fatalf("NewTaskPosition() error = %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		callerID        domain.UserID
+		taskID          domain.TaskID
+		targetColumnID  domain.ColumnID
+		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
+		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
+		setupTaskRepo   func(t *testing.T, r *MockTaskRepository)
+		wantErr         error
+		wantColumn      domain.ColumnID
+		wantPosition    domain.TaskPosition
+	}{
+		{
+			name:           "Success same column",
+			callerID:       validBoard.OwnerID,
+			taskID:         validTask.ID,
+			targetColumnID: validColumn.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					if columnID != validColumn.ID {
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
+					}
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return validTask, nil
+				}
+				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, currentColumnID domain.ColumnID, taskID domain.TaskID, gotTargetColumnID domain.ColumnID, gotTargetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					if boardID != validBoard.ID {
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
+					}
+					if currentColumnID != validColumn.ID {
+						t.Errorf("got current column id %v, want %v", currentColumnID, validColumn.ID)
+					}
+					if taskID != validTask.ID {
+						t.Errorf("got task id %v, want %v", taskID, validTask.ID)
+					}
+					if gotTargetColumnID != validColumn.ID {
+						t.Errorf("got target column id %v, want %v", gotTargetColumnID, validColumn.ID)
+					}
+					if gotTargetPosition != targetPosition {
+						t.Errorf("got target position %v, want %v", gotTargetPosition, targetPosition)
+					}
+					return validColumn.ID, targetPosition, nil
+				}
+			},
+			wantColumn:   validColumn.ID,
+			wantPosition: targetPosition,
+		},
+		{
+			name:           "Success cross column",
+			callerID:       validBoard.OwnerID,
+			taskID:         validTask.ID,
+			targetColumnID: targetColumn.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					switch columnID {
+					case validColumn.ID:
+						return validColumn, nil
+					case targetColumn.ID:
+						return targetColumn, nil
+					default:
+						t.Errorf("got column id %v, want %v or %v", columnID, validColumn.ID, targetColumn.ID)
+						return domain.Column{}, nil
+					}
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return validTask, nil
+				}
+				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, currentColumnID domain.ColumnID, taskID domain.TaskID, gotTargetColumnID domain.ColumnID, gotTargetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					if gotTargetColumnID != targetColumn.ID {
+						t.Errorf("got target column id %v, want %v", gotTargetColumnID, targetColumn.ID)
+					}
+					return targetColumn.ID, targetPosition, nil
+				}
+			},
+			wantColumn:   targetColumn.ID,
+			wantPosition: targetPosition,
+		},
+		{
+			name:           "Target column not found",
+			callerID:       validBoard.OwnerID,
+			taskID:         validTask.ID,
+			targetColumnID: targetColumn.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					if columnID == validColumn.ID {
+						return validColumn, nil
+					}
+					return domain.Column{}, repository.ErrRowNotFound
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return validTask, nil
+				}
+				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, currentColumnID domain.ColumnID, taskID domain.TaskID, gotTargetColumnID domain.ColumnID, gotTargetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					t.Fatalf("got call, want no call")
+					return domain.ColumnID{}, domain.TaskPosition{}, nil
+				}
+			},
+			wantErr: service.ErrColumnNotFound,
+		},
+		{
+			name:           "Target column belongs to another board",
+			callerID:       validBoard.OwnerID,
+			taskID:         validTask.ID,
+			targetColumnID: targetColumn.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					if columnID == validColumn.ID {
+						return validColumn, nil
+					}
+					otherBoardColumn := targetColumn
+					otherBoardColumn.BoardID = domain.NewBoardID()
+					return otherBoardColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return validTask, nil
+				}
+				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, currentColumnID domain.ColumnID, taskID domain.TaskID, gotTargetColumnID domain.ColumnID, gotTargetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					t.Fatalf("got call, want no call")
+					return domain.ColumnID{}, domain.TaskPosition{}, nil
+				}
+			},
+			wantErr: service.ErrColumnNotFound,
+		},
+		{
+			name:           "Index out of bounds",
+			callerID:       validBoard.OwnerID,
+			taskID:         validTask.ID,
+			targetColumnID: validColumn.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return validTask, nil
+				}
+				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, currentColumnID domain.ColumnID, taskID domain.TaskID, gotTargetColumnID domain.ColumnID, gotTargetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					return domain.ColumnID{}, domain.TaskPosition{}, repository.ErrIndexOutOfBounds
+				}
+			},
+			wantErr: service.ErrIndexOutOfBounds,
+		},
+		{
+			name:           "Move row not found",
+			callerID:       validBoard.OwnerID,
+			taskID:         validTask.ID,
+			targetColumnID: validColumn.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return validTask, nil
+				}
+				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, currentColumnID domain.ColumnID, taskID domain.TaskID, gotTargetColumnID domain.ColumnID, gotTargetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					return domain.ColumnID{}, domain.TaskPosition{}, repository.ErrRowNotFound
+				}
+			},
+			wantErr: service.ErrTaskNotFound,
+		},
+		{
+			name:           "Task not found",
+			callerID:       validBoard.OwnerID,
+			taskID:         validTask.ID,
+			targetColumnID: validColumn.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return domain.Task{}, repository.ErrRowNotFound
+				}
+				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, currentColumnID domain.ColumnID, taskID domain.TaskID, gotTargetColumnID domain.ColumnID, gotTargetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					t.Fatalf("got call, want no call")
+					return domain.ColumnID{}, domain.TaskPosition{}, nil
+				}
+			},
+			wantErr: service.ErrTaskNotFound,
+		},
+		{
+			name:           "Move internal error",
+			callerID:       validBoard.OwnerID,
+			taskID:         validTask.ID,
+			targetColumnID: validColumn.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return validTask, nil
+				}
+				r.MoveFunc = func(ctx context.Context, boardID domain.BoardID, currentColumnID domain.ColumnID, taskID domain.TaskID, gotTargetColumnID domain.ColumnID, gotTargetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
+					return domain.ColumnID{}, domain.TaskPosition{}, errors.New("move failed")
+				}
+			},
+			wantErr: service.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			boardRepo := &MockBoardRepository{}
+			columnRepo := &MockColumnRepository{}
+			taskRepo := &MockTaskRepository{}
+			tt.setupBoardRepo(t, boardRepo)
+			tt.setupColumnRepo(t, columnRepo)
+			tt.setupTaskRepo(t, taskRepo)
+
+			s := service.NewTask(taskRepo, boardRepo, columnRepo)
+			gotColumn, gotPosition, err := s.Move(context.Background(), tt.callerID, validBoard.ID, validColumn.ID, tt.taskID, tt.targetColumnID, targetPosition)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil {
+				if gotColumn != tt.wantColumn {
+					t.Errorf("Move() column = %v, want %v", gotColumn, tt.wantColumn)
+				}
+				if gotPosition != tt.wantPosition {
+					t.Errorf("Move() position = %v, want %v", gotPosition, tt.wantPosition)
+				}
+			}
+		})
+	}
+}
+
+func TestTask_Delete(t *testing.T) {
+	t.Parallel()
+
+	validBoard := testutil.ValidBoard()
+	validColumn := testutil.ValidColumn(validBoard.ID)
+	validTask := testutil.ValidTask(validColumn.ID)
+
+	tests := []struct {
+		name            string
+		callerID        domain.UserID
+		taskID          domain.TaskID
+		setupBoardRepo  func(t *testing.T, r *MockBoardRepository)
+		setupColumnRepo func(t *testing.T, r *MockColumnRepository)
+		setupTaskRepo   func(t *testing.T, r *MockTaskRepository)
+		wantErr         error
+	}{
+		{
+			name:     "Success",
+			callerID: validBoard.OwnerID,
+			taskID:   validTask.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return validTask, nil
+				}
+				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error {
+					if boardID != validBoard.ID {
+						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
+					}
+					if columnID != validColumn.ID {
+						t.Errorf("got column id %v, want %v", columnID, validColumn.ID)
+					}
+					if taskID != validTask.ID {
+						t.Errorf("got task id %v, want %v", taskID, validTask.ID)
+					}
+					return nil
+				}
+			},
+		},
+		{
+			name:     "Board not found",
+			callerID: validBoard.OwnerID,
+			taskID:   validTask.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return domain.Board{}, repository.ErrRowNotFound
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Column{}, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error {
+					t.Fatalf("got call, want no call")
+					return nil
+				}
+			},
+			wantErr: service.ErrTaskNotFound,
+		},
+		{
+			name:     "Caller has no access",
+			callerID: domain.NewUserID(),
+			taskID:   validTask.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Column{}, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					t.Fatalf("got call, want no call")
+					return domain.Task{}, nil
+				}
+				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error {
+					t.Fatalf("got call, want no call")
+					return nil
+				}
+			},
+			wantErr: service.ErrTaskNotFound,
+		},
+		{
+			name:     "Task not found",
+			callerID: validBoard.OwnerID,
+			taskID:   validTask.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return validTask, nil
+				}
+				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error {
+					return repository.ErrRowNotFound
+				}
+			},
+			wantErr: service.ErrTaskNotFound,
+		},
+		{
+			name:     "Delete internal error",
+			callerID: validBoard.OwnerID,
+			taskID:   validTask.ID,
+			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
+				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
+					return validBoard, nil
+				}
+			},
+			setupColumnRepo: func(t *testing.T, r *MockColumnRepository) {
+				r.GetByIDFunc = func(ctx context.Context, columnID domain.ColumnID) (domain.Column, error) {
+					return validColumn, nil
+				}
+			},
+			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
+				r.GetByIDFunc = func(ctx context.Context, taskID domain.TaskID) (domain.Task, error) {
+					return validTask, nil
+				}
+				r.DeleteFunc = func(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error {
+					return errors.New("delete failed")
+				}
+			},
+			wantErr: service.ErrInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			boardRepo := &MockBoardRepository{}
+			columnRepo := &MockColumnRepository{}
+			taskRepo := &MockTaskRepository{}
+			tt.setupBoardRepo(t, boardRepo)
+			tt.setupColumnRepo(t, columnRepo)
+			tt.setupTaskRepo(t, taskRepo)
+
+			s := service.NewTask(taskRepo, boardRepo, columnRepo)
+			err := s.Delete(context.Background(), tt.callerID, validBoard.ID, validColumn.ID, tt.taskID)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/service/task_test.go
+++ b/internal/service/task_test.go
@@ -703,10 +703,7 @@ func TestTask_Move(t *testing.T) {
 	validColumn := testutil.ValidColumn(validBoard.ID)
 	targetColumn := testutil.NewValidColumn(t, validBoard.ID, "Done", 2)
 	validTask := testutil.ValidTask(validColumn.ID)
-	targetPosition, err := domain.NewTaskPosition(2)
-	if err != nil {
-		t.Fatalf("NewTaskPosition() error = %v", err)
-	}
+	targetPosition := testutil.MustTaskPosition(t, 2)
 
 	tests := []struct {
 		name            string

--- a/internal/service/task_test.go
+++ b/internal/service/task_test.go
@@ -18,17 +18,9 @@ func TestTask_Create(t *testing.T) {
 
 	validBoard := testutil.ValidBoard()
 	validColumn := testutil.ValidColumn(validBoard.ID)
-	validName, err := domain.NewTaskName("Write tests")
-	if err != nil {
-		t.Fatalf("NewTaskName() error = %v", err)
-	}
-	validDescription, err := domain.NewTaskDescription("Cover the new endpoint")
-	if err != nil {
-		t.Fatalf("NewTaskDescription() error = %v", err)
-	}
 	validTask := testutil.ValidTask(validColumn.ID)
-	validTask.Name = validName
-	validTask.Description = validDescription
+	validName := validTask.Name
+	validDescription := validTask.Description
 
 	tests := []struct {
 		name            string

--- a/internal/service/task_test.go
+++ b/internal/service/task_test.go
@@ -392,18 +392,9 @@ func TestTask_UpdateByID(t *testing.T) {
 	validBoard := testutil.ValidBoard()
 	validColumn := testutil.ValidColumn(validBoard.ID)
 	validTask := testutil.ValidTask(validColumn.ID)
-	updatedName, err := domain.NewTaskName("Renamed")
-	if err != nil {
-		t.Fatalf("NewTaskName() error = %v", err)
-	}
-	updatedDescription, err := domain.NewTaskDescription("Renamed description")
-	if err != nil {
-		t.Fatalf("NewTaskDescription() error = %v", err)
-	}
-	updatedTask := validTask
-	updatedTask.Name = updatedName
-	updatedTask.Description = updatedDescription
-	updatedTask.UpdatedAt = testutil.FixedTimeNow()
+	updatedTask := testutil.UpdateValidTask(t, &validTask, "Renamed", "Renamed description", testutil.FixedTimeNow())
+	updatedName := updatedTask.Name
+	updatedDescription := updatedTask.Description
 
 	tests := []struct {
 		name             string

--- a/internal/testutil/cmp.go
+++ b/internal/testutil/cmp.go
@@ -15,5 +15,9 @@ func CmpAllowUnexported() cmp.Option {
 		domain.ColumnID{},
 		domain.ColumnName{},
 		domain.ColumnPosition{},
+		domain.TaskID{},
+		domain.TaskName{},
+		domain.TaskDescription{},
+		domain.TaskPosition{},
 	)
 }

--- a/internal/testutil/data.go
+++ b/internal/testutil/data.go
@@ -72,6 +72,23 @@ func ValidColumnPosition() domain.ColumnPosition {
 	return position
 }
 
+func ValidTaskName() domain.TaskName {
+	return must(domain.NewTaskName, "Write tests")
+}
+
+func ValidTaskDescription() domain.TaskDescription {
+	return must(domain.NewTaskDescription, "Cover the new endpoint with tests")
+}
+
+func ValidTaskPosition() domain.TaskPosition {
+	position, err := domain.NewTaskPosition(1)
+	if err != nil {
+		panic(fmt.Errorf("testutil: BUG: value is no longer valid: %w", err))
+	}
+
+	return position
+}
+
 func ValidJWTSecret() secrecy.SecretString {
 	return secrecy.SecretString("secret")
 }
@@ -175,5 +192,73 @@ func UpdateValidColumn(t *testing.T, base *domain.Column, name string, updatedAt
 		Position:  base.Position,
 		CreatedAt: base.CreatedAt,
 		UpdatedAt: updatedAt,
+	}
+}
+
+func ValidTask(columnID domain.ColumnID) domain.Task {
+	name := ValidTaskName()
+	description := ValidTaskDescription()
+	position := ValidTaskPosition()
+	pseudoNow := FixedTimeNow()
+
+	return domain.Task{
+		ID:          domain.NewTaskID(),
+		ColumnID:    columnID,
+		Name:        name,
+		Description: description,
+		Position:    position,
+		CreatedAt:   pseudoNow,
+		UpdatedAt:   pseudoNow,
+	}
+}
+
+func NewValidTask(t *testing.T, columnID domain.ColumnID, name, description string, position int64) domain.Task {
+	t.Helper()
+
+	task := ValidTask(columnID)
+
+	domainName, err := domain.NewTaskName(name)
+	if err != nil {
+		t.Fatalf("NewTaskName() error = %v", err)
+	}
+
+	domainDescription, err := domain.NewTaskDescription(description)
+	if err != nil {
+		t.Fatalf("NewTaskDescription() error = %v", err)
+	}
+
+	domainPosition, err := domain.NewTaskPosition(position)
+	if err != nil {
+		t.Fatalf("NewTaskPosition() error = %v", err)
+	}
+
+	task.Name = domainName
+	task.Description = domainDescription
+	task.Position = domainPosition
+
+	return task
+}
+
+func UpdateValidTask(t *testing.T, base *domain.Task, name, description string, updatedAt time.Time) domain.Task {
+	t.Helper()
+
+	domainName, err := domain.NewTaskName(name)
+	if err != nil {
+		t.Fatalf("NewTaskName() error = %v", err)
+	}
+
+	domainDescription, err := domain.NewTaskDescription(description)
+	if err != nil {
+		t.Fatalf("NewTaskDescription() error = %v", err)
+	}
+
+	return domain.Task{
+		ID:          base.ID,
+		ColumnID:    base.ColumnID,
+		Name:        domainName,
+		Description: domainDescription,
+		Position:    base.Position,
+		CreatedAt:   base.CreatedAt,
+		UpdatedAt:   updatedAt,
 	}
 }

--- a/internal/testutil/data.go
+++ b/internal/testutil/data.go
@@ -22,7 +22,7 @@ func FixedTime5mFromNowStr() string {
 
 func FixedTimeNowStr() string { return FixedTimeNow().UTC().Format(timeFormat) }
 
-func must[A any, T any](fn func(A) (T, error), arg A) T {
+func Must[A any, T any](fn func(A) (T, error), arg A) T {
 	v, err := fn(arg)
 	if err != nil {
 		panic(err)
@@ -31,15 +31,15 @@ func must[A any, T any](fn func(A) (T, error), arg A) T {
 }
 
 func ValidUserID() domain.UserID {
-	return must(domain.ParseUserID, "018e1000-0000-7000-8000-000000000000")
+	return Must(domain.ParseUserID, "018e1000-0000-7000-8000-000000000000")
 }
 
 func ValidEmail() domain.Email {
-	return must(domain.NewEmail, "test@example.com")
+	return Must(domain.NewEmail, "test@example.com")
 }
 
 func ValidPassword() domain.UserPassword {
-	return must(domain.NewUserPassword, "qwerty")
+	return Must(domain.NewUserPassword, "qwerty")
 }
 
 func ValidPasswordHash() string {
@@ -51,31 +51,35 @@ func AnotherValidPasswordHash() string {
 }
 
 func ValidBoardName() domain.BoardName {
-	return must(domain.NewBoardName, "Test Board")
+	return Must(domain.NewBoardName, "Test Board")
 }
 
 func ValidBoardDescription() domain.BoardDescription {
-	return must(domain.NewBoardDescription, "Test Board Description")
+	return Must(domain.NewBoardDescription, "Test Board Description")
 }
 
 func ValidColumnName() domain.ColumnName {
-	return must(domain.NewColumnName, "To Do")
+	return Must(domain.NewColumnName, "To Do")
 }
 
 func ValidColumnPosition() domain.ColumnPosition {
-	return must(domain.NewColumnPosition, 1)
+	return Must(domain.NewColumnPosition, 1)
 }
 
 func ValidTaskName() domain.TaskName {
-	return must(domain.NewTaskName, "Write tests")
+	return Must(domain.NewTaskName, "Write tests")
 }
 
 func ValidTaskDescription() domain.TaskDescription {
-	return must(domain.NewTaskDescription, "Cover the new endpoint with tests")
+	return Must(domain.NewTaskDescription, "Cover the new endpoint with tests")
 }
 
 func ValidTaskPosition() domain.TaskPosition {
-	return must(domain.NewTaskPosition, 1)
+	return Must(domain.NewTaskPosition, 1)
+}
+
+func MustTaskPosition(t *testing.T, n int64) domain.TaskPosition {
+	return Must(domain.NewTaskPosition, n)
 }
 
 func ValidJWTSecret() secrecy.SecretString {

--- a/internal/testutil/data.go
+++ b/internal/testutil/data.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -23,10 +22,10 @@ func FixedTime5mFromNowStr() string {
 
 func FixedTimeNowStr() string { return FixedTimeNow().UTC().Format(timeFormat) }
 
-func must[T any](fn func(string) (T, error), s string) T {
-	v, err := fn(s)
+func must[A any, T any](fn func(A) (T, error), arg A) T {
+	v, err := fn(arg)
 	if err != nil {
-		panic(fmt.Errorf("testutil: BUG: value is no longer valid: %w", err))
+		panic(err)
 	}
 	return v
 }
@@ -64,12 +63,7 @@ func ValidColumnName() domain.ColumnName {
 }
 
 func ValidColumnPosition() domain.ColumnPosition {
-	position, err := domain.NewColumnPosition(1)
-	if err != nil {
-		panic(fmt.Errorf("testutil: BUG: value is no longer valid: %w", err))
-	}
-
-	return position
+	return must(domain.NewColumnPosition, 1)
 }
 
 func ValidTaskName() domain.TaskName {
@@ -81,12 +75,7 @@ func ValidTaskDescription() domain.TaskDescription {
 }
 
 func ValidTaskPosition() domain.TaskPosition {
-	position, err := domain.NewTaskPosition(1)
-	if err != nil {
-		panic(fmt.Errorf("testutil: BUG: value is no longer valid: %w", err))
-	}
-
-	return position
+	return must(domain.NewTaskPosition, 1)
 }
 
 func ValidJWTSecret() secrecy.SecretString {

--- a/internal/testutil/database.go
+++ b/internal/testutil/database.go
@@ -48,7 +48,7 @@ func TruncateAllTables(t *testing.T, pool *pgxpool.Pool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	names := []string{"columns", "boards", "users"}
+	names := []string{"tasks", "columns", "boards", "users"}
 	parts := make([]string, len(names))
 	for i, name := range names {
 		parts[i] = pgx.Identifier{name}.Sanitize()

--- a/migrations/20260421140000_create_tasks_table.sql
+++ b/migrations/20260421140000_create_tasks_table.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+CREATE TABLE tasks (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    column_id UUID NOT NULL REFERENCES columns(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    position INT NOT NULL CHECK (position > 0),
+    created_at TIMESTAMP NOT NULL DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    updated_at TIMESTAMP NOT NULL DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    CONSTRAINT tasks_column_id_position_key UNIQUE (column_id, position) DEFERRABLE INITIALLY IMMEDIATE
+);
+
+-- +goose Down
+DROP TABLE tasks;

--- a/tests/task_test.go
+++ b/tests/task_test.go
@@ -1,0 +1,369 @@
+//go:build e2e
+
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"goroutine/internal/testutil"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+)
+
+type taskJSON struct {
+	ID          string `json:"id"`
+	ColumnID    string `json:"columnId"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Position    int64  `json:"position"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+}
+
+type taskPositionJSON struct {
+	ColumnID string `json:"columnId"`
+	Position int64  `json:"position"`
+}
+
+func TestTask_HappyPath(t *testing.T) {
+	httpClient, ts, pool := Prelude(t)
+
+	t.Run("Full task flow", func(t *testing.T) {
+		testutil.TruncateAllTables(t, pool)
+
+		// 1. Register (already done via ac client)
+		ac := CreateUserAndAuthenticateClient(t, httpClient, ts.URL)
+
+		boardName := testutil.ValidBoardName().String()
+		boardDescription := testutil.ValidBoardDescription().String()
+
+		createBoardResp := ac.Do(t, http.MethodPost, "/v1/boards", map[string]string{
+			"name":        boardName,
+			"description": boardDescription,
+		})
+		defer func() {
+			_ = createBoardResp.Body.Close()
+		}()
+		if createBoardResp.StatusCode != http.StatusCreated {
+			t.Fatalf("got create board status %d, want %d", createBoardResp.StatusCode, http.StatusCreated)
+		}
+
+		board := parseBoard(t, createBoardResp)
+
+		// 2. Create two columns so we can later move a task across them
+		createColumnAResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
+			"name": "To Do",
+		})
+		defer func() {
+			_ = createColumnAResp.Body.Close()
+		}()
+		if createColumnAResp.StatusCode != http.StatusCreated {
+			t.Fatalf("got create column A status %d, want %d", createColumnAResp.StatusCode, http.StatusCreated)
+		}
+		columnA := parseColumn(t, createColumnAResp)
+
+		createColumnBResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
+			"name": "In Progress",
+		})
+		defer func() {
+			_ = createColumnBResp.Body.Close()
+		}()
+		if createColumnBResp.StatusCode != http.StatusCreated {
+			t.Fatalf("got create column B status %d, want %d", createColumnBResp.StatusCode, http.StatusCreated)
+		}
+		columnB := parseColumn(t, createColumnBResp)
+
+		name := "Write tests"
+		description := "Cover the new endpoint with tests"
+
+		// 3. Create a task in column A, store response in createdTask, and validate response fields
+		createResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", map[string]string{
+			"name":        name,
+			"description": description,
+		})
+		defer func() {
+			_ = createResp.Body.Close()
+		}()
+		if createResp.StatusCode != http.StatusCreated {
+			t.Fatalf("got status %d, want %d", createResp.StatusCode, http.StatusCreated)
+		}
+
+		createdTask := parseTask(t, createResp)
+
+		if _, err := uuid.Parse(createdTask.ID); err != nil {
+			t.Errorf("uuid.Parse(%q) error = %v, want nil", createdTask.ID, err)
+		}
+		if _, err := uuid.Parse(createdTask.ColumnID); err != nil {
+			t.Errorf("uuid.Parse(%q) error = %v, want nil", createdTask.ColumnID, err)
+		}
+		if createdTask.ColumnID != columnA.ID {
+			t.Errorf("got column ID %q, want %q", createdTask.ColumnID, columnA.ID)
+		}
+		if createdTask.Name != name {
+			t.Errorf("got name %q, want %q", createdTask.Name, name)
+		}
+		if createdTask.Description != description {
+			t.Errorf("got description %q, want %q", createdTask.Description, description)
+		}
+		if createdTask.Position != 1 {
+			t.Errorf("got position %d, want %d", createdTask.Position, 1)
+		}
+		if _, err := time.Parse(timeFormat, createdTask.CreatedAt); err != nil {
+			t.Errorf("time.Parse(%q) error = %v, want nil", createdTask.CreatedAt, err)
+		}
+		if _, err := time.Parse(timeFormat, createdTask.UpdatedAt); err != nil {
+			t.Errorf("time.Parse(%q) error = %v, want nil", createdTask.UpdatedAt, err)
+		}
+
+		// 4. List tasks in column A, get the first task, and perform deep comparison with createdTask
+		listResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", nil)
+		defer func() {
+			_ = listResp.Body.Close()
+		}()
+		if listResp.StatusCode != http.StatusOK {
+			t.Fatalf("got list status %d, want %d", listResp.StatusCode, http.StatusOK)
+		}
+
+		listedTasks := parseTasksList(t, listResp)
+		if len(listedTasks) != 1 {
+			t.Fatalf("got %d tasks in list, want 1", len(listedTasks))
+		}
+		if diff := cmp.Diff(createdTask, listedTasks[0]); diff != "" {
+			t.Errorf("List item mismatch (-want +got):\n%s", diff)
+		}
+
+		// 5. Update by id with name and description, store response in updatedTask, validate fields, and ensure updatedAt advanced
+		updatedName := "Updated Name"
+		updatedDescription := "Updated description"
+		WaitForTimestampTicker(t)
+		updateResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+createdTask.ID, map[string]string{
+			"name":        updatedName,
+			"description": updatedDescription,
+		})
+		defer func() {
+			_ = updateResp.Body.Close()
+		}()
+		if updateResp.StatusCode != http.StatusOK {
+			t.Fatalf("got Update by id status %d, want %d", updateResp.StatusCode, http.StatusOK)
+		}
+
+		updatedTask := parseTask(t, updateResp)
+
+		// Validation trick: revert changed fields in a clone and compare with createdTask
+		checkTask := updatedTask
+		checkTask.Name = createdTask.Name
+		checkTask.Description = createdTask.Description
+		checkTask.UpdatedAt = createdTask.UpdatedAt
+		if diff := cmp.Diff(createdTask, checkTask); diff != "" {
+			t.Errorf("UpdateByID() diff (-want +got):\n%s", diff)
+		}
+
+		// Verify specific changes
+		if updatedTask.Name != updatedName {
+			t.Errorf("got updated name %q, want %q", updatedTask.Name, updatedName)
+		}
+		if updatedTask.Description != updatedDescription {
+			t.Errorf("got updated description %q, want %q", updatedTask.Description, updatedDescription)
+		}
+
+		updatedAtAfterUpdate, err := time.Parse(timeFormat, updatedTask.UpdatedAt)
+		if err != nil {
+			t.Fatalf("time.Parse(%q) error = %v", updatedTask.UpdatedAt, err)
+		}
+		updatedAtBeforeUpdate, err := time.Parse(timeFormat, createdTask.UpdatedAt)
+		if err != nil {
+			t.Fatalf("time.Parse(%q) error = %v", createdTask.UpdatedAt, err)
+		}
+		if !updatedAtAfterUpdate.After(updatedAtBeforeUpdate) {
+			t.Errorf("updatedAt must advance after Update by id; got %v, previous %v", updatedAtAfterUpdate, updatedAtBeforeUpdate)
+		}
+
+		// 6. Create the second task in column A so we can later delete it from the middle and verify shifting
+		createSecondResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", map[string]string{
+			"name":        "Second",
+			"description": "second",
+		})
+		defer func() {
+			_ = createSecondResp.Body.Close()
+		}()
+		if createSecondResp.StatusCode != http.StatusCreated {
+			t.Fatalf("got second create status %d, want %d", createSecondResp.StatusCode, http.StatusCreated)
+		}
+
+		secondTask := parseTask(t, createSecondResp)
+		if secondTask.Position != 2 {
+			t.Errorf("got second task position %d, want %d", secondTask.Position, 2)
+		}
+
+		// 7. Create the third task in column A so delete can verify position compaction for trailing items
+		createThirdResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", map[string]string{
+			"name":        "Third",
+			"description": "third",
+		})
+		defer func() {
+			_ = createThirdResp.Body.Close()
+		}()
+		if createThirdResp.StatusCode != http.StatusCreated {
+			t.Fatalf("got third create status %d, want %d", createThirdResp.StatusCode, http.StatusCreated)
+		}
+
+		thirdTask := parseTask(t, createThirdResp)
+		if thirdTask.Position != 3 {
+			t.Errorf("got third task position %d, want %d", thirdTask.Position, 3)
+		}
+
+		// 8. Delete the middle task and expect the request to succeed
+		deleteResp := ac.Do(t, http.MethodDelete, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+secondTask.ID, nil)
+		defer func() {
+			_ = deleteResp.Body.Close()
+		}()
+		if deleteResp.StatusCode != http.StatusNoContent {
+			t.Fatalf("got delete status %d, want %d", deleteResp.StatusCode, http.StatusNoContent)
+		}
+
+		// 9. List tasks again and verify delete preserved the first task and compacted positions
+		listAfterDeleteResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", nil)
+		defer func() {
+			_ = listAfterDeleteResp.Body.Close()
+		}()
+		if listAfterDeleteResp.StatusCode != http.StatusOK {
+			t.Fatalf("got list status %d after delete, want %d", listAfterDeleteResp.StatusCode, http.StatusOK)
+		}
+
+		listedAfterDelete := parseTasksList(t, listAfterDeleteResp)
+		if len(listedAfterDelete) != 2 {
+			t.Fatalf("got %d tasks after delete, want 2", len(listedAfterDelete))
+		}
+		if listedAfterDelete[0].ID != updatedTask.ID || listedAfterDelete[0].Position != 1 {
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterDelete[0].ID, listedAfterDelete[0].Position, updatedTask.ID, 1)
+		}
+		if listedAfterDelete[1].ID != thirdTask.ID || listedAfterDelete[1].Position != 2 {
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterDelete[1].ID, listedAfterDelete[1].Position, thirdTask.ID, 2)
+		}
+
+		// 10. Move the third task up to first position within the same column and expect the new column and position in response
+		moveResp := ac.Do(t, http.MethodPut, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+thirdTask.ID+"/position", map[string]any{
+			"targetColumnId": columnA.ID,
+			"targetPosition": 1,
+		})
+		defer func() {
+			_ = moveResp.Body.Close()
+		}()
+		if moveResp.StatusCode != http.StatusOK {
+			t.Fatalf("got move status %d, want %d", moveResp.StatusCode, http.StatusOK)
+		}
+
+		movedPosition := parseTaskPosition(t, moveResp)
+		if movedPosition.ColumnID != columnA.ID {
+			t.Errorf("got move response column id %q, want %q", movedPosition.ColumnID, columnA.ID)
+		}
+		if movedPosition.Position != 1 {
+			t.Errorf("got move response position %d, want %d", movedPosition.Position, 1)
+		}
+
+		// 11. List tasks again and verify move reordered the remaining tasks in column A
+		listAfterMoveResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", nil)
+		defer func() {
+			_ = listAfterMoveResp.Body.Close()
+		}()
+		if listAfterMoveResp.StatusCode != http.StatusOK {
+			t.Fatalf("got list status %d after move, want %d", listAfterMoveResp.StatusCode, http.StatusOK)
+		}
+
+		listedAfterMove := parseTasksList(t, listAfterMoveResp)
+		if len(listedAfterMove) != 2 {
+			t.Fatalf("got %d tasks after move, want 2", len(listedAfterMove))
+		}
+		if listedAfterMove[0].ID != thirdTask.ID || listedAfterMove[0].Position != 1 {
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterMove[0].ID, listedAfterMove[0].Position, thirdTask.ID, 1)
+		}
+		if listedAfterMove[1].ID != updatedTask.ID || listedAfterMove[1].Position != 2 {
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterMove[1].ID, listedAfterMove[1].Position, updatedTask.ID, 2)
+		}
+
+		// 12. Move the third task across columns from column A to column B at position 1 and expect the new column and position in response
+		crossMoveResp := ac.Do(t, http.MethodPut, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+thirdTask.ID+"/position", map[string]any{
+			"targetColumnId": columnB.ID,
+			"targetPosition": 1,
+		})
+		defer func() {
+			_ = crossMoveResp.Body.Close()
+		}()
+		if crossMoveResp.StatusCode != http.StatusOK {
+			t.Fatalf("got cross-column move status %d, want %d", crossMoveResp.StatusCode, http.StatusOK)
+		}
+
+		crossMovedPosition := parseTaskPosition(t, crossMoveResp)
+		if crossMovedPosition.ColumnID != columnB.ID {
+			t.Errorf("got cross-column move response column id %q, want %q", crossMovedPosition.ColumnID, columnB.ID)
+		}
+		if crossMovedPosition.Position != 1 {
+			t.Errorf("got cross-column move response position %d, want %d", crossMovedPosition.Position, 1)
+		}
+
+		// 13. List tasks in column A and verify the moved task is gone, and the remaining task kept position 1
+		listAAfterCrossResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", nil)
+		defer func() {
+			_ = listAAfterCrossResp.Body.Close()
+		}()
+		if listAAfterCrossResp.StatusCode != http.StatusOK {
+			t.Fatalf("got list column A status %d after cross move, want %d", listAAfterCrossResp.StatusCode, http.StatusOK)
+		}
+
+		listedAAfterCross := parseTasksList(t, listAAfterCrossResp)
+		if len(listedAAfterCross) != 1 {
+			t.Fatalf("got %d tasks in column A after cross move, want 1", len(listedAAfterCross))
+		}
+		if listedAAfterCross[0].ID != updatedTask.ID || listedAAfterCross[0].Position != 1 {
+			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAAfterCross[0].ID, listedAAfterCross[0].Position, updatedTask.ID, 1)
+		}
+
+		// 14. List tasks in column B and verify the moved task landed at position 1 with updated columnId
+		listBAfterCrossResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnB.ID+"/tasks", nil)
+		defer func() {
+			_ = listBAfterCrossResp.Body.Close()
+		}()
+		if listBAfterCrossResp.StatusCode != http.StatusOK {
+			t.Fatalf("got list column B status %d after cross move, want %d", listBAfterCrossResp.StatusCode, http.StatusOK)
+		}
+
+		listedBAfterCross := parseTasksList(t, listBAfterCrossResp)
+		if len(listedBAfterCross) != 1 {
+			t.Fatalf("got %d tasks in column B after cross move, want 1", len(listedBAfterCross))
+		}
+		if listedBAfterCross[0].ID != thirdTask.ID || listedBAfterCross[0].Position != 1 || listedBAfterCross[0].ColumnID != columnB.ID {
+			t.Errorf("got id=%s position=%d columnId=%s, want id=%s position=%d columnId=%s", listedBAfterCross[0].ID, listedBAfterCross[0].Position, listedBAfterCross[0].ColumnID, thirdTask.ID, 1, columnB.ID)
+		}
+	})
+}
+
+func parseTask(t *testing.T, resp *http.Response) taskJSON {
+	t.Helper()
+	var tk taskJSON
+	if err := json.NewDecoder(resp.Body).Decode(&tk); err != nil {
+		t.Fatalf("Task Decode() error = %v", err)
+	}
+	return tk
+}
+
+func parseTasksList(t *testing.T, resp *http.Response) []taskJSON {
+	t.Helper()
+	var tasks []taskJSON
+	if err := json.NewDecoder(resp.Body).Decode(&tasks); err != nil {
+		t.Fatalf("Tasks list Decode() error = %v", err)
+	}
+	return tasks
+}
+
+func parseTaskPosition(t *testing.T, resp *http.Response) taskPositionJSON {
+	t.Helper()
+	var p taskPositionJSON
+	if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
+		t.Fatalf("Task position Decode() error = %v", err)
+	}
+	return p
+}


### PR DESCRIPTION
### Related Issues
Refers to #106

### Summary
- Giga PR because the code is very similar to columns api for now (copy-paste); I'm cutting corners to complete the project faster
- Code duplicated a lot because it may diverge in future; abstractions will hurt readability here; wrong abstraction is much more expensive than duplication to fix
- Full tasks api with tests
- Contract differences from columns api:
  - Tasks can contain description, which is passed when creating and updating a task
  - Tasks depend on columnId instead of boardId
  - Move accepts required `targetColumn` as well id to allow moving tasks between column
  - Move always returns destination `column` as well
  - New TASK_NOT_FOUND error added, similar to BOARD_NOT_FOUND
- Lock affected columns instead of a whole board

### Verification
- [x] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [x] Unit tests added/updated
- [ ] Documentation updated
- [x] No sensitive data committed
