### PR TITLE
fix: add login credentials when checking service availability

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -63,13 +63,18 @@ services:
       - ./infra/prometheus/web-config.template.yml:/etc/prometheus/web-config.yml.template:ro,Z
       - prometheus_data_prod:/prometheus
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "localhost:9090/-/healthy"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget --spider -q http://$$PROMETHEUS_USER:$$PROMETHEUS_PASSWORD@localhost:9090/-/healthy",
+        ]
       interval: 10s
       timeout: 5s
       retries: 3
     environment:
       - ADMIN_PORT
       - PROMETHEUS_USER
+      - PROMETHEUS_PASSWORD
       - PROMETHEUS_BCRYPT_HASH
     user: root
     entrypoint: ["/bin/sh", "-c"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -66,7 +66,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget --spider -q http://$$PROMETHEUS_USER:$$PROMETHEUS_PASSWORD@localhost:9090/-/healthy",
+          'wget --spider -q "http://$$PROMETHEUS_USER:$$PROMETHEUS_PASSWORD@localhost:9090/-/healthy"',
         ]
       interval: 10s
       timeout: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,11 @@ services:
       - ./infra/prometheus/web-config.template.yml:/etc/prometheus/web-config.yml.template:ro,Z
       - prometheus_data_dev:/prometheus
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "localhost:9090/-/healthy"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget --spider -q http://$$PROMETHEUS_USER:$$PROMETHEUS_PASSWORD@localhost:9090/-/healthy",
+        ]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -43,6 +47,7 @@ services:
     environment:
       - ADMIN_PORT
       - PROMETHEUS_USER
+      - PROMETHEUS_PASSWORD
       - PROMETHEUS_BCRYPT_HASH
     user: root
     entrypoint: ["/bin/sh", "-c"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget --spider -q http://$$PROMETHEUS_USER:$$PROMETHEUS_PASSWORD@localhost:9090/-/healthy",
+          'wget --spider -q "http://$$PROMETHEUS_USER:$$PROMETHEUS_PASSWORD@localhost:9090/-/healthy"',
         ]
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
### Summary
Some of the last changes added basic auth to Prometheus, but the healtcheck code was not updated to provide credentials, causing 'unhealthy' status for an effectively healthy container.
- Add basic auth support to healthcheck

### Verification
- [ ] Ssh'd into the server after a deployment, the container is healthy

### Checklist
- [x] Code follows the style guidelines
- [x] Unit, E2E, integration tests, load/race tests added or updated
- [ ] Documentation updated
- [x] No sensitive data committed
