### PR TITLE
fix: client disconnected treated as error

### DIFF
--- a/internal/config/app_test.go
+++ b/internal/config/app_test.go
@@ -75,7 +75,7 @@ func TestNewAppConfigFromEnv(t *testing.T) {
 
 	t.Run("warnings on unset variables", func(t *testing.T) {
 		UnsetEnv(t, appEnvVars...)
-		logger, buf := testutil.NewBufJsonLogger(t)
+		logger, buf := testutil.NewBufJsonLogger(t, slog.LevelWarn)
 		_ = config.NewAppConfigFromEnv(logger)
 
 		for _, envVar := range appEnvVars {
@@ -88,7 +88,7 @@ func TestNewAppConfigFromEnv(t *testing.T) {
 	t.Run("no warnings on all variables are set", func(t *testing.T) {
 		setCustomAppEnvVars(t)
 
-		logger, buf := testutil.NewBufJsonLogger(t)
+		logger, buf := testutil.NewBufJsonLogger(t, slog.LevelWarn)
 		_ = config.NewAppConfigFromEnv(logger)
 
 		if buf.String() != "" {

--- a/internal/config/database_test.go
+++ b/internal/config/database_test.go
@@ -62,7 +62,7 @@ func TestNewPGConfigFromEnv(t *testing.T) {
 	t.Run("warnings on unset variables", func(t *testing.T) {
 		UnsetEnv(t, pgEnvVars...)
 
-		logger, buf := testutil.NewBufJsonLogger(t)
+		logger, buf := testutil.NewBufJsonLogger(t, slog.LevelWarn)
 		_ = config.NewPGConfigFromEnv(logger)
 
 		for _, envVar := range pgEnvVars {
@@ -75,7 +75,7 @@ func TestNewPGConfigFromEnv(t *testing.T) {
 	t.Run("no warnings if all variables are set", func(t *testing.T) {
 		setCustomPgEnvVars(t)
 
-		logger, buf := testutil.NewBufJsonLogger(t)
+		logger, buf := testutil.NewBufJsonLogger(t, slog.LevelWarn)
 		_ = config.NewPGConfigFromEnv(logger)
 
 		if buf.String() != "" {

--- a/internal/http/httpschema/code_map.go
+++ b/internal/http/httpschema/code_map.go
@@ -13,6 +13,7 @@ var codeMap = map[string]string{
 	"USER_NOT_FOUND":        "User not found",
 	"INVALID_TOKEN":         "Invalid token",
 	"CLIENT_CLOSED_REQUEST": "Client closed request",
+	"REQUEST_TIMEOUT":       "Request timed out",
 }
 
 func MapCodeToDescription(code string) string {

--- a/internal/http/httpschema/code_map.go
+++ b/internal/http/httpschema/code_map.go
@@ -12,6 +12,7 @@ var codeMap = map[string]string{
 	"INVALID_AUTH_HEADER":   "Invalid authorization header",
 	"USER_NOT_FOUND":        "User not found",
 	"INVALID_TOKEN":         "Invalid token",
+	"CLIENT_CLOSED_REQUEST": "Client closed request",
 }
 
 func MapCodeToDescription(code string) string {

--- a/internal/http/httpschema/error_responder.go
+++ b/internal/http/httpschema/error_responder.go
@@ -1,6 +1,8 @@
 package httpschema
 
 import (
+	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 )
@@ -21,6 +23,11 @@ func MustNewErrorResponder(logger *slog.Logger, timeFn timeFunc) *ErrorResponder
 }
 
 func (r *ErrorResponder) InternalError(w http.ResponseWriter, req *http.Request, err error) {
+	if errors.Is(err, context.Canceled) {
+		r.logger.DebugContext(req.Context(), "Client closed request", slog.String("err", err.Error()))
+		r.Error(w, 499, "CLIENT_CLOSED_REQUEST")
+		return
+	}
 	r.logger.ErrorContext(req.Context(), "Internal server error", slog.String("err", err.Error()))
 	r.Error(w, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR")
 }

--- a/internal/http/httpschema/error_responder.go
+++ b/internal/http/httpschema/error_responder.go
@@ -28,6 +28,11 @@ func (r *ErrorResponder) InternalError(w http.ResponseWriter, req *http.Request,
 		r.Error(w, 499, "CLIENT_CLOSED_REQUEST")
 		return
 	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		r.logger.DebugContext(req.Context(), "Request timed out", slog.String("err", err.Error()))
+		r.Error(w, http.StatusRequestTimeout, "REQUEST_TIMEOUT")
+		return
+	}
 	r.logger.ErrorContext(req.Context(), "Internal server error", slog.String("err", err.Error()))
 	r.Error(w, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR")
 }

--- a/internal/http/httpschema/error_responder.go
+++ b/internal/http/httpschema/error_responder.go
@@ -25,12 +25,12 @@ func MustNewErrorResponder(logger *slog.Logger, timeFn timeFunc) *ErrorResponder
 func (r *ErrorResponder) InternalError(w http.ResponseWriter, req *http.Request, err error) {
 	if errors.Is(err, context.Canceled) {
 		r.logger.DebugContext(req.Context(), "Client closed request", slog.String("err", err.Error()))
-		r.Error(w, 499, "CLIENT_CLOSED_REQUEST")
+		w.WriteHeader(499)
 		return
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		r.logger.DebugContext(req.Context(), "Request timed out", slog.String("err", err.Error()))
-		r.Error(w, http.StatusRequestTimeout, "REQUEST_TIMEOUT")
+		w.WriteHeader(http.StatusRequestTimeout)
 		return
 	}
 	r.logger.ErrorContext(req.Context(), "Internal server error", slog.String("err", err.Error()))

--- a/internal/http/httpschema/error_responder.go
+++ b/internal/http/httpschema/error_responder.go
@@ -25,7 +25,7 @@ func MustNewErrorResponder(logger *slog.Logger, timeFn timeFunc) *ErrorResponder
 func (r *ErrorResponder) InternalError(w http.ResponseWriter, req *http.Request, err error) {
 	if errors.Is(err, context.Canceled) {
 		r.logger.DebugContext(req.Context(), "Client closed request", slog.String("err", err.Error()))
-		w.WriteHeader(499)
+		w.WriteHeader(499) // ClientClosedRequest, non-standard, used by nginx
 		return
 	}
 	if errors.Is(err, context.DeadlineExceeded) {

--- a/internal/http/httpschema/error_responder_test.go
+++ b/internal/http/httpschema/error_responder_test.go
@@ -30,23 +30,15 @@ func TestErrorResponder_InternalError(t *testing.T) {
 			name:         "wrapped context.Canceled returns 499 and logs DEBUG",
 			err:          fmt.Errorf("task service: create get board: %w", context.Canceled),
 			wantHTTPCode: 499,
-			wantBody: map[string]any{
-				"code":      "CLIENT_CLOSED_REQUEST",
-				"message":   "Client closed request",
-				"timestamp": testutil.FixedTimeNowStr(),
-			},
-			wantLevel: "DEBUG",
+			wantBody:     nil,
+			wantLevel:    "DEBUG",
 		},
 		{
 			name:         "wrapped context.DeadlineExceeded returns 408 and logs DEBUG",
 			err:          fmt.Errorf("board repo: get by id: %w", context.DeadlineExceeded),
 			wantHTTPCode: http.StatusRequestTimeout,
-			wantBody: map[string]any{
-				"code":      "REQUEST_TIMEOUT",
-				"message":   "Request timed out",
-				"timestamp": testutil.FixedTimeNowStr(),
-			},
-			wantLevel: "DEBUG",
+			wantBody:     nil,
+			wantLevel:    "DEBUG",
 		},
 		{
 			name:         "ordinary error returns 500 and logs ERROR",
@@ -74,7 +66,14 @@ func TestErrorResponder_InternalError(t *testing.T) {
 			er.InternalError(rr, req, tt.err)
 
 			testutil.AssertStatusCode(t, rr, tt.wantHTTPCode)
-			testutil.AssertResponseBody(t, rr, tt.wantBody)
+
+			if tt.wantBody == nil {
+				if rr.Body.Len() != 0 {
+					t.Fatalf("got body %q, want empty", rr.Body.String())
+				}
+			} else {
+				testutil.AssertResponseBody(t, rr, tt.wantBody)
+			}
 
 			assertLogLevel(t, buf, tt.wantLevel)
 		})

--- a/internal/http/httpschema/error_responder_test.go
+++ b/internal/http/httpschema/error_responder_test.go
@@ -38,6 +38,17 @@ func TestErrorResponder_InternalError(t *testing.T) {
 			wantLevel: "DEBUG",
 		},
 		{
+			name:         "wrapped context.DeadlineExceeded returns 408 and logs DEBUG",
+			err:          fmt.Errorf("board repo: get by id: %w", context.DeadlineExceeded),
+			wantHTTPCode: http.StatusRequestTimeout,
+			wantBody: map[string]any{
+				"code":      "REQUEST_TIMEOUT",
+				"message":   "Request timed out",
+				"timestamp": testutil.FixedTimeNowStr(),
+			},
+			wantLevel: "DEBUG",
+		},
+		{
 			name:         "ordinary error returns 500 and logs ERROR",
 			err:          fmt.Errorf("db connection refused"),
 			wantHTTPCode: http.StatusInternalServerError,

--- a/internal/http/httpschema/error_responder_test.go
+++ b/internal/http/httpschema/error_responder_test.go
@@ -29,7 +29,7 @@ func TestErrorResponder_InternalError(t *testing.T) {
 		{
 			name:         "wrapped context.Canceled returns 499 and logs DEBUG",
 			err:          fmt.Errorf("task service: create get board: %w", context.Canceled),
-			wantHTTPCode: 499,
+			wantHTTPCode: 499, // ClientClosedRequest, non-standard, used by nginx
 			wantBody:     nil,
 			wantLevel:    "DEBUG",
 		},

--- a/internal/http/httpschema/error_responder_test.go
+++ b/internal/http/httpschema/error_responder_test.go
@@ -1,0 +1,85 @@
+package httpschema_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"goroutine/internal/http/httpschema"
+	"goroutine/internal/testutil"
+)
+
+// Other methods are tested in handler tests indirectly
+
+func TestErrorResponder_InternalError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		err          error
+		wantHTTPCode int
+		wantBody     map[string]any
+		wantLevel    string
+	}{
+		{
+			name:         "wrapped context.Canceled returns 499 and logs DEBUG",
+			err:          fmt.Errorf("task service: create get board: %w", context.Canceled),
+			wantHTTPCode: 499,
+			wantBody: map[string]any{
+				"code":      "CLIENT_CLOSED_REQUEST",
+				"message":   "Client closed request",
+				"timestamp": testutil.FixedTimeNowStr(),
+			},
+			wantLevel: "DEBUG",
+		},
+		{
+			name:         "ordinary error returns 500 and logs ERROR",
+			err:          fmt.Errorf("db connection refused"),
+			wantHTTPCode: http.StatusInternalServerError,
+			wantBody: map[string]any{
+				"code":      "INTERNAL_SERVER_ERROR",
+				"message":   "Internal server error",
+				"timestamp": testutil.FixedTimeNowStr(),
+			},
+			wantLevel: "ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger, buf := testutil.NewBufJsonLogger(t, slog.LevelDebug)
+			er := httpschema.MustNewErrorResponder(logger, testutil.FixedTimeNowStr)
+
+			req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+			rr := httptest.NewRecorder()
+
+			er.InternalError(rr, req, tt.err)
+
+			testutil.AssertStatusCode(t, rr, tt.wantHTTPCode)
+			testutil.AssertResponseBody(t, rr, tt.wantBody)
+
+			assertLogLevel(t, buf, tt.wantLevel)
+		})
+	}
+}
+
+func assertLogLevel(t *testing.T, buf *bytes.Buffer, wantLevel string) {
+	t.Helper()
+
+	var entry struct {
+		Level string `json:"level"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log entry: %v", err)
+	}
+	if entry.Level != wantLevel {
+		t.Errorf("got log level %q, want %q", entry.Level, wantLevel)
+	}
+}

--- a/internal/http/middleware/cors_test.go
+++ b/internal/http/middleware/cors_test.go
@@ -1,6 +1,7 @@
 package middleware_test
 
 import (
+	"log/slog"
 	"maps"
 	"net/http"
 	"strings"
@@ -155,7 +156,7 @@ func TestCors_Wrap(t *testing.T) {
 func TestCors_WarnsAnyOriginAllowed(t *testing.T) {
 	t.Parallel()
 
-	logger, buf := testutil.NewBufJsonLogger(t)
+	logger, buf := testutil.NewBufJsonLogger(t, slog.LevelWarn)
 
 	_ = middleware.NewCORS(logger, config.ParseAllowedOrigins(goodSite+",*,"+awesomeSite))
 

--- a/internal/testutil/logging.go
+++ b/internal/testutil/logging.go
@@ -26,9 +26,9 @@ func NewTestLogger(t testing.TB) *slog.Logger {
 	return slog.New(slog.NewTextHandler(testWriter{t}, nil))
 }
 
-func NewBufJsonLogger(t testing.TB) (*slog.Logger, *bytes.Buffer) {
+func NewBufJsonLogger(t testing.TB, level slog.Level) (*slog.Logger, *bytes.Buffer) {
 	var buf bytes.Buffer
-	h := slog.NewJSONHandler(&buf, nil)
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: level})
 	logger := slog.New(h)
 	return logger, &buf
 }


### PR DESCRIPTION
### Summary
- Treat disconnects as 499 Client Closed Request
- Treat timeouts as 408 Request Timeout
- Log errors above at DEBUG level
- This avoids spam in metrics and logs

### Verification
- [x] Tests extended
- [x] Tests are green 

### Checklist
- [x] Code follows the style guidelines
- [x] Unit, E2E, integration tests, load/race tests added or updated
- [ ] Documentation updated
- [x] No sensitive data committed
