### PR TITLE
fix: add missing API methods for CORS

### DIFF
--- a/internal/http/middleware/cors.go
+++ b/internal/http/middleware/cors.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 )
 
+// Every method used by NewRouter + OPTIONS for preflight
+const corsAllowedMethods = "DELETE, GET, OPTIONS, PATCH, POST, PUT"
+
 type CORS struct {
 	allowedOrigins map[string]struct{}
 }
@@ -39,7 +42,7 @@ func (m *CORS) Wrap(next http.Handler) http.HandlerFunc {
 		}
 
 		w.Header().Set("Access-Control-Allow-Origin", origin)
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", corsAllowedMethods)
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Max-Age", "86400")

--- a/internal/http/middleware/cors_test.go
+++ b/internal/http/middleware/cors_test.go
@@ -24,7 +24,7 @@ func TestCors_Wrap(t *testing.T) {
 
 	filledGoodCORSHeaders := map[string]string{
 		"Access-Control-Allow-Origin":      goodSite,
-		"Access-Control-Allow-Methods":     "GET, POST, OPTIONS",
+		"Access-Control-Allow-Methods":     "DELETE, GET, OPTIONS, PATCH, POST, PUT",
 		"Access-Control-Allow-Headers":     "Content-Type, Authorization",
 		"Access-Control-Allow-Credentials": "true",
 		"Access-Control-Max-Age":           "86400",


### PR DESCRIPTION
### Summary
- Some API methods were not specified in CORS header, causing errors that couldn't be found with current test suite.
- Added them

### Verification
- [x] Tests updated
- [x] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [x] Unit tests added/updated
- [x] Documentation updated
- [x] No sensitive data committed
