### PR TITLE
fix: no order guarantees in repo/service methods returning multiple objects

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -22,7 +22,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Get many boards for the current user",
+                "description": "Get many boards for the current user. Results are returned in increasing creation time order.",
                 "consumes": [
                     "application/json"
                 ],
@@ -311,7 +311,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Get a board with nested columns and tasks for the current user (owner only)",
+                "description": "Get a board with nested columns and tasks for the current user (owner only). Columns are returned in increasing position order, and tasks inside each column are returned in increasing position order.",
                 "consumes": [
                     "application/json"
                 ],
@@ -372,7 +372,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Get all columns belonging to the specified board, ordered by position ASC.",
+                "description": "Get all columns belonging to the specified board. Results are returned in increasing position order.",
                 "produces": [
                     "application/json"
                 ],
@@ -718,7 +718,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Get all tasks belonging to the specified column, ordered by position ASC.",
+                "description": "Get all tasks belonging to the specified column. Results are returned in increasing position order.",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -14,7 +14,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Get many boards for the current user",
+                "description": "Get many boards for the current user. Results are returned in increasing creation time order.",
                 "consumes": [
                     "application/json"
                 ],
@@ -303,7 +303,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Get a board with nested columns and tasks for the current user (owner only)",
+                "description": "Get a board with nested columns and tasks for the current user (owner only). Columns are returned in increasing position order, and tasks inside each column are returned in increasing position order.",
                 "consumes": [
                     "application/json"
                 ],
@@ -364,7 +364,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Get all columns belonging to the specified board, ordered by position ASC.",
+                "description": "Get all columns belonging to the specified board. Results are returned in increasing position order.",
                 "produces": [
                     "application/json"
                 ],
@@ -710,7 +710,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Get all tasks belonging to the specified column, ordered by position ASC.",
+                "description": "Get all tasks belonging to the specified column. Results are returned in increasing position order.",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -292,7 +292,8 @@ paths:
     get:
       consumes:
       - application/json
-      description: Get many boards for the current user
+      description: Get many boards for the current user. Results are returned in increasing
+        creation time order.
       produces:
       - application/json
       responses:
@@ -480,7 +481,8 @@ paths:
       consumes:
       - application/json
       description: Get a board with nested columns and tasks for the current user
-        (owner only)
+        (owner only). Columns are returned in increasing position order, and tasks
+        inside each column are returned in increasing position order.
       parameters:
       - description: Board ID
         in: path
@@ -517,8 +519,8 @@ paths:
       - boards
   /v1/boards/{boardId}/columns:
     get:
-      description: Get all columns belonging to the specified board, ordered by position
-        ASC.
+      description: Get all columns belonging to the specified board. Results are returned
+        in increasing position order.
       parameters:
       - description: Board ID
         in: path
@@ -746,8 +748,8 @@ paths:
       - columns
   /v1/boards/{boardId}/columns/{columnId}/tasks:
     get:
-      description: Get all tasks belonging to the specified column, ordered by position
-        ASC.
+      description: Get all tasks belonging to the specified column. Results are returned
+        in increasing position order.
       parameters:
       - description: Board ID
         in: path

--- a/internal/http/handler/boards.go
+++ b/internal/http/handler/boards.go
@@ -183,7 +183,7 @@ func (h *Boards) Get(w http.ResponseWriter, r *http.Request) {
 
 // GetAggregate godoc
 // @Summary Get a board aggregate by id
-// @Description Get a board with nested columns and tasks for the current user (owner only)
+// @Description Get a board with nested columns and tasks for the current user (owner only). Columns are returned in increasing position order, and tasks inside each column are returned in increasing position order.
 // @Tags boards
 // @Accept json
 // @Produce json
@@ -223,7 +223,7 @@ func (h *Boards) GetAggregate(w http.ResponseWriter, r *http.Request) {
 
 // GetMany godoc
 // @Summary Get many boards
-// @Description Get many boards for the current user
+// @Description Get many boards for the current user. Results are returned in increasing creation time order.
 // @Tags boards
 // @Accept json
 // @Produce json

--- a/internal/http/handler/columns.go
+++ b/internal/http/handler/columns.go
@@ -127,7 +127,7 @@ func (h *Columns) Create(w http.ResponseWriter, r *http.Request) {
 
 // List godoc
 // @Summary List all columns in a board
-// @Description Get all columns belonging to the specified board, ordered by position ASC.
+// @Description Get all columns belonging to the specified board. Results are returned in increasing position order.
 // @Tags columns
 // @Produce json
 // @Security BearerAuth

--- a/internal/http/handler/tasks.go
+++ b/internal/http/handler/tasks.go
@@ -128,7 +128,7 @@ func (h *Tasks) Create(w http.ResponseWriter, r *http.Request) {
 
 // List godoc
 // @Summary List all tasks in a column
-// @Description Get all tasks belonging to the specified column, ordered by position ASC.
+// @Description Get all tasks belonging to the specified column. Results are returned in increasing position order.
 // @Tags tasks
 // @Produce json
 // @Security BearerAuth

--- a/internal/repository/board_test.go
+++ b/internal/repository/board_test.go
@@ -178,8 +178,8 @@ func TestBoardRepository_GetMany(t *testing.T) {
 			UpdatedAt:   testutil.FixedTime5mFromNow(),
 		}
 
-		InsertBoard(t, pool, &first)
 		InsertBoard(t, pool, &second)
+		InsertBoard(t, pool, &first)
 
 		got, err := r.GetMany(context.Background(), userID)
 		if err != nil {

--- a/internal/repository/column_test.go
+++ b/internal/repository/column_test.go
@@ -131,8 +131,8 @@ func TestColumnRepository_ListByBoardID(t *testing.T) {
 		second := testutil.NewValidColumn(t, boardA.ID, "In Progress", 2)
 		otherBoardColumn := testutil.NewValidColumn(t, boardB.ID, "Done", 1)
 
-		InsertColumn(t, pool, &first)
 		InsertColumn(t, pool, &second)
+		InsertColumn(t, pool, &first)
 		InsertColumn(t, pool, &otherBoardColumn)
 
 		got, err := r.ListByBoardID(context.Background(), boardA.ID)
@@ -305,9 +305,9 @@ func TestColumnRepository_Move(t *testing.T) {
 		second := testutil.NewValidColumn(t, board.ID, "In Progress", 2)
 		third := testutil.NewValidColumn(t, board.ID, "Done", 3)
 
+		InsertColumn(t, pool, &third)
 		InsertColumn(t, pool, &first)
 		InsertColumn(t, pool, &second)
-		InsertColumn(t, pool, &third)
 
 		targetPosition := mustColumnPosition(t, 3)
 
@@ -337,9 +337,9 @@ func TestColumnRepository_Move(t *testing.T) {
 		second := testutil.NewValidColumn(t, board.ID, "In Progress", 2)
 		third := testutil.NewValidColumn(t, board.ID, "Done", 3)
 
-		InsertColumn(t, pool, &first)
 		InsertColumn(t, pool, &second)
 		InsertColumn(t, pool, &third)
+		InsertColumn(t, pool, &first)
 
 		targetPosition := mustColumnPosition(t, 1)
 
@@ -368,8 +368,8 @@ func TestColumnRepository_Move(t *testing.T) {
 		first := testutil.ValidColumn(board.ID)
 		second := testutil.NewValidColumn(t, board.ID, "In Progress", 2)
 
-		InsertColumn(t, pool, &first)
 		InsertColumn(t, pool, &second)
+		InsertColumn(t, pool, &first)
 
 		targetPosition := mustColumnPosition(t, 2)
 
@@ -398,9 +398,9 @@ func TestColumnRepository_Move(t *testing.T) {
 		second := testutil.NewValidColumn(t, board.ID, "In Progress", 2)
 		third := testutil.NewValidColumn(t, board.ID, "Done", 3)
 
-		InsertColumn(t, pool, &first)
 		InsertColumn(t, pool, &second)
 		InsertColumn(t, pool, &third)
+		InsertColumn(t, pool, &first)
 
 		targetPosition := mustColumnPosition(t, 4)
 
@@ -456,9 +456,9 @@ func TestColumnRepository_Delete(t *testing.T) {
 		second := testutil.NewValidColumn(t, board.ID, "In Progress", 2)
 		third := testutil.NewValidColumn(t, board.ID, "Done", 3)
 
+		InsertColumn(t, pool, &third)
 		InsertColumn(t, pool, &first)
 		InsertColumn(t, pool, &second)
-		InsertColumn(t, pool, &third)
 
 		err := r.Delete(context.Background(), board.ID, second.ID)
 		if err != nil {

--- a/internal/repository/task_test.go
+++ b/internal/repository/task_test.go
@@ -129,8 +129,8 @@ func TestTaskRepository_ListByColumnID(t *testing.T) {
 		second := testutil.NewValidTask(t, columnA.ID, "Second", "second", 2)
 		otherColumnTask := testutil.NewValidTask(t, columnB.ID, "Other", "other", 1)
 
-		InsertTask(t, pool, &first)
 		InsertTask(t, pool, &second)
+		InsertTask(t, pool, &first)
 		InsertTask(t, pool, &otherColumnTask)
 
 		got, err := r.ListByColumnID(context.Background(), columnA.ID)
@@ -165,8 +165,8 @@ func TestTaskRepository_ListByBoardID(t *testing.T) {
 		thirdTask := testutil.ValidTask(secondColumn.ID)
 		otherBoardTask := testutil.ValidTask(otherBoardColumn.ID)
 
-		InsertTask(t, pool, &firstTask)
 		InsertTask(t, pool, &secondTask)
+		InsertTask(t, pool, &firstTask)
 		InsertTask(t, pool, &thirdTask)
 		InsertTask(t, pool, &otherBoardTask)
 
@@ -305,9 +305,9 @@ func TestTaskRepository_Move(t *testing.T) {
 		second := testutil.NewValidTask(t, column.ID, "Second", "second", 2)
 		third := testutil.NewValidTask(t, column.ID, "Third", "third", 3)
 
+		InsertTask(t, pool, &third)
 		InsertTask(t, pool, &first)
 		InsertTask(t, pool, &second)
-		InsertTask(t, pool, &third)
 
 		targetPosition := testutil.MustTaskPosition(t, 3)
 
@@ -340,9 +340,9 @@ func TestTaskRepository_Move(t *testing.T) {
 		second := testutil.NewValidTask(t, column.ID, "Second", "second", 2)
 		third := testutil.NewValidTask(t, column.ID, "Third", "third", 3)
 
-		InsertTask(t, pool, &first)
 		InsertTask(t, pool, &second)
 		InsertTask(t, pool, &third)
+		InsertTask(t, pool, &first)
 
 		targetPosition := testutil.MustTaskPosition(t, 1)
 
@@ -374,8 +374,8 @@ func TestTaskRepository_Move(t *testing.T) {
 		first := testutil.ValidTask(column.ID)
 		second := testutil.NewValidTask(t, column.ID, "Second", "second", 2)
 
-		InsertTask(t, pool, &first)
 		InsertTask(t, pool, &second)
+		InsertTask(t, pool, &first)
 
 		targetPosition := testutil.MustTaskPosition(t, 2)
 
@@ -407,9 +407,9 @@ func TestTaskRepository_Move(t *testing.T) {
 		second := testutil.NewValidTask(t, column.ID, "Second", "second", 2)
 		third := testutil.NewValidTask(t, column.ID, "Third", "third", 3)
 
-		InsertTask(t, pool, &first)
 		InsertTask(t, pool, &second)
 		InsertTask(t, pool, &third)
+		InsertTask(t, pool, &first)
 
 		targetPosition := testutil.MustTaskPosition(t, 4)
 
@@ -441,11 +441,11 @@ func TestTaskRepository_Move(t *testing.T) {
 		b1 := testutil.NewValidTask(t, columnB.ID, "B1", "b1", 1)
 		b2 := testutil.NewValidTask(t, columnB.ID, "B2", "b2", 2)
 
+		InsertTask(t, pool, &a3)
 		InsertTask(t, pool, &a1)
 		InsertTask(t, pool, &a2)
-		InsertTask(t, pool, &a3)
-		InsertTask(t, pool, &b1)
 		InsertTask(t, pool, &b2)
+		InsertTask(t, pool, &b1)
 
 		targetPosition := testutil.MustTaskPosition(t, 2)
 
@@ -494,8 +494,8 @@ func TestTaskRepository_Move(t *testing.T) {
 		a1 := testutil.ValidTask(columnA.ID)
 		b1 := testutil.NewValidTask(t, columnB.ID, "B1", "b1", 1)
 
-		InsertTask(t, pool, &a1)
 		InsertTask(t, pool, &b1)
+		InsertTask(t, pool, &a1)
 
 		targetPosition := testutil.MustTaskPosition(t, 2)
 
@@ -533,8 +533,8 @@ func TestTaskRepository_Move(t *testing.T) {
 		a1 := testutil.ValidTask(columnA.ID)
 		b1 := testutil.NewValidTask(t, columnB.ID, "B1", "b1", 1)
 
-		InsertTask(t, pool, &a1)
 		InsertTask(t, pool, &b1)
+		InsertTask(t, pool, &a1)
 
 		targetPosition := testutil.MustTaskPosition(t, 3)
 
@@ -594,9 +594,9 @@ func TestTaskRepository_Delete(t *testing.T) {
 		second := testutil.NewValidTask(t, column.ID, "Second", "second", 2)
 		third := testutil.NewValidTask(t, column.ID, "Third", "third", 3)
 
+		InsertTask(t, pool, &third)
 		InsertTask(t, pool, &first)
 		InsertTask(t, pool, &second)
-		InsertTask(t, pool, &third)
 
 		err := r.Delete(context.Background(), board.ID, column.ID, second.ID)
 		if err != nil {

--- a/internal/service/board.go
+++ b/internal/service/board.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"goroutine/internal/domain"
 	"goroutine/internal/repository"
@@ -104,9 +105,19 @@ func (s *Board) GetAggregate(ctx context.Context, callerID domain.UserID, boardI
 		Columns: make([]AggregateColumn, len(columns)),
 	}
 
+	sort.Slice(columns, func(i, j int) bool {
+		return columns[i].Position.Int64() < columns[j].Position.Int64()
+	})
+
 	columnIDToTaskMap := make(map[domain.ColumnID][]domain.Task, len(columns))
 	for _, t := range tasks {
 		columnIDToTaskMap[t.ColumnID] = append(columnIDToTaskMap[t.ColumnID], t)
+	}
+	for columnID, colTasks := range columnIDToTaskMap {
+		sort.Slice(colTasks, func(i, j int) bool {
+			return colTasks[i].Position.Int64() < colTasks[j].Position.Int64()
+		})
+		columnIDToTaskMap[columnID] = colTasks
 	}
 
 	for i, column := range columns {

--- a/internal/service/board_test.go
+++ b/internal/service/board_test.go
@@ -273,7 +273,7 @@ func TestBoard_GetAggregate(t *testing.T) {
 		wantAggregate   service.AggregateBoard
 	}{
 		{
-			name:     "Success",
+			name:     "Success sorts aggregate by positions",
 			callerID: validBoard.OwnerID,
 			setupBoardRepo: func(t *testing.T, r *MockBoardRepository) {
 				r.GetByIDFunc = func(ctx context.Context, id domain.BoardID) (domain.Board, error) {
@@ -288,7 +288,7 @@ func TestBoard_GetAggregate(t *testing.T) {
 					if boardID != validBoard.ID {
 						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
 					}
-					return []domain.Column{firstColumn, secondColumn}, nil
+					return []domain.Column{secondColumn, firstColumn}, nil
 				}
 			},
 			setupTaskRepo: func(t *testing.T, r *MockTaskRepository) {
@@ -296,7 +296,7 @@ func TestBoard_GetAggregate(t *testing.T) {
 					if boardID != validBoard.ID {
 						t.Errorf("got board id %v, want %v", boardID, validBoard.ID)
 					}
-					return []domain.Task{firstTask, secondTask, doneTask}, nil
+					return []domain.Task{secondTask, doneTask, firstTask}, nil
 				}
 			},
 			wantAggregate: wantAggregate,


### PR DESCRIPTION
### Related Issues
Closes #169 

### Summary
- Repository integration tests verify `List*` and `GetMany` operations ordering
- Boards service `Aggregate` returns sorted arrays independently from repositories implementation
- Unit tests verify `Aggregate` with intentionally broken ordering in mocks

### Verification
- [x] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [x] Unit tests added/updated
- [ ] Documentation updated
- [x] No sensitive data committed