### PR TITLE
chore: rename containers according to #176

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,7 @@
 services:
   db:
     image: postgres:18-alpine
+    container_name: goro-postgres-prod
     cpu_shares: 1024
     oom_score_adj: -800
     restart: unless-stopped
@@ -20,6 +21,7 @@ services:
 
   app:
     image: ghcr.io/mipselqq/goroutine:latest
+    container_name: goro-goroutine-prod
     cpu_shares: 1024
     oom_score_adj: -900
     restart: unless-stopped
@@ -52,6 +54,7 @@ services:
 
   prometheus:
     image: prom/prometheus:v3.9.1
+    container_name: goro-prometheus-prod
     cpu_shares: 512
     oom_score_adj: 100
     restart: unless-stopped
@@ -83,6 +86,7 @@ services:
 
   grafana:
     image: grafana/grafana:12.3.2
+    container_name: goro-grafana-prod
     cpu_shares: 256
     oom_score_adj: 200
     environment:
@@ -105,6 +109,7 @@ services:
 
   node_exporter:
     image: prom/node-exporter:v1.10.2
+    container_name: goro-node-exporter-prod
     cpu_shares: 128
     oom_score_adj: 500
     restart: unless-stopped
@@ -124,6 +129,7 @@ services:
 
   loki:
     image: grafana/loki:3.3.2
+    container_name: goro-loki-prod
     cpu_shares: 256
     oom_score_adj: 300
     restart: unless-stopped
@@ -138,6 +144,7 @@ services:
 
   alloy:
     image: grafana/alloy:v1.6.1
+    container_name: goro-alloy-prod
     cpu_shares: 128
     oom_score_adj: 400
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
     image: postgres:18-alpine
-    container_name: go_todo_db_dev
+    container_name: goro-postgres-dev
     cpu_shares: 1024
     oom_score_adj: -800
     restart: unless-stopped
@@ -23,6 +23,7 @@ services:
 
   prometheus:
     image: prom/prometheus:v3.9.1
+    container_name: goro-prometheus-dev
     cpu_shares: 512
     oom_score_adj: 100
     restart: unless-stopped
@@ -58,6 +59,7 @@ services:
 
   grafana:
     image: grafana/grafana:12.3.2
+    container_name: goro-grafana-dev
     cpu_shares: 256
     oom_score_adj: 200
     restart: unless-stopped
@@ -81,6 +83,7 @@ services:
 
   node_exporter:
     image: prom/node-exporter:v1.10.2
+    container_name: goro-node-exporter-dev
     cpu_shares: 128
     oom_score_adj: 500
     restart: unless-stopped
@@ -94,6 +97,7 @@ services:
 
   loki:
     image: grafana/loki:3.3.2
+    container_name: goro-loki-dev
     cpu_shares: 256
     oom_score_adj: 300
     restart: unless-stopped
@@ -110,6 +114,7 @@ services:
 
   alloy:
     image: grafana/alloy:v1.6.1
+    container_name: goro-alloy-dev
     cpu_shares: 128
     oom_score_adj: 400
     restart: unless-stopped


### PR DESCRIPTION
### Related Issues
Closes #176

### Summary
To keep docker docker container naming consistent, this PR sets container_name for each container.

### Verification
- [x] Changes do not affect codebase

### Checklist
- [x] Code follows the style guidelines
- [ ] Unit tests added/updated
- [ ] Documentation updated
- [x] No sensitive data committed
