### PR TITLE
refactor: ditch log and return antipattern

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN go mod download
 COPY . .
 RUN make build-bin
 
-FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b0f95cfd3baed1f36083ddb47ca3160
+FROM gcr.io/distroless/static-debian12@sha256:22fd79fd75eab2372585b44517f8a094349938919dc613aafc37e4bdc9967c82
 
 COPY --from=builder /bin/app /app
 COPY --from=builder /bin/ping /ping

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -48,11 +48,13 @@ func main() {
 
 	pool, err := app.SetupPostgresFromEnv(logger, "migrations")
 	if err != nil {
+		logger.Error("failed to setup postgres", slog.String("err", err.Error()))
 		os.Exit(1)
 	}
 
 	redisClient, err := app.SetupRedisFromEnv(logger)
 	if err != nil {
+		logger.Error("failed to setup redis", slog.String("err", err.Error()))
 		pool.Close()
 		os.Exit(1)
 	}

--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -23,8 +24,7 @@ func SetupPostgresFromEnv(logger *slog.Logger, migrationsDir string) (*pgxpool.P
 
 	cfg, err := pgxpool.ParseConfig(envConfig.BuildDSN().RevealSecret())
 	if err != nil {
-		logger.Error("Failed to parse database config", slog.String("err", err.Error()))
-		return nil, err
+		return nil, fmt.Errorf("failed to parse database config: %v", err)
 	}
 
 	pingTimeout := 5 * time.Second
@@ -41,32 +41,28 @@ func SetupPostgresFromEnv(logger *slog.Logger, migrationsDir string) (*pgxpool.P
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
 	if err != nil {
-		logger.Error("Failed to connect to database", slog.String("err", err.Error()))
-		return nil, err
+		return nil, fmt.Errorf("failed to connect to database: %v", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
 	defer cancel()
 	err = pool.Ping(ctx)
 	if err != nil {
-		logger.Error("Failed to ping database", slog.String("err", err.Error()))
-		return nil, err
+		return nil, fmt.Errorf("failed to ping database: %v", err)
 	}
 
 	goose.SetLogger(&logging.GooseLogger{Base: logger})
 
 	err = goose.SetDialect("postgres")
 	if err != nil {
-		logger.Error("Failed to set goose dialect", slog.String("err", err.Error()))
-		return nil, err
+		return nil, fmt.Errorf("failed to set goose dialect: %v", err)
 	}
 
 	db := stdlib.OpenDBFromPool(pool)
 
 	err = goose.Up(db, migrationsDir)
 	if err != nil {
-		logger.Error("Failed to run migrations", slog.String("err", err.Error()))
-		return nil, err
+		return nil, fmt.Errorf("failed to run migrations: %v", err)
 	}
 
 	return pool, nil
@@ -89,8 +85,7 @@ func SetupRedisFromEnv(logger *slog.Logger) (*redis.Client, error) {
 
 	err := client.Ping(context.Background()).Err() // Uses client timeouts
 	if err != nil {
-		logger.Error("Failed to ping Redis", slog.String("err", err.Error()))
-		return nil, err
+		return nil, fmt.Errorf("failed to ping redis: %v", err)
 	}
 
 	return client, nil

--- a/internal/http/handler/auth.go
+++ b/internal/http/handler/auth.go
@@ -166,7 +166,6 @@ type whoAmIResponse struct {
 func (h *Auth) WhoAmI(w http.ResponseWriter, r *http.Request) {
 	uid, ok := r.Context().Value(httpschema.ContextKeyUserID).(domain.UserID)
 	if !ok {
-		h.logger.ErrorContext(r.Context(), "BUG: failed to get user id from context")
 		h.responder.InternalError(w, r, errors.New("failed to get user id from context"))
 		return
 	}


### PR DESCRIPTION
### Related Issues
Refers to #196

### Summary
- Avoid spam due to double logging by removing logs on a callee side and adding them to the caller

### Verification
- [x] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [ ] Unit, E2E, integration tests, load/race tests added or updated
- [ ] Documentation updated
- [x] No sensitive data committed
