### PR TITLE
feat: add explicit timeouts

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -77,6 +78,7 @@ func New(
 	reqIDMiddleware := middleware.MustNewRequestID(logger, func() string {
 		return fmt.Sprintf("req-%s", uuid.Must(uuid.NewV7()))
 	})
+	timeoutMiddleware := middleware.NewTimeout(30 * time.Second)
 
 	handlers := &handler.Handlers{
 		Auth:    authHandler,
@@ -91,6 +93,7 @@ func New(
 		CORS:      corsMiddleware,
 		Auth:      authMiddleware,
 		RequestID: reqIDMiddleware,
+		Timeout:   timeoutMiddleware,
 	}
 
 	return &App{

--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -17,18 +17,29 @@ import (
 )
 
 func SetupPostgresFromEnv(logger *slog.Logger, migrationsDir string) (*pgxpool.Pool, error) {
-	cfg := config.NewPGFromEnv(logger)
+	envConfig := config.NewPGFromEnv(logger)
 
-	logger.Info("Database config", slog.Any("config", cfg))
+	logger.Info("Database config", slog.Any("config", envConfig))
 
-	poolConfig, err := cfg.ParsePGXpoolConfig()
+	cfg, err := pgxpool.ParseConfig(envConfig.BuildDSN().RevealSecret())
 	if err != nil {
 		logger.Error("Failed to parse database config", slog.String("err", err.Error()))
 		return nil, err
 	}
 
+	cfg.ConnConfig.ConnectTimeout = 10 * time.Second
+	cfg.PingTimeout = 5 * time.Second
+	cfg.MaxConnLifetime = 30 * time.Minute
+	cfg.MaxConnIdleTime = 5 * time.Minute
+
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = map[string]string{}
+	}
+	cfg.ConnConfig.RuntimeParams["statement_timeout"] = "5s"
+	cfg.ConnConfig.RuntimeParams["timezone"] = "UTC"
+
 	ctx := context.Background()
-	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		logger.Error("Failed to connect to database", slog.String("err", err.Error()))
 		return nil, err

--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -65,8 +65,13 @@ func SetupRedisFromEnv(logger *slog.Logger) (*redis.Client, error) {
 	logger.Info("Redis config", slog.Any("config", cfg))
 
 	client := redis.NewClient(&redis.Options{
-		Addr:     cfg.BuildAddr(),
-		Password: cfg.Password.RevealSecret(),
+		Addr:            cfg.BuildAddr(),
+		Password:        cfg.Password.RevealSecret(),
+		DialTimeout:     5 * time.Second,
+		ReadTimeout:     3 * time.Second,
+		WriteTimeout:    3 * time.Second,
+		PoolTimeout:     4 * time.Second,
+		ConnMaxIdleTime: 5 * time.Minute,
 	})
 
 	err := client.Ping(context.Background()).Err()

--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -27,8 +27,9 @@ func SetupPostgresFromEnv(logger *slog.Logger, migrationsDir string) (*pgxpool.P
 		return nil, err
 	}
 
+	pingTimeout := 5 * time.Second
 	cfg.ConnConfig.ConnectTimeout = 10 * time.Second
-	cfg.PingTimeout = 5 * time.Second
+	cfg.PingTimeout = pingTimeout
 	cfg.MaxConnLifetime = 30 * time.Minute
 	cfg.MaxConnIdleTime = 5 * time.Minute
 
@@ -38,13 +39,14 @@ func SetupPostgresFromEnv(logger *slog.Logger, migrationsDir string) (*pgxpool.P
 	cfg.ConnConfig.RuntimeParams["statement_timeout"] = "5s"
 	cfg.ConnConfig.RuntimeParams["timezone"] = "UTC"
 
-	ctx := context.Background()
-	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
 	if err != nil {
 		logger.Error("Failed to connect to database", slog.String("err", err.Error()))
 		return nil, err
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
+	defer cancel()
 	err = pool.Ping(ctx)
 	if err != nil {
 		logger.Error("Failed to ping database", slog.String("err", err.Error()))
@@ -85,7 +87,7 @@ func SetupRedisFromEnv(logger *slog.Logger) (*redis.Client, error) {
 		ConnMaxIdleTime: 5 * time.Minute,
 	})
 
-	err := client.Ping(context.Background()).Err()
+	err := client.Ping(context.Background()).Err() // Uses client timeouts
 	if err != nil {
 		logger.Error("Failed to ping Redis", slog.String("err", err.Error()))
 		return nil, err

--- a/internal/config/postgres.go
+++ b/internal/config/postgres.go
@@ -5,8 +5,6 @@ import (
 	"log/slog"
 
 	"goroutine/internal/secrecy"
-
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type PG struct {
@@ -29,20 +27,6 @@ func NewPGFromEnv(logger *slog.Logger) PG {
 
 func (c *PG) BuildDSN() secrecy.SecretString {
 	return secrecy.SecretString(fmt.Sprintf("postgres://%s:%s@%s:%s/%s", c.User, c.Password.RevealSecret(), c.Host, c.Port, c.DB))
-}
-
-func (c *PG) ParsePGXpoolConfig() (*pgxpool.Config, error) {
-	config, err := pgxpool.ParseConfig(c.BuildDSN().RevealSecret())
-	if err != nil {
-		return nil, err
-	}
-
-	if config.ConnConfig.RuntimeParams == nil {
-		config.ConnConfig.RuntimeParams = map[string]string{}
-	}
-	config.ConnConfig.RuntimeParams["timezone"] = "UTC"
-
-	return config, nil
 }
 
 //nolint:gocritic // Pointer receiver disables formatting

--- a/internal/config/postgres_test.go
+++ b/internal/config/postgres_test.go
@@ -96,17 +96,6 @@ func TestPG_BuildDSN(t *testing.T) {
 	testutil.AssertSecretHidden(t, want, dsn)
 }
 
-func TestPG_ParsePGXpoolConfig(t *testing.T) {
-	cfg, err := defaultPgConfig.ParsePGXpoolConfig()
-	if err != nil {
-		t.Fatalf("ParsePGXpoolConfig() error = %v", err)
-	}
-
-	if got := cfg.ConnConfig.RuntimeParams["timezone"]; got != "UTC" {
-		t.Errorf("ConnConfig.RuntimeParams[timezone] = %q, want %q", got, "UTC")
-	}
-}
-
 func TestPG_LogValue(t *testing.T) {
 	v := defaultPgConfig.LogValue()
 	if v.Kind() != slog.KindGroup {

--- a/internal/http/helpers_test.go
+++ b/internal/http/helpers_test.go
@@ -39,3 +39,12 @@ func (s *spyRequestIDMiddleware) Wrap(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
+
+type spyTimeoutMiddleware struct{}
+
+func (s *spyTimeoutMiddleware) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Timeout-Tracked", "true")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/http/middleware/middlewares.go
+++ b/internal/http/middleware/middlewares.go
@@ -11,4 +11,5 @@ type Middlewares struct {
 	CORS      Middleware
 	Auth      Middleware
 	RequestID Middleware
+	Timeout   Middleware
 }

--- a/internal/http/middleware/timeout.go
+++ b/internal/http/middleware/timeout.go
@@ -1,0 +1,24 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+type Timeout struct {
+	Duration time.Duration
+}
+
+func NewTimeout(d time.Duration) *Timeout {
+	return &Timeout{Duration: d}
+}
+
+// Prevents unexpected resource leaks by forcing context cancellation after specified duration
+func (m *Timeout) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), m.Duration)
+		defer cancel()
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/internal/http/middleware/timeout_test.go
+++ b/internal/http/middleware/timeout_test.go
@@ -1,0 +1,34 @@
+package middleware_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"goroutine/internal/http/middleware"
+	"goroutine/internal/testutil"
+)
+
+func TestTimeout(t *testing.T) {
+	var gotCtx context.Context
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { gotCtx = r.Context() })
+
+	wantTimeout := 500 * time.Millisecond
+	mw := middleware.NewTimeout(wantTimeout)
+
+	req, rr := testutil.NewJSONRequestAndRecorder(t, http.MethodGet, "/", http.NoBody)
+	mw.Wrap(handler).ServeHTTP(rr, req)
+
+	deadline, ok := gotCtx.Deadline()
+	if !ok {
+		t.Fatal("deadline not set")
+	}
+
+	timeout := time.Until(deadline)
+	threshold := 30 * time.Millisecond
+
+	if timeout > wantTimeout || timeout < wantTimeout-threshold {
+		t.Errorf("want deadline %vms, got %vms", wantTimeout, timeout)
+	}
+}

--- a/internal/http/route.go
+++ b/internal/http/route.go
@@ -47,7 +47,7 @@ func NewRouter(handlers *handler.Handlers, middlewares *middleware.Middlewares, 
 	mux.Handle("GET "+swaggerBasePath, NewSwaggerHandler(swaggerBasePath, loginPath))
 	mux.Handle("POST /webhook/telegram", middlewares.Metrics.Wrap(telegramWebhook))
 
-	return middlewares.RequestID.Wrap(middlewares.CORS.Wrap(mux))
+	return middlewares.Timeout.Wrap(middlewares.RequestID.Wrap(middlewares.CORS.Wrap(mux)))
 }
 
 func NewAdminRouter() *http.ServeMux {

--- a/internal/http/route_test.go
+++ b/internal/http/route_test.go
@@ -34,6 +34,7 @@ func TestNewRouter_Full(t *testing.T) {
 		CORS:      &spyCorsMiddleware{},
 		Auth:      &spyAuthMiddleware{},
 		RequestID: &spyRequestIDMiddleware{},
+		Timeout:   &spyTimeoutMiddleware{},
 	}
 	telegramWebhook := telegram.NewWebhookHandler(logger, nil, nil)
 
@@ -51,86 +52,87 @@ func TestNewRouter_Full(t *testing.T) {
 		metrics   bool
 		cors      bool
 		requestID bool
+		timeout   bool
 	}{
 		{
 			entry: entry{"Register", http.MethodPost, "/v1/register"},
-			auth:  false, metrics: true, cors: true, requestID: true,
+			auth:  false, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Login", http.MethodPost, "/v1/login"},
-			auth:  false, metrics: true, cors: true, requestID: true,
+			auth:  false, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Health", http.MethodGet, "/v1/health"},
-			auth:  false, metrics: true, cors: true, requestID: true,
+			auth:  false, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Boards list", http.MethodGet, "/v1/boards"},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Board by id", http.MethodGet, "/v1/boards/" + UUIDv7},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Board aggregate by id", http.MethodGet, "/v1/boards/" + UUIDv7 + "/aggregate"},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Update board", http.MethodPatch, "/v1/boards/" + UUIDv7},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Delete board", http.MethodDelete, "/v1/boards/" + UUIDv7},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Create column", http.MethodPost, "/v1/boards/" + UUIDv7 + "/columns"},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"List columns", http.MethodGet, "/v1/boards/" + UUIDv7 + "/columns"},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Update column", http.MethodPatch, "/v1/boards/" + UUIDv7 + "/columns/" + UUIDv7},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Move column", http.MethodPut, "/v1/boards/" + UUIDv7 + "/columns/" + UUIDv7 + "/position"},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Delete column", http.MethodDelete, "/v1/boards/" + UUIDv7 + "/columns/" + UUIDv7},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Create task", http.MethodPost, "/v1/boards/" + UUIDv7 + "/columns/" + UUIDv7 + "/tasks"},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"List tasks", http.MethodGet, "/v1/boards/" + UUIDv7 + "/columns/" + UUIDv7 + "/tasks"},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Update task", http.MethodPatch, "/v1/boards/" + UUIDv7 + "/columns/" + UUIDv7 + "/tasks/" + UUIDv7},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Move task", http.MethodPut, "/v1/boards/" + UUIDv7 + "/columns/" + UUIDv7 + "/tasks/" + UUIDv7 + "/position"},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Delete task", http.MethodDelete, "/v1/boards/" + UUIDv7 + "/columns/" + UUIDv7 + "/tasks/" + UUIDv7},
-			auth:  true, metrics: true, cors: true, requestID: true,
+			auth:  true, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Swagger", http.MethodGet, "/v1/swagger/index.html"},
-			auth:  false, metrics: false, cors: true, requestID: true,
+			auth:  false, metrics: false, cors: true, requestID: true, timeout: true,
 		},
 		{
 			entry: entry{"Telegram webhook", http.MethodPost, "/webhook/telegram"},
-			auth:  false, metrics: true, cors: true, requestID: true,
+			auth:  false, metrics: true, cors: true, requestID: true, timeout: true,
 		},
 	}
 
@@ -165,6 +167,11 @@ func TestNewRouter_Full(t *testing.T) {
 			hasReqID := rr.Header().Get("X-RequestId-Tracked") == "true"
 			if hasReqID != tt.requestID {
 				t.Errorf("got request ID middleware=%v for %q, want %v", hasReqID, tt.entry.path, tt.requestID)
+			}
+
+			hasTimeout := rr.Header().Get("X-Timeout-Tracked") == "true"
+			if hasTimeout != tt.timeout {
+				t.Errorf("got timeout middleware=%v for %q, want %v", hasTimeout, tt.entry.path, tt.timeout)
 			}
 		})
 	}


### PR DESCRIPTION
### Related Issues
Closes #204 

### Summary
This PR adds various timeouts to improve performance by releasing stuck resources and make it clear when the server hangs instead of holding queries for a long time.

### Technical Details
- The timeouts are set with a margin
- Explicit timeouts make the code obvious to troubleshoot
- Timeouts are not configurable from env variables since they will never be tweaked, speaking honestly 

### Verification
- [x] Tests are green
- [x] K6 happy path test run shows no performance gains or regressions

### Checklist
- [x] Code follows the style guidelines
- [x] Unit, E2E, integration tests, load/race tests added or updated
- [x] Documentation updated
- [x] No sensitive data committed
