### PR TITLE
ci: use DEPLOY_SSH_PORT variable during deployments

### DIFF
--- a/.github/workflows/generic-deploy.yml
+++ b/.github/workflows/generic-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
 
           ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
-          ssh-keyscan -H "${{ vars.DEPLOY_HOST }}" >> ~/.ssh/known_hosts
+          ssh-keyscan -H -p "${{ vars.DEPLOY_SSH_PORT }}" "${{ vars.DEPLOY_HOST }}" >> ~/.ssh/known_hosts
 
       - name: Cache Ansible
         id: cache-ansible
@@ -69,6 +69,7 @@ jobs:
             -u "root" \
             --private-key ~/.ssh/id_rsa \
             -e "deploy_username=${{ vars.DEPLOY_USERNAME }}" \
+            -e "ansible_port=${{ vars.DEPLOY_SSH_PORT }}" \
             infra/ansible/server-setup-ubuntu.yml
         env:
           ANSIBLE_HOST_KEY_CHECKING: False


### PR DESCRIPTION
### Summary
As project moves to home server with gray IP, there's need to customize ssh port used for deployments:
- Use `DEPLOY_SSH_PORT` GitHub variable to set arbitrary port in all ssh operations

### Verification
- [ ] Deployment completes

### Checklist
- [ ] Code follows the style guidelines
- [ ] Unit tests added/updated
- [ ] Documentation updated
- [ ] No sensitive data committed
