### PR TITLE
refactor: integration and e2e tests cleanup

### DIFF
--- a/internal/repository/board_test.go
+++ b/internal/repository/board_test.go
@@ -58,20 +58,9 @@ func TestBoardRepository_Create(t *testing.T) {
 		if !ok {
 			t.Fatalf("created board %q not found in DB", board.ID)
 		}
-		if stored.OwnerID != userID {
-			t.Errorf("DB: got owner ID %q, want %q", stored.OwnerID, userID)
-		}
-		if stored.Name != boardName {
-			t.Errorf("DB: got name %q, want %q", stored.Name, boardName)
-		}
-		if stored.Description != boardDescription {
-			t.Errorf("DB: got description %q, want %q", stored.Description, boardDescription)
-		}
-		if !stored.CreatedAt.Equal(board.CreatedAt) {
-			t.Errorf("DB: got created_at %v, want %v", stored.CreatedAt, board.CreatedAt)
-		}
-		if !stored.UpdatedAt.Equal(board.UpdatedAt) {
-			t.Errorf("DB: got updated_at %v, want %v", stored.UpdatedAt, board.UpdatedAt)
+		diff := cmp.Diff(board, stored, testutil.CmpAllowUnexported())
+		if diff != "" {
+			t.Errorf("stored board mismatch (-returned +stored):\n%s", diff)
 		}
 	})
 }

--- a/internal/repository/board_test.go
+++ b/internal/repository/board_test.go
@@ -54,12 +54,11 @@ func TestBoardRepository_Create(t *testing.T) {
 		}
 		AssertTimestampPrecisionAtLeastMillis(t, pool, "boards", "created_at", "updated_at")
 
-		stored, ok := GetBoard(t, pool, board.ID)
-		if !ok {
-			t.Fatalf("created board %q not found in DB", board.ID)
+		storedBoards := ListBoards(t, pool)
+		if len(storedBoards) != 1 {
+			t.Fatalf("ListBoards() returned %d boards, want exactly 1", len(storedBoards))
 		}
-		diff := cmp.Diff(board, stored, testutil.CmpAllowUnexported())
-		if diff != "" {
+		if diff := cmp.Diff(board, storedBoards[0], testutil.CmpAllowUnexported()); diff != "" {
 			t.Errorf("stored board mismatch (-returned +stored):\n%s", diff)
 		}
 	})
@@ -223,11 +222,11 @@ func TestBoardRepository_Update(t *testing.T) {
 		}
 		AssertTimestampPrecisionAtLeastMillis(t, pool, "boards", "created_at", "updated_at")
 
-		stored, ok := GetBoard(t, pool, validBoard.ID)
-		if !ok {
-			t.Fatalf("updated board %q not found in DB", validBoard.ID)
+		storedBoards := ListBoards(t, pool)
+		if len(storedBoards) != 1 {
+			t.Fatalf("ListBoards() returned %d boards, want exactly 1", len(storedBoards))
 		}
-		if diff := cmp.Diff(got, stored, testutil.CmpAllowUnexported()); diff != "" {
+		if diff := cmp.Diff(got, storedBoards[0], testutil.CmpAllowUnexported()); diff != "" {
 			t.Errorf("got stored board mismatch (-want +got):\n%s", diff)
 		}
 	}
@@ -294,9 +293,9 @@ func TestBoardRepository_Delete(t *testing.T) {
 			t.Errorf("Delete() error = %v", err)
 		}
 
-		_, ok := GetBoard(t, pool, board.ID)
-		if ok {
-			t.Errorf("got board %q in DB, want deleted row", board.ID)
+		storedBoards := ListBoards(t, pool)
+		if len(storedBoards) != 0 {
+			t.Errorf("ListBoards() returned %d boards after delete, want 0", len(storedBoards))
 		}
 	})
 

--- a/internal/repository/column_test.go
+++ b/internal/repository/column_test.go
@@ -62,11 +62,11 @@ func TestColumnRepository_Create(t *testing.T) {
 		}
 		AssertTimestampPrecisionAtLeastMillis(t, pool, "columns", "created_at", "updated_at")
 
-		stored, ok := GetColumn(t, pool, column.ID)
-		if !ok {
-			t.Fatalf("created column %q not found in DB", column.ID)
+		storedColumns := ListColumnsByBoardID(t, pool, board.ID)
+		if len(storedColumns) != 1 {
+			t.Fatalf("ListColumnsByBoardID() returned %d columns, want exactly 1", len(storedColumns))
 		}
-		if diff := cmp.Diff(column, stored, testutil.CmpAllowUnexported()); diff != "" {
+		if diff := cmp.Diff(column, storedColumns[0], testutil.CmpAllowUnexported()); diff != "" {
 			t.Errorf("got stored column mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -204,11 +204,11 @@ func TestColumnRepository_Update(t *testing.T) {
 		}
 		AssertTimestampPrecisionAtLeastMillis(t, pool, "columns", "created_at", "updated_at")
 
-		stored, ok := GetColumn(t, pool, want.ID)
-		if !ok {
-			t.Fatalf("updated column %q not found in DB", want.ID)
+		storedColumns := ListColumnsByBoardID(t, pool, want.BoardID)
+		if len(storedColumns) != 1 {
+			t.Fatalf("ListColumnsByBoardID() returned %d columns, want exactly 1", len(storedColumns))
 		}
-		if diff := cmp.Diff(got, stored, testutil.CmpAllowUnexported()); diff != "" {
+		if diff := cmp.Diff(got, storedColumns[0], testutil.CmpAllowUnexported()); diff != "" {
 			t.Errorf("got stored column mismatch (-want +got):\n%s", diff)
 		}
 	}
@@ -260,12 +260,13 @@ func TestColumnRepository_Update(t *testing.T) {
 		if updated.Description != newDesc {
 			t.Errorf("got description %q, want %q", updated.Description, newDesc)
 		}
-		stored, ok := GetColumn(t, pool, created.ID)
-		if !ok {
-			t.Fatalf("column not found after update")
+		storedColumns := ListColumnsByBoardID(t, pool, created.BoardID)
+		if len(storedColumns) != 1 {
+			t.Fatalf("ListColumnsByBoardID() returned %d columns, want exactly 1", len(storedColumns))
 		}
-		if stored.Description != newDesc {
-			t.Errorf("stored description %q, want %q", stored.Description, newDesc)
+		storedColumn := storedColumns[0]
+		if storedColumn.Description != newDesc {
+			t.Errorf("stored description %q, want %q", storedColumn.Description, newDesc)
 		}
 	})
 
@@ -472,11 +473,6 @@ func TestColumnRepository_Delete(t *testing.T) {
 		}
 		assertColumnIDAndPosition(t, &got[0], first.ID, 1)
 		assertColumnIDAndPosition(t, &got[1], third.ID, 2)
-
-		_, ok := GetColumn(t, pool, second.ID)
-		if ok {
-			t.Error("got deleted column in DB, want absent")
-		}
 	})
 
 	t.Run("Not found by column id", func(t *testing.T) {

--- a/internal/repository/postgres_test.go
+++ b/internal/repository/postgres_test.go
@@ -10,7 +10,6 @@ import (
 	"goroutine/internal/repository"
 	"goroutine/internal/testutil"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -58,7 +57,7 @@ func CreateBoard(t *testing.T, pool *pgxpool.Pool, board *domain.Board) {
 	}
 }
 
-func GetBoard(t *testing.T, pool *pgxpool.Pool, boardID domain.BoardID) (domain.Board, bool) {
+func ListBoards(t *testing.T, pool *pgxpool.Pool) []domain.Board {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -67,17 +66,29 @@ func GetBoard(t *testing.T, pool *pgxpool.Pool, boardID domain.BoardID) (domain.
 	const q = `
 			SELECT id, owner_id, name, description, created_at, updated_at
 			FROM boards
-			WHERE id = $1`
+			ORDER BY created_at ASC`
 
-	board, err := repository.ScanBoard(pool.QueryRow(ctx, q, boardID))
+	rows, err := pool.Query(ctx, q)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return domain.Board{}, false
+		t.Fatalf("ListBoards() error = %v", err)
+	}
+	defer rows.Close()
+
+	var boards []domain.Board
+	for rows.Next() {
+		board, scanErr := repository.ScanBoard(rows)
+		if scanErr != nil {
+			t.Fatalf("Board row Scan() error = %v", scanErr)
 		}
-		t.Fatalf("GetBoard() error = %v", err)
+		boards = append(boards, board)
 	}
 
-	return board, true
+	err = rows.Err()
+	if err != nil {
+		t.Fatalf("rows.Err() error = %v", err)
+	}
+
+	return boards
 }
 
 func CreateColumn(t *testing.T, pool *pgxpool.Pool, column *domain.Column) {
@@ -102,28 +113,6 @@ func CreateColumn(t *testing.T, pool *pgxpool.Pool, column *domain.Column) {
 	if err != nil {
 		t.Fatalf("CreateColumn() error = %v", err)
 	}
-}
-
-func GetColumn(t *testing.T, pool *pgxpool.Pool, columnID domain.ColumnID) (domain.Column, bool) {
-	t.Helper()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	const q = `
-			SELECT id, board_id, name, description, position, created_at, updated_at
-			FROM columns
-			WHERE id = $1`
-
-	column, err := repository.ScanColumn(pool.QueryRow(ctx, q, columnID))
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return domain.Column{}, false
-		}
-		t.Fatalf("GetColumn() error = %v", err)
-	}
-
-	return column, true
 }
 
 func ListColumnsByBoardID(t *testing.T, pool *pgxpool.Pool, boardID domain.BoardID) []domain.Column {
@@ -184,28 +173,6 @@ func CreateTask(t *testing.T, pool *pgxpool.Pool, task *domain.Task) {
 	if err != nil {
 		t.Fatalf("CreateTask() error = %v", err)
 	}
-}
-
-func GetTask(t *testing.T, pool *pgxpool.Pool, taskID domain.TaskID) (domain.Task, bool) {
-	t.Helper()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	const q = `
-			SELECT id, column_id, name, description, position, created_at, updated_at
-			FROM tasks
-			WHERE id = $1`
-
-	task, err := repository.ScanTask(pool.QueryRow(ctx, q, taskID))
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return domain.Task{}, false
-		}
-		t.Fatalf("GetTask() error = %v", err)
-	}
-
-	return task, true
 }
 
 func ListTasksByColumnID(t *testing.T, pool *pgxpool.Pool, columnID domain.ColumnID) []domain.Task {
@@ -289,23 +256,35 @@ func AssertTimestampPrecisionAtLeastMillis(t *testing.T, pool *pgxpool.Pool, tab
 	}
 }
 
-func GetUser(t *testing.T, pool *pgxpool.Pool, userID domain.UserID) (domain.User, bool) {
+func ListUsers(t *testing.T, pool *pgxpool.Pool) []domain.User {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	const q = `SELECT id, email, password_hash, telegram_chat_id, telegram_username FROM users WHERE id = $1`
+	const q = `SELECT id, email, password_hash, telegram_chat_id, telegram_username FROM users ORDER BY id`
 
-	user, err := repository.ScanUser(pool.QueryRow(ctx, q, userID))
+	rows, err := pool.Query(ctx, q)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return domain.User{}, false
+		t.Fatalf("ListUsers() error = %v", err)
+	}
+	defer rows.Close()
+
+	var users []domain.User
+	for rows.Next() {
+		user, scanErr := repository.ScanUser(rows)
+		if scanErr != nil {
+			t.Fatalf("User row Scan() error = %v", scanErr)
 		}
-		t.Fatalf("GetUser() error = %v", err)
+		users = append(users, user)
 	}
 
-	return user, true
+	err = rows.Err()
+	if err != nil {
+		t.Fatalf("rows.Err() error = %v", err)
+	}
+
+	return users
 }
 
 func assertErrRowNotFound(t *testing.T, err error) {

--- a/internal/repository/postgres_test.go
+++ b/internal/repository/postgres_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// TODO: remove this function. Too implicit.
 func CreateFixedUser(t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
 

--- a/internal/repository/postgres_test.go
+++ b/internal/repository/postgres_test.go
@@ -40,11 +40,11 @@ func CreateBoard(t *testing.T, pool *pgxpool.Pool, board *domain.Board) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	const q = `
+	const query = `
 			INSERT INTO boards (id, owner_id, name, description, created_at, updated_at)
 			VALUES ($1, $2, $3, $4, $5, $6)`
 	_, err := pool.Exec(
-		ctx, q,
+		ctx, query,
 		board.ID,
 		board.OwnerID,
 		board.Name,
@@ -63,12 +63,12 @@ func ListBoards(t *testing.T, pool *pgxpool.Pool) []domain.Board {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	const q = `
+	const query = `
 			SELECT id, owner_id, name, description, created_at, updated_at
 			FROM boards
 			ORDER BY created_at ASC`
 
-	rows, err := pool.Query(ctx, q)
+	rows, err := pool.Query(ctx, query)
 	if err != nil {
 		t.Fatalf("ListBoards() error = %v", err)
 	}
@@ -97,11 +97,11 @@ func CreateColumn(t *testing.T, pool *pgxpool.Pool, column *domain.Column) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	const q = `
+	const query = `
 			INSERT INTO columns (id, board_id, name, description, position, created_at, updated_at)
 			VALUES ($1, $2, $3, $4, $5, $6, $7)`
 	_, err := pool.Exec(
-		ctx, q,
+		ctx, query,
 		column.ID,
 		column.BoardID,
 		column.Name,
@@ -121,13 +121,13 @@ func ListColumnsByBoardID(t *testing.T, pool *pgxpool.Pool, boardID domain.Board
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	const q = `
+	const query = `
 			SELECT id, board_id, name, description, position, created_at, updated_at
 			FROM columns
 			WHERE board_id = $1
 			ORDER BY position ASC`
 
-	rows, err := pool.Query(ctx, q, boardID)
+	rows, err := pool.Query(ctx, query, boardID)
 	if err != nil {
 		t.Fatalf("ListColumnsByBoardID() error = %v", err)
 	}
@@ -157,11 +157,11 @@ func CreateTask(t *testing.T, pool *pgxpool.Pool, task *domain.Task) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	const q = `
+	const query = `
 			INSERT INTO tasks (id, column_id, name, description, position, created_at, updated_at)
 			VALUES ($1, $2, $3, $4, $5, $6, $7)`
 	_, err := pool.Exec(
-		ctx, q,
+		ctx, query,
 		task.ID,
 		task.ColumnID,
 		task.Name,
@@ -181,13 +181,13 @@ func ListTasksByColumnID(t *testing.T, pool *pgxpool.Pool, columnID domain.Colum
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	const q = `
+	const query = `
 			SELECT id, column_id, name, description, position, created_at, updated_at
 			FROM tasks
 			WHERE column_id = $1
 			ORDER BY position ASC`
 
-	rows, err := pool.Query(ctx, q, columnID)
+	rows, err := pool.Query(ctx, query, columnID)
 	if err != nil {
 		t.Fatalf("ListTasksByColumnID() error = %v", err)
 	}
@@ -262,9 +262,9 @@ func ListUsers(t *testing.T, pool *pgxpool.Pool) []domain.User {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	const q = `SELECT id, email, password_hash, telegram_chat_id, telegram_username FROM users ORDER BY id`
+	const query = `SELECT id, email, password_hash, telegram_chat_id, telegram_username FROM users ORDER BY id`
 
-	rows, err := pool.Query(ctx, q)
+	rows, err := pool.Query(ctx, query)
 	if err != nil {
 		t.Fatalf("ListUsers() error = %v", err)
 	}

--- a/internal/repository/task_test.go
+++ b/internal/repository/task_test.go
@@ -65,11 +65,11 @@ func TestTaskRepository_Create(t *testing.T) {
 		}
 		AssertTimestampPrecisionAtLeastMillis(t, pool, "tasks", "created_at", "updated_at")
 
-		stored, ok := GetTask(t, pool, task.ID)
-		if !ok {
-			t.Fatalf("created task %q not found in DB", task.ID)
+		storedTasks := ListTasksByColumnID(t, pool, column.ID)
+		if len(storedTasks) != 1 {
+			t.Fatalf("ListTasksByColumnID() returned %d tasks, want exactly 1", len(storedTasks))
 		}
-		if diff := cmp.Diff(task, stored, testutil.CmpAllowUnexported()); diff != "" {
+		if diff := cmp.Diff(task, storedTasks[0], testutil.CmpAllowUnexported()); diff != "" {
 			t.Errorf("got stored task mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -239,11 +239,11 @@ func TestTaskRepository_Update(t *testing.T) {
 		}
 		AssertTimestampPrecisionAtLeastMillis(t, pool, "tasks", "created_at", "updated_at")
 
-		stored, ok := GetTask(t, pool, want.ID)
-		if !ok {
-			t.Fatalf("updated task %q not found in DB", want.ID)
+		storedTasks := ListTasksByColumnID(t, pool, want.ColumnID)
+		if len(storedTasks) != 1 {
+			t.Fatalf("ListTasksByColumnID() returned %d tasks, want exactly 1", len(storedTasks))
 		}
-		if diff := cmp.Diff(got, stored, testutil.CmpAllowUnexported()); diff != "" {
+		if diff := cmp.Diff(got, storedTasks[0], testutil.CmpAllowUnexported()); diff != "" {
 			t.Errorf("got stored task mismatch (-want +got):\n%s", diff)
 		}
 	}
@@ -474,14 +474,6 @@ func TestTaskRepository_Move(t *testing.T) {
 		assertTaskIDAndPosition(t, &gotB[0], b1.ID, 1)
 		assertTaskIDAndPosition(t, &gotB[1], a2.ID, 2)
 		assertTaskIDAndPosition(t, &gotB[2], b2.ID, 3)
-
-		movedTask, ok := GetTask(t, pool, a2.ID)
-		if !ok {
-			t.Fatalf("moved task %q not found in DB", a2.ID)
-		}
-		if movedTask.ColumnID != columnB.ID {
-			t.Errorf("got moved columnID %q, want %q", movedTask.ColumnID, columnB.ID)
-		}
 	})
 
 	t.Run("Success move across columns to append", func(t *testing.T) {
@@ -610,11 +602,6 @@ func TestTaskRepository_Delete(t *testing.T) {
 		}
 		assertTaskIDAndPosition(t, &got[0], first.ID, 1)
 		assertTaskIDAndPosition(t, &got[1], third.ID, 2)
-
-		_, ok := GetTask(t, pool, second.ID)
-		if ok {
-			t.Error("got deleted task in DB, want absent")
-		}
 	})
 
 	t.Run("Not found by task id", func(t *testing.T) {

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -114,15 +114,16 @@ func TestUserRepository_UpdateTelegramInfo(t *testing.T) {
 			t.Fatalf("UpdateTelegramInfo() error = %v", err)
 		}
 
-		user, found := GetUser(t, pool, userID)
-		if !found {
-			t.Fatal("GetUser() user not found")
+		storedUsers := ListUsers(t, pool)
+		if len(storedUsers) != 1 {
+			t.Fatalf("ListUsers() returned %d users, want exactly 1", len(storedUsers))
 		}
-		if user.TelegramChatID != chatID {
-			t.Errorf("got chatID %v, want %v", user.TelegramChatID, chatID)
+		storedUser := storedUsers[0]
+		if storedUser.TelegramChatID != chatID {
+			t.Errorf("got chatID %v, want %v", storedUser.TelegramChatID, chatID)
 		}
-		if user.TelegramUsername != username {
-			t.Errorf("got username %v, want %v", user.TelegramUsername, username)
+		if storedUser.TelegramUsername != username {
+			t.Errorf("got username %v, want %v", storedUser.TelegramUsername, username)
 		}
 	})
 

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -17,36 +17,34 @@ import (
 func TestAuth_HappyPath(t *testing.T) {
 	p := Prelude(t)
 
-	t.Run("Full auth flow: register then login", func(t *testing.T) {
-		testutil.TruncateAllTables(t, p.Pool)
+	testutil.TruncateAllTables(t, p.Pool)
 
-		ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
+	ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
 
-		parts := strings.Split(ac.Token, ".")
-		if len(parts) != 3 {
-			t.Fatalf("got %d JWT segments, want 3", len(parts))
-		}
+	parts := strings.Split(ac.Token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("got %d JWT segments, want 3", len(parts))
+	}
 
-		whoamiResp := ac.Do(t, http.MethodGet, "/v1/whoami", nil)
-		defer func() {
-			_ = whoamiResp.Body.Close()
-		}()
+	whoamiResp := ac.Do(t, http.MethodGet, "/v1/whoami", nil)
+	defer func() {
+		_ = whoamiResp.Body.Close()
+	}()
 
-		if whoamiResp.StatusCode != http.StatusOK {
-			t.Fatalf("got status %d, want %d", whoamiResp.StatusCode, http.StatusOK)
-		}
+	if whoamiResp.StatusCode != http.StatusOK {
+		t.Fatalf("got status %d, want %d", whoamiResp.StatusCode, http.StatusOK)
+	}
 
-		var whoamiData struct {
-			UID string `json:"uid"`
-		}
-		err := json.NewDecoder(whoamiResp.Body).Decode(&whoamiData)
-		if err != nil {
-			t.Fatalf("Whoami response Decode() error = %v", err)
-		}
+	var whoamiData struct {
+		UID string `json:"uid"`
+	}
+	err := json.NewDecoder(whoamiResp.Body).Decode(&whoamiData)
+	if err != nil {
+		t.Fatalf("Whoami response Decode() error = %v", err)
+	}
 
-		_, err = uuid.Parse(whoamiData.UID)
-		if err != nil {
-			t.Errorf("uuid.Parse(%q) error = %v, want nil", whoamiData.UID, err)
-		}
-	})
+	_, err = uuid.Parse(whoamiData.UID)
+	if err != nil {
+		t.Errorf("uuid.Parse(%q) error = %v, want nil", whoamiData.UID, err)
+	}
 }

--- a/tests/board_test.go
+++ b/tests/board_test.go
@@ -38,192 +38,190 @@ type BoardAggregateJSON struct {
 func TestBoard_HappyPath(t *testing.T) {
 	p := Prelude(t)
 
-	t.Run("Full board flow", func(t *testing.T) {
-		testutil.TruncateAllTables(t, p.Pool)
+	testutil.TruncateAllTables(t, p.Pool)
 
-		// 1. Register (already done via ac client)
-		ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
+	// 1. Register (already done via ac client)
+	ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
 
-		name := testutil.ValidBoardName().String()
-		description := testutil.ValidBoardDescription().String()
+	name := testutil.ValidBoardName().String()
+	description := testutil.ValidBoardDescription().String()
 
-		// 2. Create a board, store response in createdBoard, and validate response fields
-		createResp := ac.Do(t, http.MethodPost, "/v1/boards", map[string]string{
-			"name":        name,
-			"description": description,
-		})
-		defer func() {
-			_ = createResp.Body.Close()
-		}()
-
-		if createResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got status %d, want %d", createResp.StatusCode, http.StatusCreated)
-		}
-
-		createdBoard := parseBoard(t, createResp)
-
-		_, err := uuid.Parse(createdBoard.ID)
-		if err != nil {
-			t.Errorf("uuid.Parse(%q) error = %v, want nil", createdBoard.ID, err)
-		}
-		_, err = uuid.Parse(createdBoard.OwnerID)
-		if err != nil {
-			t.Errorf("uuid.Parse(%q) error = %v, want nil", createdBoard.OwnerID, err)
-		}
-		if createdBoard.Name != name {
-			t.Errorf("got name %q, want %q", createdBoard.Name, name)
-		}
-		if createdBoard.Description != description {
-			t.Errorf("got description %q, want %q", createdBoard.Description, description)
-		}
-		_, err = time.Parse(timeFormat, createdBoard.CreatedAt)
-		if err != nil {
-			t.Errorf("time.Parse(%q) error = %v, want nil", createdBoard.CreatedAt, err)
-		}
-		_, err = time.Parse(timeFormat, createdBoard.UpdatedAt)
-		if err != nil {
-			t.Errorf("time.Parse(%q) error = %v, want nil", createdBoard.UpdatedAt, err)
-		}
-
-		// 3. Get by id, store response in getByIDBoard, and perform deep comparison with createdBoard
-		oneResp := ac.Do(t, http.MethodGet, "/v1/boards/"+createdBoard.ID, nil)
-		defer func() {
-			_ = oneResp.Body.Close()
-		}()
-		if oneResp.StatusCode != http.StatusOK {
-			t.Fatalf("got Get by id status %d, want %d", oneResp.StatusCode, http.StatusOK)
-		}
-
-		getByIDBoard := parseBoard(t, oneResp)
-		if diff := cmp.Diff(createdBoard, getByIDBoard); diff != "" {
-			t.Errorf("Get by id mismatch (-want +got):\n%s", diff)
-		}
-
-		// 4. List boards, get the first board, and perform deep comparison with createdBoard
-		listResp := ac.Do(t, http.MethodGet, "/v1/boards", nil)
-		defer func() {
-			_ = listResp.Body.Close()
-		}()
-
-		if listResp.StatusCode != http.StatusOK {
-			t.Fatalf("got list status %d, want %d", listResp.StatusCode, http.StatusOK)
-		}
-
-		listedBoards := parseBoardsList(t, listResp)
-		if len(listedBoards) != 1 {
-			t.Fatalf("got %d boards in list, want 1", len(listedBoards))
-		}
-		if diff := cmp.Diff(createdBoard, listedBoards[0]); diff != "" {
-			t.Errorf("List item mismatch (-want +got):\n%s", diff)
-		}
-
-		// 5. Update by id with name only, store response in updatedNameBoard, validate fields, and ensure updatedAt advanced
-		updatedName := "Updated Name Only"
-		WaitForTimestampTicker(t)
-		updateNameResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+createdBoard.ID, map[string]string{
-			"name": updatedName,
-		})
-		defer func() {
-			_ = updateNameResp.Body.Close()
-		}()
-		if updateNameResp.StatusCode != http.StatusOK {
-			t.Fatalf("got Update by id status %d, want %d", updateNameResp.StatusCode, http.StatusOK)
-		}
-
-		updatedNameBoard := parseBoard(t, updateNameResp)
-
-		// Validation trick: revert changed fields in a clone and compare with createdBoard
-		checkBoard := updatedNameBoard
-		checkBoard.Name = createdBoard.Name
-		checkBoard.UpdatedAt = createdBoard.UpdatedAt
-		if diff := cmp.Diff(createdBoard, checkBoard); diff != "" {
-			t.Errorf("Update() diff (-want +got):\n%s", diff)
-		}
-
-		// Verify specific changes
-		if updatedNameBoard.Name != updatedName {
-			t.Errorf("got updated name %q, want %q", updatedNameBoard.Name, updatedName)
-		}
-
-		updatedAtAfterUpdate, _ := time.Parse(timeFormat, updatedNameBoard.UpdatedAt)
-		updatedAtBeforeUpdate, _ := time.Parse(timeFormat, createdBoard.UpdatedAt)
-		if !updatedAtAfterUpdate.After(updatedAtBeforeUpdate) {
-			t.Errorf("updatedAt must advance after Update by id; got %v, previous %v", updatedAtAfterUpdate, updatedAtBeforeUpdate)
-		}
-
-		// 6. Get by id again, store response in getByIDBoardAfterUpdate, and perform deep comparison with updatedNameBoard
-		afterUpdateResp := ac.Do(t, http.MethodGet, "/v1/boards/"+createdBoard.ID, nil)
-		defer func() {
-			_ = afterUpdateResp.Body.Close()
-		}()
-
-		if afterUpdateResp.StatusCode != http.StatusOK {
-			t.Fatalf("got Get by id status %d after update, want %d", afterUpdateResp.StatusCode, http.StatusOK)
-		}
-
-		getByIDBoardAfterUpdate := parseBoard(t, afterUpdateResp)
-		if diff := cmp.Diff(updatedNameBoard, getByIDBoardAfterUpdate); diff != "" {
-			t.Errorf("Get by id after update mismatch (-want +got):\n%s", diff)
-		}
-
-		// 7. One column and one task: GET /aggregate must match the created board, column, and task from their POST responses.
-		colResp := ac.Do(t, http.MethodPost, "/v1/boards/"+createdBoard.ID+"/columns", map[string]string{"name": "To Do"})
-		defer func() { _ = colResp.Body.Close() }()
-		if colResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got create column status %d, want %d", colResp.StatusCode, http.StatusCreated)
-		}
-		col := parseColumn(t, colResp)
-
-		taskResp := ac.Do(t, http.MethodPost, "/v1/boards/"+createdBoard.ID+"/columns/"+col.ID+"/tasks", map[string]string{
-			"name":        "One task",
-			"description": "E2E aggregate",
-		})
-		defer func() { _ = taskResp.Body.Close() }()
-		if taskResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got create task status %d, want %d", taskResp.StatusCode, http.StatusCreated)
-		}
-		task := parseTask(t, taskResp)
-
-		aggResp := ac.Do(t, http.MethodGet, "/v1/boards/"+createdBoard.ID+"/aggregate", nil)
-		defer func() { _ = aggResp.Body.Close() }()
-		if aggResp.StatusCode != http.StatusOK {
-			t.Fatalf("got aggregate status %d, want %d", aggResp.StatusCode, http.StatusOK)
-		}
-		gotAgg := parseBoardAggregate(t, aggResp)
-
-		wantAgg := BoardAggregateJSON{
-			BoardJSON: getByIDBoardAfterUpdate,
-			Columns: []AggregateColumnJSON{
-				{ColumnJSON: col, Tasks: []TaskJSON{task}},
-			},
-		}
-		if diff := cmp.Diff(wantAgg, gotAgg); diff != "" {
-			t.Errorf("aggregate vs POST responses (-want +got):\n%s", diff)
-		}
-
-		// 8. Delete by id and verify StatusNoContent
-		delResp := ac.Do(t, http.MethodDelete, "/v1/boards/"+createdBoard.ID, nil)
-		defer func() {
-			_ = delResp.Body.Close()
-		}()
-		if delResp.StatusCode != http.StatusNoContent {
-			t.Fatalf("got Delete by id status %d, want %d", delResp.StatusCode, http.StatusNoContent)
-		}
-
-		// 9. List boards and ensure an empty list is returned
-		listAfterDelResp := ac.Do(t, http.MethodGet, "/v1/boards", nil)
-		defer func() {
-			_ = listAfterDelResp.Body.Close()
-		}()
-		if listAfterDelResp.StatusCode != http.StatusOK {
-			t.Fatalf("got list status %d after delete, want %d", listAfterDelResp.StatusCode, http.StatusOK)
-		}
-
-		listedAfterDelete := parseBoardsList(t, listAfterDelResp)
-		if len(listedAfterDelete) != 0 {
-			t.Fatalf("got %d boards after delete, want 0", len(listedAfterDelete))
-		}
+	// 2. Create a board, store response in createdBoard, and validate response fields
+	createResp := ac.Do(t, http.MethodPost, "/v1/boards", map[string]string{
+		"name":        name,
+		"description": description,
 	})
+	defer func() {
+		_ = createResp.Body.Close()
+	}()
+
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got status %d, want %d", createResp.StatusCode, http.StatusCreated)
+	}
+
+	createdBoard := parseBoard(t, createResp)
+
+	_, err := uuid.Parse(createdBoard.ID)
+	if err != nil {
+		t.Errorf("uuid.Parse(%q) error = %v, want nil", createdBoard.ID, err)
+	}
+	_, err = uuid.Parse(createdBoard.OwnerID)
+	if err != nil {
+		t.Errorf("uuid.Parse(%q) error = %v, want nil", createdBoard.OwnerID, err)
+	}
+	if createdBoard.Name != name {
+		t.Errorf("got name %q, want %q", createdBoard.Name, name)
+	}
+	if createdBoard.Description != description {
+		t.Errorf("got description %q, want %q", createdBoard.Description, description)
+	}
+	_, err = time.Parse(timeFormat, createdBoard.CreatedAt)
+	if err != nil {
+		t.Errorf("time.Parse(%q) error = %v, want nil", createdBoard.CreatedAt, err)
+	}
+	_, err = time.Parse(timeFormat, createdBoard.UpdatedAt)
+	if err != nil {
+		t.Errorf("time.Parse(%q) error = %v, want nil", createdBoard.UpdatedAt, err)
+	}
+
+	// 3. Get by id, store response in getByIDBoard, and perform deep comparison with createdBoard
+	oneResp := ac.Do(t, http.MethodGet, "/v1/boards/"+createdBoard.ID, nil)
+	defer func() {
+		_ = oneResp.Body.Close()
+	}()
+	if oneResp.StatusCode != http.StatusOK {
+		t.Fatalf("got Get by id status %d, want %d", oneResp.StatusCode, http.StatusOK)
+	}
+
+	getByIDBoard := parseBoard(t, oneResp)
+	if diff := cmp.Diff(createdBoard, getByIDBoard); diff != "" {
+		t.Errorf("Get by id mismatch (-want +got):\n%s", diff)
+	}
+
+	// 4. List boards, get the first board, and perform deep comparison with createdBoard
+	listResp := ac.Do(t, http.MethodGet, "/v1/boards", nil)
+	defer func() {
+		_ = listResp.Body.Close()
+	}()
+
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("got list status %d, want %d", listResp.StatusCode, http.StatusOK)
+	}
+
+	listedBoards := parseBoardsList(t, listResp)
+	if len(listedBoards) != 1 {
+		t.Fatalf("got %d boards in list, want 1", len(listedBoards))
+	}
+	if diff := cmp.Diff(createdBoard, listedBoards[0]); diff != "" {
+		t.Errorf("List item mismatch (-want +got):\n%s", diff)
+	}
+
+	// 5. Update by id with name only, store response in updatedNameBoard, validate fields, and ensure updatedAt advanced
+	updatedName := "Updated Name Only"
+	WaitForTimestampTicker(t)
+	updateNameResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+createdBoard.ID, map[string]string{
+		"name": updatedName,
+	})
+	defer func() {
+		_ = updateNameResp.Body.Close()
+	}()
+	if updateNameResp.StatusCode != http.StatusOK {
+		t.Fatalf("got Update by id status %d, want %d", updateNameResp.StatusCode, http.StatusOK)
+	}
+
+	updatedNameBoard := parseBoard(t, updateNameResp)
+
+	// Validation trick: revert changed fields in a clone and compare with createdBoard
+	checkBoard := updatedNameBoard
+	checkBoard.Name = createdBoard.Name
+	checkBoard.UpdatedAt = createdBoard.UpdatedAt
+	if diff := cmp.Diff(createdBoard, checkBoard); diff != "" {
+		t.Errorf("Update() diff (-want +got):\n%s", diff)
+	}
+
+	// Verify specific changes
+	if updatedNameBoard.Name != updatedName {
+		t.Errorf("got updated name %q, want %q", updatedNameBoard.Name, updatedName)
+	}
+
+	updatedAtAfterUpdate, _ := time.Parse(timeFormat, updatedNameBoard.UpdatedAt)
+	updatedAtBeforeUpdate, _ := time.Parse(timeFormat, createdBoard.UpdatedAt)
+	if !updatedAtAfterUpdate.After(updatedAtBeforeUpdate) {
+		t.Errorf("updatedAt must advance after Update by id; got %v, previous %v", updatedAtAfterUpdate, updatedAtBeforeUpdate)
+	}
+
+	// 6. Get by id again, store response in getByIDBoardAfterUpdate, and perform deep comparison with updatedNameBoard
+	afterUpdateResp := ac.Do(t, http.MethodGet, "/v1/boards/"+createdBoard.ID, nil)
+	defer func() {
+		_ = afterUpdateResp.Body.Close()
+	}()
+
+	if afterUpdateResp.StatusCode != http.StatusOK {
+		t.Fatalf("got Get by id status %d after update, want %d", afterUpdateResp.StatusCode, http.StatusOK)
+	}
+
+	getByIDBoardAfterUpdate := parseBoard(t, afterUpdateResp)
+	if diff := cmp.Diff(updatedNameBoard, getByIDBoardAfterUpdate); diff != "" {
+		t.Errorf("Get by id after update mismatch (-want +got):\n%s", diff)
+	}
+
+	// 7. One column and one task: GET /aggregate must match the created board, column, and task from their POST responses.
+	colResp := ac.Do(t, http.MethodPost, "/v1/boards/"+createdBoard.ID+"/columns", map[string]string{"name": "To Do"})
+	defer func() { _ = colResp.Body.Close() }()
+	if colResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got create column status %d, want %d", colResp.StatusCode, http.StatusCreated)
+	}
+	col := parseColumn(t, colResp)
+
+	taskResp := ac.Do(t, http.MethodPost, "/v1/boards/"+createdBoard.ID+"/columns/"+col.ID+"/tasks", map[string]string{
+		"name":        "One task",
+		"description": "E2E aggregate",
+	})
+	defer func() { _ = taskResp.Body.Close() }()
+	if taskResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got create task status %d, want %d", taskResp.StatusCode, http.StatusCreated)
+	}
+	task := parseTask(t, taskResp)
+
+	aggResp := ac.Do(t, http.MethodGet, "/v1/boards/"+createdBoard.ID+"/aggregate", nil)
+	defer func() { _ = aggResp.Body.Close() }()
+	if aggResp.StatusCode != http.StatusOK {
+		t.Fatalf("got aggregate status %d, want %d", aggResp.StatusCode, http.StatusOK)
+	}
+	gotAgg := parseBoardAggregate(t, aggResp)
+
+	wantAgg := BoardAggregateJSON{
+		BoardJSON: getByIDBoardAfterUpdate,
+		Columns: []AggregateColumnJSON{
+			{ColumnJSON: col, Tasks: []TaskJSON{task}},
+		},
+	}
+	if diff := cmp.Diff(wantAgg, gotAgg); diff != "" {
+		t.Errorf("aggregate vs POST responses (-want +got):\n%s", diff)
+	}
+
+	// 8. Delete by id and verify StatusNoContent
+	delResp := ac.Do(t, http.MethodDelete, "/v1/boards/"+createdBoard.ID, nil)
+	defer func() {
+		_ = delResp.Body.Close()
+	}()
+	if delResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("got Delete by id status %d, want %d", delResp.StatusCode, http.StatusNoContent)
+	}
+
+	// 9. List boards and ensure an empty list is returned
+	listAfterDelResp := ac.Do(t, http.MethodGet, "/v1/boards", nil)
+	defer func() {
+		_ = listAfterDelResp.Body.Close()
+	}()
+	if listAfterDelResp.StatusCode != http.StatusOK {
+		t.Fatalf("got list status %d after delete, want %d", listAfterDelResp.StatusCode, http.StatusOK)
+	}
+
+	listedAfterDelete := parseBoardsList(t, listAfterDelResp)
+	if len(listedAfterDelete) != 0 {
+		t.Fatalf("got %d boards after delete, want 0", len(listedAfterDelete))
+	}
 }
 
 func parseBoard(t *testing.T, resp *http.Response) BoardJSON {

--- a/tests/column_test.go
+++ b/tests/column_test.go
@@ -31,275 +31,273 @@ type ColumnPositionJSON struct {
 func TestColumn_HappyPath(t *testing.T) {
 	p := Prelude(t)
 
-	t.Run("Full column flow", func(t *testing.T) {
-		testutil.TruncateAllTables(t, p.Pool)
+	testutil.TruncateAllTables(t, p.Pool)
 
-		// 1. Register (already done via ac client)
-		ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
+	// 1. Register (already done via ac client)
+	ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
 
-		boardName := testutil.ValidBoardName().String()
-		boardDescription := testutil.ValidBoardDescription().String()
+	boardName := testutil.ValidBoardName().String()
+	boardDescription := testutil.ValidBoardDescription().String()
 
-		createBoardResp := ac.Do(t, http.MethodPost, "/v1/boards", map[string]string{
-			"name":        boardName,
-			"description": boardDescription,
-		})
-		defer func() {
-			_ = createBoardResp.Body.Close()
-		}()
-		if createBoardResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got create board status %d, want %d", createBoardResp.StatusCode, http.StatusCreated)
-		}
-
-		board := parseBoard(t, createBoardResp)
-
-		name := "To Do"
-		columnDescription := testutil.ValidColumnDescription().String()
-
-		// 2. Create a column, store response in createdColumn, and validate response fields
-		createResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
-			"name":        name,
-			"description": columnDescription,
-		})
-		defer func() {
-			_ = createResp.Body.Close()
-		}()
-		if createResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got status %d, want %d", createResp.StatusCode, http.StatusCreated)
-		}
-
-		createdColumn := parseColumn(t, createResp)
-
-		_, err := uuid.Parse(createdColumn.ID)
-		if err != nil {
-			t.Errorf("uuid.Parse(%q) error = %v, want nil", createdColumn.ID, err)
-		}
-		_, err = uuid.Parse(createdColumn.BoardID)
-		if err != nil {
-			t.Errorf("uuid.Parse(%q) error = %v, want nil", createdColumn.BoardID, err)
-		}
-		if createdColumn.BoardID != board.ID {
-			t.Errorf("got board ID %q, want %q", createdColumn.BoardID, board.ID)
-		}
-		if createdColumn.Name != name {
-			t.Errorf("got name %q, want %q", createdColumn.Name, name)
-		}
-		if createdColumn.Description != columnDescription {
-			t.Errorf("got description %q, want %q", createdColumn.Description, columnDescription)
-		}
-		if createdColumn.Position != 1 {
-			t.Errorf("got position %d, want %d", createdColumn.Position, 1)
-		}
-		_, err = time.Parse(timeFormat, createdColumn.CreatedAt)
-		if err != nil {
-			t.Errorf("time.Parse(%q) error = %v, want nil", createdColumn.CreatedAt, err)
-		}
-		_, err = time.Parse(timeFormat, createdColumn.UpdatedAt)
-		if err != nil {
-			t.Errorf("time.Parse(%q) error = %v, want nil", createdColumn.UpdatedAt, err)
-		}
-
-		// 3. List columns, get the first column, and perform deep comparison with createdColumn
-		listResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns", nil)
-		defer func() {
-			_ = listResp.Body.Close()
-		}()
-		if listResp.StatusCode != http.StatusOK {
-			t.Fatalf("got list status %d, want %d", listResp.StatusCode, http.StatusOK)
-		}
-
-		listedColumns := parseColumnsList(t, listResp)
-		if len(listedColumns) != 1 {
-			t.Fatalf("got %d columns in list, want 1", len(listedColumns))
-		}
-		if diff := cmp.Diff(createdColumn, listedColumns[0]); diff != "" {
-			t.Errorf("List item mismatch (-want +got):\n%s", diff)
-		}
-
-		// 4. Update by id with name only, store response in updatedNameColumn, validate fields, and ensure updatedAt advanced
-		updatedName := "Updated Name Only"
-		WaitForTimestampTicker(t)
-		updateNameResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+board.ID+"/columns/"+createdColumn.ID, map[string]string{
-			"name": updatedName,
-		})
-		defer func() {
-			_ = updateNameResp.Body.Close()
-		}()
-		if updateNameResp.StatusCode != http.StatusOK {
-			t.Fatalf("got Update by id status %d, want %d", updateNameResp.StatusCode, http.StatusOK)
-		}
-
-		updatedNameColumn := parseColumn(t, updateNameResp)
-
-		// Validation trick: revert changed fields in a clone and compare with createdColumn
-		checkColumn := updatedNameColumn
-		checkColumn.Name = createdColumn.Name
-		checkColumn.UpdatedAt = createdColumn.UpdatedAt
-		if diff := cmp.Diff(createdColumn, checkColumn); diff != "" {
-			t.Errorf("Update() diff (-want +got):\n%s", diff)
-		}
-
-		// Verify specific changes
-		if updatedNameColumn.Name != updatedName {
-			t.Errorf("got updated name %q, want %q", updatedNameColumn.Name, updatedName)
-		}
-		if updatedNameColumn.Description != createdColumn.Description {
-			t.Errorf("got description %q after name-only update, want %q", updatedNameColumn.Description, createdColumn.Description)
-		}
-
-		updatedDesc := "Updated column description body"
-		WaitForTimestampTicker(t)
-		updateDescResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+board.ID+"/columns/"+createdColumn.ID, map[string]string{
-			"description": updatedDesc,
-		})
-		defer func() {
-			_ = updateDescResp.Body.Close()
-		}()
-		if updateDescResp.StatusCode != http.StatusOK {
-			t.Fatalf("got Update description status %d, want %d", updateDescResp.StatusCode, http.StatusOK)
-		}
-		updatedDescColumn := parseColumn(t, updateDescResp)
-		if updatedDescColumn.Description != updatedDesc {
-			t.Errorf("got description %q, want %q", updatedDescColumn.Description, updatedDesc)
-		}
-		if updatedDescColumn.Name != updatedName {
-			t.Errorf("got name %q after description update, want %q", updatedDescColumn.Name, updatedName)
-		}
-
-		updatedAtAfterName, err := time.Parse(timeFormat, updatedNameColumn.UpdatedAt)
-		if err != nil {
-			t.Fatalf("time.Parse(%q) error = %v", updatedNameColumn.UpdatedAt, err)
-		}
-		updatedAtBeforeUpdate, err := time.Parse(timeFormat, createdColumn.UpdatedAt)
-		if err != nil {
-			t.Fatalf("time.Parse(%q) error = %v", createdColumn.UpdatedAt, err)
-		}
-		if !updatedAtAfterName.After(updatedAtBeforeUpdate) {
-			t.Errorf("updatedAt must advance after name-only update; got %v, previous %v", updatedAtAfterName, updatedAtBeforeUpdate)
-		}
-
-		updatedAtAfterDesc, err := time.Parse(timeFormat, updatedDescColumn.UpdatedAt)
-		if err != nil {
-			t.Fatalf("time.Parse(%q) error = %v", updatedDescColumn.UpdatedAt, err)
-		}
-		if !updatedAtAfterDesc.After(updatedAtAfterName) {
-			t.Errorf("updatedAt must advance after description update; got %v, previous %v", updatedAtAfterDesc, updatedAtAfterName)
-		}
-
-		// 5. List columns again, get the first column, and perform deep comparison with updatedDescColumn
-		listAfterUpdateResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns", nil)
-		defer func() {
-			_ = listAfterUpdateResp.Body.Close()
-		}()
-		if listAfterUpdateResp.StatusCode != http.StatusOK {
-			t.Fatalf("got list status %d after update, want %d", listAfterUpdateResp.StatusCode, http.StatusOK)
-		}
-
-		listedAfterUpdate := parseColumnsList(t, listAfterUpdateResp)
-		if len(listedAfterUpdate) != 1 {
-			t.Fatalf("got %d columns after update, want 1", len(listedAfterUpdate))
-		}
-		if diff := cmp.Diff(updatedDescColumn, listedAfterUpdate[0]); diff != "" {
-			t.Errorf("List item after update mismatch (-want +got):\n%s", diff)
-		}
-
-		// 6. Create the second column so we can later delete it from the middle of the ordered list
-		createSecondResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
-			"name": "In Progress",
-		})
-		defer func() {
-			_ = createSecondResp.Body.Close()
-		}()
-		if createSecondResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got second create status %d, want %d", createSecondResp.StatusCode, http.StatusCreated)
-		}
-
-		secondColumn := parseColumn(t, createSecondResp)
-		if secondColumn.Position != 2 {
-			t.Errorf("got second column position %d, want %d", secondColumn.Position, 2)
-		}
-
-		// 7. Create the third column so delete can verify position compaction for trailing items
-		createThirdResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
-			"name": "Done",
-		})
-		defer func() {
-			_ = createThirdResp.Body.Close()
-		}()
-		if createThirdResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got third create status %d, want %d", createThirdResp.StatusCode, http.StatusCreated)
-		}
-
-		thirdColumn := parseColumn(t, createThirdResp)
-		if thirdColumn.Position != 3 {
-			t.Errorf("got third column position %d, want %d", thirdColumn.Position, 3)
-		}
-
-		// 8. Delete the middle column and expect the request to succeed
-		deleteResp := ac.Do(t, http.MethodDelete, "/v1/boards/"+board.ID+"/columns/"+secondColumn.ID, nil)
-		defer func() {
-			_ = deleteResp.Body.Close()
-		}()
-		if deleteResp.StatusCode != http.StatusNoContent {
-			t.Fatalf("got delete status %d, want %d", deleteResp.StatusCode, http.StatusNoContent)
-		}
-
-		// 9. List columns again and verify delete preserved the first column and compacted positions
-		listAfterDeleteResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns", nil)
-		defer func() {
-			_ = listAfterDeleteResp.Body.Close()
-		}()
-		if listAfterDeleteResp.StatusCode != http.StatusOK {
-			t.Fatalf("got list status %d after delete, want %d", listAfterDeleteResp.StatusCode, http.StatusOK)
-		}
-
-		listedAfterDelete := parseColumnsList(t, listAfterDeleteResp)
-		if len(listedAfterDelete) != 2 {
-			t.Fatalf("got %d columns after delete, want 2", len(listedAfterDelete))
-		}
-		if listedAfterDelete[0].ID != updatedDescColumn.ID || listedAfterDelete[0].Name != updatedDescColumn.Name || listedAfterDelete[0].Position != 1 {
-			t.Errorf("got id=%s name=%q position=%d, want id=%s name=%q position=%d", listedAfterDelete[0].ID, listedAfterDelete[0].Name, listedAfterDelete[0].Position, updatedDescColumn.ID, updatedDescColumn.Name, 1)
-		}
-		if listedAfterDelete[1].ID != thirdColumn.ID || listedAfterDelete[1].Position != 2 {
-			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterDelete[1].ID, listedAfterDelete[1].Position, thirdColumn.ID, 2)
-		}
-
-		// 10. Move the remaining second column to the first position and expect the new position in response
-		moveResp := ac.Do(t, http.MethodPut, "/v1/boards/"+board.ID+"/columns/"+thirdColumn.ID+"/position", map[string]int64{
-			"targetPosition": 1,
-		})
-		defer func() {
-			_ = moveResp.Body.Close()
-		}()
-		if moveResp.StatusCode != http.StatusOK {
-			t.Fatalf("got move status %d, want %d", moveResp.StatusCode, http.StatusOK)
-		}
-
-		movedPosition := parseColumnPosition(t, moveResp)
-		if movedPosition.Position != 1 {
-			t.Errorf("got move response position %d, want %d", movedPosition.Position, 1)
-		}
-
-		// 11. List columns again and verify move reordered the remaining columns
-		listAfterMoveResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns", nil)
-		defer func() {
-			_ = listAfterMoveResp.Body.Close()
-		}()
-		if listAfterMoveResp.StatusCode != http.StatusOK {
-			t.Fatalf("got list status %d after move, want %d", listAfterMoveResp.StatusCode, http.StatusOK)
-		}
-
-		listedAfterMove := parseColumnsList(t, listAfterMoveResp)
-		if len(listedAfterMove) != 2 {
-			t.Fatalf("got %d columns after move, want 2", len(listedAfterMove))
-		}
-		if listedAfterMove[0].ID != thirdColumn.ID || listedAfterMove[0].Position != 1 {
-			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterMove[0].ID, listedAfterMove[0].Position, thirdColumn.ID, 1)
-		}
-		if listedAfterMove[1].ID != updatedDescColumn.ID || listedAfterMove[1].Position != 2 {
-			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterMove[1].ID, listedAfterMove[1].Position, updatedDescColumn.ID, 2)
-		}
+	createBoardResp := ac.Do(t, http.MethodPost, "/v1/boards", map[string]string{
+		"name":        boardName,
+		"description": boardDescription,
 	})
+	defer func() {
+		_ = createBoardResp.Body.Close()
+	}()
+	if createBoardResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got create board status %d, want %d", createBoardResp.StatusCode, http.StatusCreated)
+	}
+
+	board := parseBoard(t, createBoardResp)
+
+	name := "To Do"
+	columnDescription := testutil.ValidColumnDescription().String()
+
+	// 2. Create a column, store response in createdColumn, and validate response fields
+	createResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
+		"name":        name,
+		"description": columnDescription,
+	})
+	defer func() {
+		_ = createResp.Body.Close()
+	}()
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got status %d, want %d", createResp.StatusCode, http.StatusCreated)
+	}
+
+	createdColumn := parseColumn(t, createResp)
+
+	_, err := uuid.Parse(createdColumn.ID)
+	if err != nil {
+		t.Errorf("uuid.Parse(%q) error = %v, want nil", createdColumn.ID, err)
+	}
+	_, err = uuid.Parse(createdColumn.BoardID)
+	if err != nil {
+		t.Errorf("uuid.Parse(%q) error = %v, want nil", createdColumn.BoardID, err)
+	}
+	if createdColumn.BoardID != board.ID {
+		t.Errorf("got board ID %q, want %q", createdColumn.BoardID, board.ID)
+	}
+	if createdColumn.Name != name {
+		t.Errorf("got name %q, want %q", createdColumn.Name, name)
+	}
+	if createdColumn.Description != columnDescription {
+		t.Errorf("got description %q, want %q", createdColumn.Description, columnDescription)
+	}
+	if createdColumn.Position != 1 {
+		t.Errorf("got position %d, want %d", createdColumn.Position, 1)
+	}
+	_, err = time.Parse(timeFormat, createdColumn.CreatedAt)
+	if err != nil {
+		t.Errorf("time.Parse(%q) error = %v, want nil", createdColumn.CreatedAt, err)
+	}
+	_, err = time.Parse(timeFormat, createdColumn.UpdatedAt)
+	if err != nil {
+		t.Errorf("time.Parse(%q) error = %v, want nil", createdColumn.UpdatedAt, err)
+	}
+
+	// 3. List columns, get the first column, and perform deep comparison with createdColumn
+	listResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns", nil)
+	defer func() {
+		_ = listResp.Body.Close()
+	}()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("got list status %d, want %d", listResp.StatusCode, http.StatusOK)
+	}
+
+	listedColumns := parseColumnsList(t, listResp)
+	if len(listedColumns) != 1 {
+		t.Fatalf("got %d columns in list, want 1", len(listedColumns))
+	}
+	if diff := cmp.Diff(createdColumn, listedColumns[0]); diff != "" {
+		t.Errorf("List item mismatch (-want +got):\n%s", diff)
+	}
+
+	// 4. Update by id with name only, store response in updatedNameColumn, validate fields, and ensure updatedAt advanced
+	updatedName := "Updated Name Only"
+	WaitForTimestampTicker(t)
+	updateNameResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+board.ID+"/columns/"+createdColumn.ID, map[string]string{
+		"name": updatedName,
+	})
+	defer func() {
+		_ = updateNameResp.Body.Close()
+	}()
+	if updateNameResp.StatusCode != http.StatusOK {
+		t.Fatalf("got Update by id status %d, want %d", updateNameResp.StatusCode, http.StatusOK)
+	}
+
+	updatedNameColumn := parseColumn(t, updateNameResp)
+
+	// Validation trick: revert changed fields in a clone and compare with createdColumn
+	checkColumn := updatedNameColumn
+	checkColumn.Name = createdColumn.Name
+	checkColumn.UpdatedAt = createdColumn.UpdatedAt
+	if diff := cmp.Diff(createdColumn, checkColumn); diff != "" {
+		t.Errorf("Update() diff (-want +got):\n%s", diff)
+	}
+
+	// Verify specific changes
+	if updatedNameColumn.Name != updatedName {
+		t.Errorf("got updated name %q, want %q", updatedNameColumn.Name, updatedName)
+	}
+	if updatedNameColumn.Description != createdColumn.Description {
+		t.Errorf("got description %q after name-only update, want %q", updatedNameColumn.Description, createdColumn.Description)
+	}
+
+	updatedDesc := "Updated column description body"
+	WaitForTimestampTicker(t)
+	updateDescResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+board.ID+"/columns/"+createdColumn.ID, map[string]string{
+		"description": updatedDesc,
+	})
+	defer func() {
+		_ = updateDescResp.Body.Close()
+	}()
+	if updateDescResp.StatusCode != http.StatusOK {
+		t.Fatalf("got Update description status %d, want %d", updateDescResp.StatusCode, http.StatusOK)
+	}
+	updatedDescColumn := parseColumn(t, updateDescResp)
+	if updatedDescColumn.Description != updatedDesc {
+		t.Errorf("got description %q, want %q", updatedDescColumn.Description, updatedDesc)
+	}
+	if updatedDescColumn.Name != updatedName {
+		t.Errorf("got name %q after description update, want %q", updatedDescColumn.Name, updatedName)
+	}
+
+	updatedAtAfterName, err := time.Parse(timeFormat, updatedNameColumn.UpdatedAt)
+	if err != nil {
+		t.Fatalf("time.Parse(%q) error = %v", updatedNameColumn.UpdatedAt, err)
+	}
+	updatedAtBeforeUpdate, err := time.Parse(timeFormat, createdColumn.UpdatedAt)
+	if err != nil {
+		t.Fatalf("time.Parse(%q) error = %v", createdColumn.UpdatedAt, err)
+	}
+	if !updatedAtAfterName.After(updatedAtBeforeUpdate) {
+		t.Errorf("updatedAt must advance after name-only update; got %v, previous %v", updatedAtAfterName, updatedAtBeforeUpdate)
+	}
+
+	updatedAtAfterDesc, err := time.Parse(timeFormat, updatedDescColumn.UpdatedAt)
+	if err != nil {
+		t.Fatalf("time.Parse(%q) error = %v", updatedDescColumn.UpdatedAt, err)
+	}
+	if !updatedAtAfterDesc.After(updatedAtAfterName) {
+		t.Errorf("updatedAt must advance after description update; got %v, previous %v", updatedAtAfterDesc, updatedAtAfterName)
+	}
+
+	// 5. List columns again, get the first column, and perform deep comparison with updatedDescColumn
+	listAfterUpdateResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns", nil)
+	defer func() {
+		_ = listAfterUpdateResp.Body.Close()
+	}()
+	if listAfterUpdateResp.StatusCode != http.StatusOK {
+		t.Fatalf("got list status %d after update, want %d", listAfterUpdateResp.StatusCode, http.StatusOK)
+	}
+
+	listedAfterUpdate := parseColumnsList(t, listAfterUpdateResp)
+	if len(listedAfterUpdate) != 1 {
+		t.Fatalf("got %d columns after update, want 1", len(listedAfterUpdate))
+	}
+	if diff := cmp.Diff(updatedDescColumn, listedAfterUpdate[0]); diff != "" {
+		t.Errorf("List item after update mismatch (-want +got):\n%s", diff)
+	}
+
+	// 6. Create the second column so we can later delete it from the middle of the ordered list
+	createSecondResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
+		"name": "In Progress",
+	})
+	defer func() {
+		_ = createSecondResp.Body.Close()
+	}()
+	if createSecondResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got second create status %d, want %d", createSecondResp.StatusCode, http.StatusCreated)
+	}
+
+	secondColumn := parseColumn(t, createSecondResp)
+	if secondColumn.Position != 2 {
+		t.Errorf("got second column position %d, want %d", secondColumn.Position, 2)
+	}
+
+	// 7. Create the third column so delete can verify position compaction for trailing items
+	createThirdResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
+		"name": "Done",
+	})
+	defer func() {
+		_ = createThirdResp.Body.Close()
+	}()
+	if createThirdResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got third create status %d, want %d", createThirdResp.StatusCode, http.StatusCreated)
+	}
+
+	thirdColumn := parseColumn(t, createThirdResp)
+	if thirdColumn.Position != 3 {
+		t.Errorf("got third column position %d, want %d", thirdColumn.Position, 3)
+	}
+
+	// 8. Delete the middle column and expect the request to succeed
+	deleteResp := ac.Do(t, http.MethodDelete, "/v1/boards/"+board.ID+"/columns/"+secondColumn.ID, nil)
+	defer func() {
+		_ = deleteResp.Body.Close()
+	}()
+	if deleteResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("got delete status %d, want %d", deleteResp.StatusCode, http.StatusNoContent)
+	}
+
+	// 9. List columns again and verify delete preserved the first column and compacted positions
+	listAfterDeleteResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns", nil)
+	defer func() {
+		_ = listAfterDeleteResp.Body.Close()
+	}()
+	if listAfterDeleteResp.StatusCode != http.StatusOK {
+		t.Fatalf("got list status %d after delete, want %d", listAfterDeleteResp.StatusCode, http.StatusOK)
+	}
+
+	listedAfterDelete := parseColumnsList(t, listAfterDeleteResp)
+	if len(listedAfterDelete) != 2 {
+		t.Fatalf("got %d columns after delete, want 2", len(listedAfterDelete))
+	}
+	if listedAfterDelete[0].ID != updatedDescColumn.ID || listedAfterDelete[0].Name != updatedDescColumn.Name || listedAfterDelete[0].Position != 1 {
+		t.Errorf("got id=%s name=%q position=%d, want id=%s name=%q position=%d", listedAfterDelete[0].ID, listedAfterDelete[0].Name, listedAfterDelete[0].Position, updatedDescColumn.ID, updatedDescColumn.Name, 1)
+	}
+	if listedAfterDelete[1].ID != thirdColumn.ID || listedAfterDelete[1].Position != 2 {
+		t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterDelete[1].ID, listedAfterDelete[1].Position, thirdColumn.ID, 2)
+	}
+
+	// 10. Move the remaining second column to the first position and expect the new position in response
+	moveResp := ac.Do(t, http.MethodPut, "/v1/boards/"+board.ID+"/columns/"+thirdColumn.ID+"/position", map[string]int64{
+		"targetPosition": 1,
+	})
+	defer func() {
+		_ = moveResp.Body.Close()
+	}()
+	if moveResp.StatusCode != http.StatusOK {
+		t.Fatalf("got move status %d, want %d", moveResp.StatusCode, http.StatusOK)
+	}
+
+	movedPosition := parseColumnPosition(t, moveResp)
+	if movedPosition.Position != 1 {
+		t.Errorf("got move response position %d, want %d", movedPosition.Position, 1)
+	}
+
+	// 11. List columns again and verify move reordered the remaining columns
+	listAfterMoveResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns", nil)
+	defer func() {
+		_ = listAfterMoveResp.Body.Close()
+	}()
+	if listAfterMoveResp.StatusCode != http.StatusOK {
+		t.Fatalf("got list status %d after move, want %d", listAfterMoveResp.StatusCode, http.StatusOK)
+	}
+
+	listedAfterMove := parseColumnsList(t, listAfterMoveResp)
+	if len(listedAfterMove) != 2 {
+		t.Fatalf("got %d columns after move, want 2", len(listedAfterMove))
+	}
+	if listedAfterMove[0].ID != thirdColumn.ID || listedAfterMove[0].Position != 1 {
+		t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterMove[0].ID, listedAfterMove[0].Position, thirdColumn.ID, 1)
+	}
+	if listedAfterMove[1].ID != updatedDescColumn.ID || listedAfterMove[1].Position != 2 {
+		t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterMove[1].ID, listedAfterMove[1].Position, updatedDescColumn.ID, 2)
+	}
 }
 
 func parseColumn(t *testing.T, resp *http.Response) ColumnJSON {

--- a/tests/task_test.go
+++ b/tests/task_test.go
@@ -32,317 +32,315 @@ type TaskPositionJSON struct {
 func TestTask_HappyPath(t *testing.T) {
 	p := Prelude(t)
 
-	t.Run("Full task flow", func(t *testing.T) {
-		testutil.TruncateAllTables(t, p.Pool)
+	testutil.TruncateAllTables(t, p.Pool)
 
-		// 1. Register (already done via ac client)
-		ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
+	// 1. Register (already done via ac client)
+	ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
 
-		boardName := testutil.ValidBoardName().String()
-		boardDescription := testutil.ValidBoardDescription().String()
+	boardName := testutil.ValidBoardName().String()
+	boardDescription := testutil.ValidBoardDescription().String()
 
-		createBoardResp := ac.Do(t, http.MethodPost, "/v1/boards", map[string]string{
-			"name":        boardName,
-			"description": boardDescription,
-		})
-		defer func() {
-			_ = createBoardResp.Body.Close()
-		}()
-		if createBoardResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got create board status %d, want %d", createBoardResp.StatusCode, http.StatusCreated)
-		}
-
-		board := parseBoard(t, createBoardResp)
-
-		// 2. Create two columns so we can later move a task across them
-		createColumnAResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
-			"name": "To Do",
-		})
-		defer func() {
-			_ = createColumnAResp.Body.Close()
-		}()
-		if createColumnAResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got create column A status %d, want %d", createColumnAResp.StatusCode, http.StatusCreated)
-		}
-		columnA := parseColumn(t, createColumnAResp)
-
-		createColumnBResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
-			"name": "In Progress",
-		})
-		defer func() {
-			_ = createColumnBResp.Body.Close()
-		}()
-		if createColumnBResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got create column B status %d, want %d", createColumnBResp.StatusCode, http.StatusCreated)
-		}
-		columnB := parseColumn(t, createColumnBResp)
-
-		name := "Write tests"
-		description := "Cover the new endpoint with tests"
-
-		// 3. Create a task in column A, store response in createdTask, and validate response fields
-		createResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", map[string]string{
-			"name":        name,
-			"description": description,
-		})
-		defer func() {
-			_ = createResp.Body.Close()
-		}()
-		if createResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got status %d, want %d", createResp.StatusCode, http.StatusCreated)
-		}
-
-		createdTask := parseTask(t, createResp)
-
-		_, err := uuid.Parse(createdTask.ID)
-		if err != nil {
-			t.Errorf("uuid.Parse(%q) error = %v, want nil", createdTask.ID, err)
-		}
-		_, err = uuid.Parse(createdTask.ColumnID)
-		if err != nil {
-			t.Errorf("uuid.Parse(%q) error = %v, want nil", createdTask.ColumnID, err)
-		}
-		if createdTask.ColumnID != columnA.ID {
-			t.Errorf("got column ID %q, want %q", createdTask.ColumnID, columnA.ID)
-		}
-		if createdTask.Name != name {
-			t.Errorf("got name %q, want %q", createdTask.Name, name)
-		}
-		if createdTask.Description != description {
-			t.Errorf("got description %q, want %q", createdTask.Description, description)
-		}
-		if createdTask.Position != 1 {
-			t.Errorf("got position %d, want %d", createdTask.Position, 1)
-		}
-		_, err = time.Parse(timeFormat, createdTask.CreatedAt)
-		if err != nil {
-			t.Errorf("time.Parse(%q) error = %v, want nil", createdTask.CreatedAt, err)
-		}
-		_, err = time.Parse(timeFormat, createdTask.UpdatedAt)
-		if err != nil {
-			t.Errorf("time.Parse(%q) error = %v, want nil", createdTask.UpdatedAt, err)
-		}
-
-		// 4. List tasks in column A, get the first task, and perform deep comparison with createdTask
-		listResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", nil)
-		defer func() {
-			_ = listResp.Body.Close()
-		}()
-		if listResp.StatusCode != http.StatusOK {
-			t.Fatalf("got list status %d, want %d", listResp.StatusCode, http.StatusOK)
-		}
-
-		listedTasks := parseTasksList(t, listResp)
-		if len(listedTasks) != 1 {
-			t.Fatalf("got %d tasks in list, want 1", len(listedTasks))
-		}
-		if diff := cmp.Diff(createdTask, listedTasks[0]); diff != "" {
-			t.Errorf("List item mismatch (-want +got):\n%s", diff)
-		}
-
-		// 5. Update by id with name and description, store response in updatedTask, validate fields, and ensure updatedAt advanced
-		updatedName := "Updated Name"
-		updatedDescription := "Updated description"
-		WaitForTimestampTicker(t)
-		updateResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+createdTask.ID, map[string]string{
-			"name":        updatedName,
-			"description": updatedDescription,
-		})
-		defer func() {
-			_ = updateResp.Body.Close()
-		}()
-		if updateResp.StatusCode != http.StatusOK {
-			t.Fatalf("got Update by id status %d, want %d", updateResp.StatusCode, http.StatusOK)
-		}
-
-		updatedTask := parseTask(t, updateResp)
-
-		// Validation trick: revert changed fields in a clone and compare with createdTask
-		checkTask := updatedTask
-		checkTask.Name = createdTask.Name
-		checkTask.Description = createdTask.Description
-		checkTask.UpdatedAt = createdTask.UpdatedAt
-		if diff := cmp.Diff(createdTask, checkTask); diff != "" {
-			t.Errorf("Update() diff (-want +got):\n%s", diff)
-		}
-
-		// Verify specific changes
-		if updatedTask.Name != updatedName {
-			t.Errorf("got updated name %q, want %q", updatedTask.Name, updatedName)
-		}
-		if updatedTask.Description != updatedDescription {
-			t.Errorf("got updated description %q, want %q", updatedTask.Description, updatedDescription)
-		}
-
-		updatedAtAfterUpdate, err := time.Parse(timeFormat, updatedTask.UpdatedAt)
-		if err != nil {
-			t.Fatalf("time.Parse(%q) error = %v", updatedTask.UpdatedAt, err)
-		}
-		updatedAtBeforeUpdate, err := time.Parse(timeFormat, createdTask.UpdatedAt)
-		if err != nil {
-			t.Fatalf("time.Parse(%q) error = %v", createdTask.UpdatedAt, err)
-		}
-		if !updatedAtAfterUpdate.After(updatedAtBeforeUpdate) {
-			t.Errorf("updatedAt must advance after Update by id; got %v, previous %v", updatedAtAfterUpdate, updatedAtBeforeUpdate)
-		}
-
-		// 6. Create the second task in column A so we can later delete it from the middle and verify shifting
-		createSecondResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", map[string]string{
-			"name":        "Second",
-			"description": "second",
-		})
-		defer func() {
-			_ = createSecondResp.Body.Close()
-		}()
-		if createSecondResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got second create status %d, want %d", createSecondResp.StatusCode, http.StatusCreated)
-		}
-
-		secondTask := parseTask(t, createSecondResp)
-		if secondTask.Position != 2 {
-			t.Errorf("got second task position %d, want %d", secondTask.Position, 2)
-		}
-
-		// 7. Create the third task in column A so delete can verify position compaction for trailing items
-		createThirdResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", map[string]string{
-			"name":        "Third",
-			"description": "third",
-		})
-		defer func() {
-			_ = createThirdResp.Body.Close()
-		}()
-		if createThirdResp.StatusCode != http.StatusCreated {
-			t.Fatalf("got third create status %d, want %d", createThirdResp.StatusCode, http.StatusCreated)
-		}
-
-		thirdTask := parseTask(t, createThirdResp)
-		if thirdTask.Position != 3 {
-			t.Errorf("got third task position %d, want %d", thirdTask.Position, 3)
-		}
-
-		// 8. Delete the middle task and expect the request to succeed
-		deleteResp := ac.Do(t, http.MethodDelete, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+secondTask.ID, nil)
-		defer func() {
-			_ = deleteResp.Body.Close()
-		}()
-		if deleteResp.StatusCode != http.StatusNoContent {
-			t.Fatalf("got delete status %d, want %d", deleteResp.StatusCode, http.StatusNoContent)
-		}
-
-		// 9. List tasks again and verify delete preserved the first task and compacted positions
-		listAfterDeleteResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", nil)
-		defer func() {
-			_ = listAfterDeleteResp.Body.Close()
-		}()
-		if listAfterDeleteResp.StatusCode != http.StatusOK {
-			t.Fatalf("got list status %d after delete, want %d", listAfterDeleteResp.StatusCode, http.StatusOK)
-		}
-
-		listedAfterDelete := parseTasksList(t, listAfterDeleteResp)
-		if len(listedAfterDelete) != 2 {
-			t.Fatalf("got %d tasks after delete, want 2", len(listedAfterDelete))
-		}
-		if listedAfterDelete[0].ID != updatedTask.ID || listedAfterDelete[0].Position != 1 {
-			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterDelete[0].ID, listedAfterDelete[0].Position, updatedTask.ID, 1)
-		}
-		if listedAfterDelete[1].ID != thirdTask.ID || listedAfterDelete[1].Position != 2 {
-			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterDelete[1].ID, listedAfterDelete[1].Position, thirdTask.ID, 2)
-		}
-
-		// 10. Move the third task up to first position within the same column and expect the new column and position in response
-		moveResp := ac.Do(t, http.MethodPut, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+thirdTask.ID+"/position", map[string]any{
-			"targetColumnId": columnA.ID,
-			"targetPosition": 1,
-		})
-		defer func() {
-			_ = moveResp.Body.Close()
-		}()
-		if moveResp.StatusCode != http.StatusOK {
-			t.Fatalf("got move status %d, want %d", moveResp.StatusCode, http.StatusOK)
-		}
-
-		movedPosition := parseTaskPosition(t, moveResp)
-		if movedPosition.ColumnID != columnA.ID {
-			t.Errorf("got move response column id %q, want %q", movedPosition.ColumnID, columnA.ID)
-		}
-		if movedPosition.Position != 1 {
-			t.Errorf("got move response position %d, want %d", movedPosition.Position, 1)
-		}
-
-		// 11. List tasks again and verify move reordered the remaining tasks in column A
-		listAfterMoveResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", nil)
-		defer func() {
-			_ = listAfterMoveResp.Body.Close()
-		}()
-		if listAfterMoveResp.StatusCode != http.StatusOK {
-			t.Fatalf("got list status %d after move, want %d", listAfterMoveResp.StatusCode, http.StatusOK)
-		}
-
-		listedAfterMove := parseTasksList(t, listAfterMoveResp)
-		if len(listedAfterMove) != 2 {
-			t.Fatalf("got %d tasks after move, want 2", len(listedAfterMove))
-		}
-		if listedAfterMove[0].ID != thirdTask.ID || listedAfterMove[0].Position != 1 {
-			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterMove[0].ID, listedAfterMove[0].Position, thirdTask.ID, 1)
-		}
-		if listedAfterMove[1].ID != updatedTask.ID || listedAfterMove[1].Position != 2 {
-			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterMove[1].ID, listedAfterMove[1].Position, updatedTask.ID, 2)
-		}
-
-		// 12. Move the third task across columns from column A to column B at position 1 and expect the new column and position in response
-		crossMoveResp := ac.Do(t, http.MethodPut, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+thirdTask.ID+"/position", map[string]any{
-			"targetColumnId": columnB.ID,
-			"targetPosition": 1,
-		})
-		defer func() {
-			_ = crossMoveResp.Body.Close()
-		}()
-		if crossMoveResp.StatusCode != http.StatusOK {
-			t.Fatalf("got cross-column move status %d, want %d", crossMoveResp.StatusCode, http.StatusOK)
-		}
-
-		crossMovedPosition := parseTaskPosition(t, crossMoveResp)
-		if crossMovedPosition.ColumnID != columnB.ID {
-			t.Errorf("got cross-column move response column id %q, want %q", crossMovedPosition.ColumnID, columnB.ID)
-		}
-		if crossMovedPosition.Position != 1 {
-			t.Errorf("got cross-column move response position %d, want %d", crossMovedPosition.Position, 1)
-		}
-
-		// 13. List tasks in column A and verify the moved task is gone, and the remaining task kept position 1
-		listAAfterCrossResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", nil)
-		defer func() {
-			_ = listAAfterCrossResp.Body.Close()
-		}()
-		if listAAfterCrossResp.StatusCode != http.StatusOK {
-			t.Fatalf("got list column A status %d after cross move, want %d", listAAfterCrossResp.StatusCode, http.StatusOK)
-		}
-
-		listedAAfterCross := parseTasksList(t, listAAfterCrossResp)
-		if len(listedAAfterCross) != 1 {
-			t.Fatalf("got %d tasks in column A after cross move, want 1", len(listedAAfterCross))
-		}
-		if listedAAfterCross[0].ID != updatedTask.ID || listedAAfterCross[0].Position != 1 {
-			t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAAfterCross[0].ID, listedAAfterCross[0].Position, updatedTask.ID, 1)
-		}
-
-		// 14. List tasks in column B and verify the moved task landed at position 1 with updated columnId
-		listBAfterCrossResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnB.ID+"/tasks", nil)
-		defer func() {
-			_ = listBAfterCrossResp.Body.Close()
-		}()
-		if listBAfterCrossResp.StatusCode != http.StatusOK {
-			t.Fatalf("got list column B status %d after cross move, want %d", listBAfterCrossResp.StatusCode, http.StatusOK)
-		}
-
-		listedBAfterCross := parseTasksList(t, listBAfterCrossResp)
-		if len(listedBAfterCross) != 1 {
-			t.Fatalf("got %d tasks in column B after cross move, want 1", len(listedBAfterCross))
-		}
-		if listedBAfterCross[0].ID != thirdTask.ID || listedBAfterCross[0].Position != 1 || listedBAfterCross[0].ColumnID != columnB.ID {
-			t.Errorf("got id=%s position=%d columnId=%s, want id=%s position=%d columnId=%s", listedBAfterCross[0].ID, listedBAfterCross[0].Position, listedBAfterCross[0].ColumnID, thirdTask.ID, 1, columnB.ID)
-		}
+	createBoardResp := ac.Do(t, http.MethodPost, "/v1/boards", map[string]string{
+		"name":        boardName,
+		"description": boardDescription,
 	})
+	defer func() {
+		_ = createBoardResp.Body.Close()
+	}()
+	if createBoardResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got create board status %d, want %d", createBoardResp.StatusCode, http.StatusCreated)
+	}
+
+	board := parseBoard(t, createBoardResp)
+
+	// 2. Create two columns so we can later move a task across them
+	createColumnAResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
+		"name": "To Do",
+	})
+	defer func() {
+		_ = createColumnAResp.Body.Close()
+	}()
+	if createColumnAResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got create column A status %d, want %d", createColumnAResp.StatusCode, http.StatusCreated)
+	}
+	columnA := parseColumn(t, createColumnAResp)
+
+	createColumnBResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns", map[string]string{
+		"name": "In Progress",
+	})
+	defer func() {
+		_ = createColumnBResp.Body.Close()
+	}()
+	if createColumnBResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got create column B status %d, want %d", createColumnBResp.StatusCode, http.StatusCreated)
+	}
+	columnB := parseColumn(t, createColumnBResp)
+
+	name := "Write tests"
+	description := "Cover the new endpoint with tests"
+
+	// 3. Create a task in column A, store response in createdTask, and validate response fields
+	createResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", map[string]string{
+		"name":        name,
+		"description": description,
+	})
+	defer func() {
+		_ = createResp.Body.Close()
+	}()
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got status %d, want %d", createResp.StatusCode, http.StatusCreated)
+	}
+
+	createdTask := parseTask(t, createResp)
+
+	_, err := uuid.Parse(createdTask.ID)
+	if err != nil {
+		t.Errorf("uuid.Parse(%q) error = %v, want nil", createdTask.ID, err)
+	}
+	_, err = uuid.Parse(createdTask.ColumnID)
+	if err != nil {
+		t.Errorf("uuid.Parse(%q) error = %v, want nil", createdTask.ColumnID, err)
+	}
+	if createdTask.ColumnID != columnA.ID {
+		t.Errorf("got column ID %q, want %q", createdTask.ColumnID, columnA.ID)
+	}
+	if createdTask.Name != name {
+		t.Errorf("got name %q, want %q", createdTask.Name, name)
+	}
+	if createdTask.Description != description {
+		t.Errorf("got description %q, want %q", createdTask.Description, description)
+	}
+	if createdTask.Position != 1 {
+		t.Errorf("got position %d, want %d", createdTask.Position, 1)
+	}
+	_, err = time.Parse(timeFormat, createdTask.CreatedAt)
+	if err != nil {
+		t.Errorf("time.Parse(%q) error = %v, want nil", createdTask.CreatedAt, err)
+	}
+	_, err = time.Parse(timeFormat, createdTask.UpdatedAt)
+	if err != nil {
+		t.Errorf("time.Parse(%q) error = %v, want nil", createdTask.UpdatedAt, err)
+	}
+
+	// 4. List tasks in column A, get the first task, and perform deep comparison with createdTask
+	listResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", nil)
+	defer func() {
+		_ = listResp.Body.Close()
+	}()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("got list status %d, want %d", listResp.StatusCode, http.StatusOK)
+	}
+
+	listedTasks := parseTasksList(t, listResp)
+	if len(listedTasks) != 1 {
+		t.Fatalf("got %d tasks in list, want 1", len(listedTasks))
+	}
+	if diff := cmp.Diff(createdTask, listedTasks[0]); diff != "" {
+		t.Errorf("List item mismatch (-want +got):\n%s", diff)
+	}
+
+	// 5. Update by id with name and description, store response in updatedTask, validate fields, and ensure updatedAt advanced
+	updatedName := "Updated Name"
+	updatedDescription := "Updated description"
+	WaitForTimestampTicker(t)
+	updateResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+createdTask.ID, map[string]string{
+		"name":        updatedName,
+		"description": updatedDescription,
+	})
+	defer func() {
+		_ = updateResp.Body.Close()
+	}()
+	if updateResp.StatusCode != http.StatusOK {
+		t.Fatalf("got Update by id status %d, want %d", updateResp.StatusCode, http.StatusOK)
+	}
+
+	updatedTask := parseTask(t, updateResp)
+
+	// Validation trick: revert changed fields in a clone and compare with createdTask
+	checkTask := updatedTask
+	checkTask.Name = createdTask.Name
+	checkTask.Description = createdTask.Description
+	checkTask.UpdatedAt = createdTask.UpdatedAt
+	if diff := cmp.Diff(createdTask, checkTask); diff != "" {
+		t.Errorf("Update() diff (-want +got):\n%s", diff)
+	}
+
+	// Verify specific changes
+	if updatedTask.Name != updatedName {
+		t.Errorf("got updated name %q, want %q", updatedTask.Name, updatedName)
+	}
+	if updatedTask.Description != updatedDescription {
+		t.Errorf("got updated description %q, want %q", updatedTask.Description, updatedDescription)
+	}
+
+	updatedAtAfterUpdate, err := time.Parse(timeFormat, updatedTask.UpdatedAt)
+	if err != nil {
+		t.Fatalf("time.Parse(%q) error = %v", updatedTask.UpdatedAt, err)
+	}
+	updatedAtBeforeUpdate, err := time.Parse(timeFormat, createdTask.UpdatedAt)
+	if err != nil {
+		t.Fatalf("time.Parse(%q) error = %v", createdTask.UpdatedAt, err)
+	}
+	if !updatedAtAfterUpdate.After(updatedAtBeforeUpdate) {
+		t.Errorf("updatedAt must advance after Update by id; got %v, previous %v", updatedAtAfterUpdate, updatedAtBeforeUpdate)
+	}
+
+	// 6. Create the second task in column A so we can later delete it from the middle and verify shifting
+	createSecondResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", map[string]string{
+		"name":        "Second",
+		"description": "second",
+	})
+	defer func() {
+		_ = createSecondResp.Body.Close()
+	}()
+	if createSecondResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got second create status %d, want %d", createSecondResp.StatusCode, http.StatusCreated)
+	}
+
+	secondTask := parseTask(t, createSecondResp)
+	if secondTask.Position != 2 {
+		t.Errorf("got second task position %d, want %d", secondTask.Position, 2)
+	}
+
+	// 7. Create the third task in column A so delete can verify position compaction for trailing items
+	createThirdResp := ac.Do(t, http.MethodPost, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", map[string]string{
+		"name":        "Third",
+		"description": "third",
+	})
+	defer func() {
+		_ = createThirdResp.Body.Close()
+	}()
+	if createThirdResp.StatusCode != http.StatusCreated {
+		t.Fatalf("got third create status %d, want %d", createThirdResp.StatusCode, http.StatusCreated)
+	}
+
+	thirdTask := parseTask(t, createThirdResp)
+	if thirdTask.Position != 3 {
+		t.Errorf("got third task position %d, want %d", thirdTask.Position, 3)
+	}
+
+	// 8. Delete the middle task and expect the request to succeed
+	deleteResp := ac.Do(t, http.MethodDelete, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+secondTask.ID, nil)
+	defer func() {
+		_ = deleteResp.Body.Close()
+	}()
+	if deleteResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("got delete status %d, want %d", deleteResp.StatusCode, http.StatusNoContent)
+	}
+
+	// 9. List tasks again and verify delete preserved the first task and compacted positions
+	listAfterDeleteResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", nil)
+	defer func() {
+		_ = listAfterDeleteResp.Body.Close()
+	}()
+	if listAfterDeleteResp.StatusCode != http.StatusOK {
+		t.Fatalf("got list status %d after delete, want %d", listAfterDeleteResp.StatusCode, http.StatusOK)
+	}
+
+	listedAfterDelete := parseTasksList(t, listAfterDeleteResp)
+	if len(listedAfterDelete) != 2 {
+		t.Fatalf("got %d tasks after delete, want 2", len(listedAfterDelete))
+	}
+	if listedAfterDelete[0].ID != updatedTask.ID || listedAfterDelete[0].Position != 1 {
+		t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterDelete[0].ID, listedAfterDelete[0].Position, updatedTask.ID, 1)
+	}
+	if listedAfterDelete[1].ID != thirdTask.ID || listedAfterDelete[1].Position != 2 {
+		t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterDelete[1].ID, listedAfterDelete[1].Position, thirdTask.ID, 2)
+	}
+
+	// 10. Move the third task up to first position within the same column and expect the new column and position in response
+	moveResp := ac.Do(t, http.MethodPut, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+thirdTask.ID+"/position", map[string]any{
+		"targetColumnId": columnA.ID,
+		"targetPosition": 1,
+	})
+	defer func() {
+		_ = moveResp.Body.Close()
+	}()
+	if moveResp.StatusCode != http.StatusOK {
+		t.Fatalf("got move status %d, want %d", moveResp.StatusCode, http.StatusOK)
+	}
+
+	movedPosition := parseTaskPosition(t, moveResp)
+	if movedPosition.ColumnID != columnA.ID {
+		t.Errorf("got move response column id %q, want %q", movedPosition.ColumnID, columnA.ID)
+	}
+	if movedPosition.Position != 1 {
+		t.Errorf("got move response position %d, want %d", movedPosition.Position, 1)
+	}
+
+	// 11. List tasks again and verify move reordered the remaining tasks in column A
+	listAfterMoveResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", nil)
+	defer func() {
+		_ = listAfterMoveResp.Body.Close()
+	}()
+	if listAfterMoveResp.StatusCode != http.StatusOK {
+		t.Fatalf("got list status %d after move, want %d", listAfterMoveResp.StatusCode, http.StatusOK)
+	}
+
+	listedAfterMove := parseTasksList(t, listAfterMoveResp)
+	if len(listedAfterMove) != 2 {
+		t.Fatalf("got %d tasks after move, want 2", len(listedAfterMove))
+	}
+	if listedAfterMove[0].ID != thirdTask.ID || listedAfterMove[0].Position != 1 {
+		t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterMove[0].ID, listedAfterMove[0].Position, thirdTask.ID, 1)
+	}
+	if listedAfterMove[1].ID != updatedTask.ID || listedAfterMove[1].Position != 2 {
+		t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAfterMove[1].ID, listedAfterMove[1].Position, updatedTask.ID, 2)
+	}
+
+	// 12. Move the third task across columns from column A to column B at position 1 and expect the new column and position in response
+	crossMoveResp := ac.Do(t, http.MethodPut, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+thirdTask.ID+"/position", map[string]any{
+		"targetColumnId": columnB.ID,
+		"targetPosition": 1,
+	})
+	defer func() {
+		_ = crossMoveResp.Body.Close()
+	}()
+	if crossMoveResp.StatusCode != http.StatusOK {
+		t.Fatalf("got cross-column move status %d, want %d", crossMoveResp.StatusCode, http.StatusOK)
+	}
+
+	crossMovedPosition := parseTaskPosition(t, crossMoveResp)
+	if crossMovedPosition.ColumnID != columnB.ID {
+		t.Errorf("got cross-column move response column id %q, want %q", crossMovedPosition.ColumnID, columnB.ID)
+	}
+	if crossMovedPosition.Position != 1 {
+		t.Errorf("got cross-column move response position %d, want %d", crossMovedPosition.Position, 1)
+	}
+
+	// 13. List tasks in column A and verify the moved task is gone, and the remaining task kept position 1
+	listAAfterCrossResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks", nil)
+	defer func() {
+		_ = listAAfterCrossResp.Body.Close()
+	}()
+	if listAAfterCrossResp.StatusCode != http.StatusOK {
+		t.Fatalf("got list column A status %d after cross move, want %d", listAAfterCrossResp.StatusCode, http.StatusOK)
+	}
+
+	listedAAfterCross := parseTasksList(t, listAAfterCrossResp)
+	if len(listedAAfterCross) != 1 {
+		t.Fatalf("got %d tasks in column A after cross move, want 1", len(listedAAfterCross))
+	}
+	if listedAAfterCross[0].ID != updatedTask.ID || listedAAfterCross[0].Position != 1 {
+		t.Errorf("got id=%s position=%d, want id=%s position=%d", listedAAfterCross[0].ID, listedAAfterCross[0].Position, updatedTask.ID, 1)
+	}
+
+	// 14. List tasks in column B and verify the moved task landed at position 1 with updated columnId
+	listBAfterCrossResp := ac.Do(t, http.MethodGet, "/v1/boards/"+board.ID+"/columns/"+columnB.ID+"/tasks", nil)
+	defer func() {
+		_ = listBAfterCrossResp.Body.Close()
+	}()
+	if listBAfterCrossResp.StatusCode != http.StatusOK {
+		t.Fatalf("got list column B status %d after cross move, want %d", listBAfterCrossResp.StatusCode, http.StatusOK)
+	}
+
+	listedBAfterCross := parseTasksList(t, listBAfterCrossResp)
+	if len(listedBAfterCross) != 1 {
+		t.Fatalf("got %d tasks in column B after cross move, want 1", len(listedBAfterCross))
+	}
+	if listedBAfterCross[0].ID != thirdTask.ID || listedBAfterCross[0].Position != 1 || listedBAfterCross[0].ColumnID != columnB.ID {
+		t.Errorf("got id=%s position=%d columnId=%s, want id=%s position=%d columnId=%s", listedBAfterCross[0].ID, listedBAfterCross[0].Position, listedBAfterCross[0].ColumnID, thirdTask.ID, 1, columnB.ID)
+	}
 }
 
 func parseTask(t *testing.T, resp *http.Response) TaskJSON {

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -12,7 +12,7 @@ import (
 	"goroutine/internal/testutil"
 )
 
-func TestUser_TelegramNotifications(t *testing.T) {
+func TestUser_HappyPath(t *testing.T) {
 	mockTelegram := testutil.NewMockTelegramAPI(t, http.StatusOK)
 	defer mockTelegram.Close()
 
@@ -20,65 +20,63 @@ func TestUser_TelegramNotifications(t *testing.T) {
 
 	p := Prelude(t)
 
-	t.Run("Telegram notifications full flow", func(t *testing.T) {
-		testutil.TruncateAllTables(t, p.Pool)
-		testutil.FlushRedisDB(t, p.RedisClient)
+	testutil.TruncateAllTables(t, p.Pool)
+	testutil.FlushRedisDB(t, p.RedisClient)
 
-		ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
+	ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
 
-		// 1. Get Telegram link token.
-		linkResp := ac.Do(t, http.MethodPost, "/v1/users/me/telegram/link", nil)
-		defer func() {
-			_ = linkResp.Body.Close()
-		}()
+	// 1. Get Telegram link token.
+	linkResp := ac.Do(t, http.MethodPost, "/v1/users/me/telegram/link", nil)
+	defer func() {
+		_ = linkResp.Body.Close()
+	}()
 
-		if linkResp.StatusCode != http.StatusOK {
-			t.Fatalf("got status %d, want %d", linkResp.StatusCode, http.StatusOK)
-		}
+	if linkResp.StatusCode != http.StatusOK {
+		t.Fatalf("got status %d, want %d", linkResp.StatusCode, http.StatusOK)
+	}
 
-		var linkBody struct {
-			Token string `json:"token"`
-		}
-		err := json.NewDecoder(linkResp.Body).Decode(&linkBody)
-		if err != nil {
-			t.Fatalf("Decode() error = %v", err)
-		}
+	var linkBody struct {
+		Token string `json:"token"`
+	}
+	err := json.NewDecoder(linkResp.Body).Decode(&linkBody)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
 
-		// 2. Simulate Telegram webhook: user sends /start <token> to the bot.
-		webhookBody := map[string]any{
-			"message": map[string]any{
-				"text": "/start " + linkBody.Token,
-				"chat": map[string]any{
-					"id":       123456789,
-					"username": "testuser",
-				},
+	// 2. Simulate Telegram webhook: user sends /start <token> to the bot.
+	webhookBody := map[string]any{
+		"message": map[string]any{
+			"text": "/start " + linkBody.Token,
+			"chat": map[string]any{
+				"id":       123456789,
+				"username": "testuser",
 			},
-		}
-		body, err := json.Marshal(webhookBody)
-		if err != nil {
-			t.Fatalf("json.Marshal() error = %v", err)
-		}
-		webhookResp, err := p.HTTPClient.Post(p.Server.URL+"/webhook/telegram", "application/json", bytes.NewReader(body))
-		if err != nil {
-			t.Fatalf("webhook Post() error = %v", err)
-		}
-		defer func() {
-			_ = webhookResp.Body.Close()
-		}()
+		},
+	}
+	body, err := json.Marshal(webhookBody)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	webhookResp, err := p.HTTPClient.Post(p.Server.URL+"/webhook/telegram", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("webhook Post() error = %v", err)
+	}
+	defer func() {
+		_ = webhookResp.Body.Close()
+	}()
 
-		if webhookResp.StatusCode != http.StatusOK {
-			t.Fatalf("got webhook status %d, want %d", webhookResp.StatusCode, http.StatusOK)
-		}
+	if webhookResp.StatusCode != http.StatusOK {
+		t.Fatalf("got webhook status %d, want %d", webhookResp.StatusCode, http.StatusOK)
+	}
 
-		// 3. Verify the mock Telegram API received the confirmation message.
-		if !mockTelegram.Called {
-			t.Fatal("mock Telegram API was not called")
-		}
-		if mockTelegram.LastChatID != 123456789 {
-			t.Errorf("got chat_id %d, want %d", mockTelegram.LastChatID, 123456789)
-		}
-		if !strings.Contains(mockTelegram.LastText, "Successfully linked") {
-			t.Errorf("got text %q, want success message", mockTelegram.LastText)
-		}
-	})
+	// 3. Verify the mock Telegram API received the confirmation message.
+	if !mockTelegram.Called {
+		t.Fatal("mock Telegram API was not called")
+	}
+	if mockTelegram.LastChatID != 123456789 {
+		t.Errorf("got chat_id %d, want %d", mockTelegram.LastChatID, 123456789)
+	}
+	if !strings.Contains(mockTelegram.LastText, "Successfully linked") {
+		t.Errorf("got text %q, want success message", mockTelegram.LastText)
+	}
 }


### PR DESCRIPTION
### Summary
- Compare with validated structs instead of duplicating validation
- Stricter tests checking whole tables instead of getting just one suitable object
- Remove useless `t.Run` subtests in happy paths
- Minor style changes

### Verification
- [x] No functionality changed
- [x] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [x] Unit, E2E, integration tests, load/race tests added or updated
- [ ] Documentation updated
- [x] No sensitive data committed
