### PR TITLE
fix: inconsistent lock before creation

### DIFF
--- a/internal/repository/column.go
+++ b/internal/repository/column.go
@@ -25,27 +25,56 @@ func (r *PgColumn) Create(
 	name domain.ColumnName,
 	description domain.ColumnDescription,
 ) (domain.Column, error) {
-	const query = `
-		WITH board_lock AS (
-			SELECT id
-			FROM boards
-			WHERE id = $1
-			FOR UPDATE
-		), next_pos AS (
-			SELECT COALESCE(MAX(position), 0) + 1 AS position
-			FROM columns
-			WHERE board_id = $1
-		), inserted AS (
-			INSERT INTO columns (board_id, name, description, position)
-			SELECT $1, $2, $3, next_pos.position
-			FROM board_lock, next_pos
-			RETURNING id, board_id, name, description, position, created_at, updated_at
-		)
-		SELECT id, board_id, name, description, position, created_at, updated_at
-		FROM inserted`
+	const (
+		lockBoardQuery = `
+		SELECT 1
+		FROM boards
+		WHERE id = @board_id
+		FOR UPDATE`
+		nextPositionQuery = `
+		SELECT COALESCE(MAX(position), 0) + 1
+		FROM columns
+		WHERE board_id = @board_id`
+		insertColumnQuery = `
+		INSERT INTO columns (board_id, name, description, position)
+		VALUES (@board_id, @name, @description, @position)
+		RETURNING id, board_id, name, description, position, created_at, updated_at`
+	)
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return domain.Column{}, fmt.Errorf("column repo: create begin tx: %v: %w", err, ErrInternal)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	var locked int
+	err = tx.QueryRow(ctx, lockBoardQuery, pgx.NamedArgs{
+		"board_id": boardID,
+	}).Scan(&locked)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.Column{}, ErrRowNotFound
+		}
+		return domain.Column{}, fmt.Errorf("column repo: create lock board: %v: %w", err, ErrInternal)
+	}
+
+	var nextPosition int64
+	err = tx.QueryRow(ctx, nextPositionQuery, pgx.NamedArgs{
+		"board_id": boardID,
+	}).Scan(&nextPosition)
+	if err != nil {
+		return domain.Column{}, fmt.Errorf("column repo: create next position: %v: %w", err, ErrInternal)
+	}
 
 	var column domain.Column
-	err := r.pool.QueryRow(ctx, query, boardID, name, description).Scan(
+	err = tx.QueryRow(ctx, insertColumnQuery, pgx.NamedArgs{
+		"board_id":    boardID,
+		"name":        name,
+		"description": description,
+		"position":    nextPosition,
+	}).Scan(
 		&column.ID,
 		&column.BoardID,
 		&column.Name,
@@ -55,10 +84,12 @@ func (r *PgColumn) Create(
 		&column.UpdatedAt,
 	)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return domain.Column{}, ErrRowNotFound
-		}
-		return domain.Column{}, fmt.Errorf("column repo: create: %v: %w", err, ErrInternal)
+		return domain.Column{}, fmt.Errorf("column repo: create insert: %v: %w", err, ErrInternal)
+	}
+
+	err = tx.Commit(ctx)
+	if err != nil {
+		return domain.Column{}, fmt.Errorf("column repo: create commit: %v: %w", err, ErrInternal)
 	}
 
 	return column, nil

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -85,27 +85,56 @@ func (r *PgTask) Create(
 	name domain.TaskName,
 	description domain.TaskDescription,
 ) (domain.Task, error) {
-	const query = `
-		WITH column_lock AS (
-			SELECT id
-			FROM columns
-			WHERE id = $1
-			FOR UPDATE
-		), next_pos AS (
-			SELECT COALESCE(MAX(position), 0) + 1 AS position
-			FROM tasks
-			WHERE column_id = $1
-		), inserted AS (
-			INSERT INTO tasks (column_id, name, description, position)
-			SELECT $1, $2, $3, next_pos.position
-			FROM column_lock, next_pos
-			RETURNING id, column_id, name, description, position, created_at, updated_at
-		)
-		SELECT id, column_id, name, description, position, created_at, updated_at
-		FROM inserted`
+	const (
+		lockColumnQuery = `
+		SELECT 1
+		FROM columns
+		WHERE id = @column_id
+		FOR UPDATE`
+		nextPositionQuery = `
+		SELECT COALESCE(MAX(position), 0) + 1
+		FROM tasks
+		WHERE column_id = @column_id`
+		insertTaskQuery = `
+		INSERT INTO tasks (column_id, name, description, position)
+		VALUES (@column_id, @name, @description, @position)
+		RETURNING id, column_id, name, description, position, created_at, updated_at`
+	)
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return domain.Task{}, fmt.Errorf("task repo: create begin tx: %v: %w", err, ErrInternal)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	var locked int
+	err = tx.QueryRow(ctx, lockColumnQuery, pgx.NamedArgs{
+		"column_id": columnID,
+	}).Scan(&locked)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.Task{}, ErrRowNotFound
+		}
+		return domain.Task{}, fmt.Errorf("task repo: create lock column: %v: %w", err, ErrInternal)
+	}
+
+	var nextPosition int64
+	err = tx.QueryRow(ctx, nextPositionQuery, pgx.NamedArgs{
+		"column_id": columnID,
+	}).Scan(&nextPosition)
+	if err != nil {
+		return domain.Task{}, fmt.Errorf("task repo: create next position: %v: %w", err, ErrInternal)
+	}
 
 	var task domain.Task
-	err := r.pool.QueryRow(ctx, query, columnID, name, description).Scan(
+	err = tx.QueryRow(ctx, insertTaskQuery, pgx.NamedArgs{
+		"column_id":   columnID,
+		"name":        name,
+		"description": description,
+		"position":    nextPosition,
+	}).Scan(
 		&task.ID,
 		&task.ColumnID,
 		&task.Name,
@@ -115,10 +144,12 @@ func (r *PgTask) Create(
 		&task.UpdatedAt,
 	)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return domain.Task{}, ErrRowNotFound
-		}
-		return domain.Task{}, fmt.Errorf("task repo: create: %v: %w", err, ErrInternal)
+		return domain.Task{}, fmt.Errorf("task repo: create insert: %v: %w", err, ErrInternal)
+	}
+
+	err = tx.Commit(ctx)
+	if err != nil {
+		return domain.Task{}, fmt.Errorf("task repo: create commit: %v: %w", err, ErrInternal)
 	}
 
 	return task, nil


### PR DESCRIPTION
### Summary
CTE chain execution order in Postgres is undefined, and there used to be a lock in the first step. So under load the planner used to choose different orders, and the lock didn't always set up at first, causing 500 Internal Error with unique violations. Also, this couldn't be caught with the test suite.

### Verification
- [x] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [ ] Unit tests added/updated
- [ ] Documentation updated
- [x] No sensitive data committed
