### PR TITLE
refactor: unexport all possible identifiers

### DIFF
--- a/internal/domain/board.go
+++ b/internal/domain/board.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	ErrBoardNameTooShort       string = "Name is too short"
-	ErrBoardNameTooLong        string = "Name is too long"
-	ErrBoardDescriptionTooLong string = "Description is too long"
+	errBoardNameTooShort       string = "Name is too short"
+	errBoardNameTooLong        string = "Name is too long"
+	errBoardDescriptionTooLong string = "Description is too long"
 )
 
 type Board struct {
@@ -29,15 +29,15 @@ type (
 )
 
 func NewBoardID() BoardID {
-	return NewID[boardTag]()
+	return newID[boardTag]()
 }
 
 func ParseBoardID(s string) (BoardID, error) {
-	return ParseID[boardTag](s)
+	return parseID[boardTag](s)
 }
 
 func NewBoardIDFromUUID(u uuid.UUID) (BoardID, error) {
-	return NewIDFromUUID[boardTag](u)
+	return newIDFromUUID[boardTag](u)
 }
 
 type BoardName struct {
@@ -48,15 +48,15 @@ func NewBoardName(name string) (BoardName, error) {
 	trimmedName := strings.TrimSpace(name)
 	var issues []string
 	if trimmedName == "" {
-		issues = append(issues, ErrBoardNameTooShort)
+		issues = append(issues, errBoardNameTooShort)
 	}
 
 	if len(trimmedName) > 128 {
-		issues = append(issues, ErrBoardNameTooLong)
+		issues = append(issues, errBoardNameTooLong)
 	}
 
 	if len(issues) > 0 {
-		return BoardName{}, &ErrValidation{Issues: issues}
+		return BoardName{}, &errValidation{Issues: issues}
 	}
 
 	return BoardName{value: trimmedName}, nil
@@ -78,11 +78,11 @@ func NewBoardDescription(description string) (BoardDescription, error) {
 	trimmedDescription := strings.TrimSpace(description)
 	var issues []string
 	if len(trimmedDescription) > 1024 {
-		issues = append(issues, ErrBoardDescriptionTooLong)
+		issues = append(issues, errBoardDescriptionTooLong)
 	}
 
 	if len(issues) > 0 {
-		return BoardDescription{}, &ErrValidation{Issues: issues}
+		return BoardDescription{}, &errValidation{Issues: issues}
 	}
 
 	return BoardDescription{value: trimmedDescription}, nil

--- a/internal/domain/column.go
+++ b/internal/domain/column.go
@@ -33,15 +33,15 @@ type (
 )
 
 func NewColumnID() ColumnID {
-	return NewID[columnTag]()
+	return newID[columnTag]()
 }
 
 func ParseColumnID(s string) (ColumnID, error) {
-	return ParseID[columnTag](s)
+	return parseID[columnTag](s)
 }
 
 func NewColumnIDFromUUID(u uuid.UUID) (ColumnID, error) {
-	return NewIDFromUUID[columnTag](u)
+	return newIDFromUUID[columnTag](u)
 }
 
 type ColumnName struct {
@@ -58,7 +58,7 @@ func NewColumnName(name string) (ColumnName, error) {
 		issues = append(issues, ErrColumnNameTooLong)
 	}
 	if len(issues) > 0 {
-		return ColumnName{}, &ErrValidation{Issues: issues}
+		return ColumnName{}, &errValidation{Issues: issues}
 	}
 
 	return ColumnName{value: trimmedName}, nil
@@ -80,7 +80,7 @@ func NewColumnDescription(description string) (ColumnDescription, error) {
 	}
 
 	if len(issues) > 0 {
-		return ColumnDescription{}, &ErrValidation{Issues: issues}
+		return ColumnDescription{}, &errValidation{Issues: issues}
 	}
 
 	return ColumnDescription{value: trimmedDescription}, nil
@@ -96,7 +96,7 @@ type ColumnPosition struct {
 
 func NewColumnPosition(position int64) (ColumnPosition, error) {
 	if position <= 0 || position > math.MaxInt32 {
-		return ColumnPosition{}, &ErrValidation{Issues: []string{ErrColumnPositionValue}}
+		return ColumnPosition{}, &errValidation{Issues: []string{ErrColumnPositionValue}}
 	}
 
 	return ColumnPosition{value: int32(position)}, nil
@@ -105,7 +105,7 @@ func NewColumnPosition(position int64) (ColumnPosition, error) {
 func ParseColumnPosition(position string) (ColumnPosition, error) {
 	v, err := strconv.ParseInt(position, 10, 64)
 	if err != nil {
-		return ColumnPosition{}, &ErrValidation{Issues: []string{ErrColumnPositionValue}}
+		return ColumnPosition{}, &errValidation{Issues: []string{ErrColumnPositionValue}}
 	}
 
 	return NewColumnPosition(v)

--- a/internal/domain/email.go
+++ b/internal/domain/email.go
@@ -10,7 +10,7 @@ type Email struct {
 	value string
 }
 
-const ErrInvalidEmail = "Invalid email"
+const errInvalidEmail = "Invalid email"
 
 func NewEmail(email string) (Email, error) {
 	trimmedEmail := strings.TrimSpace(email)
@@ -18,7 +18,7 @@ func NewEmail(email string) (Email, error) {
 
 	_, err := mail.ParseAddress(lowercasedEmail)
 	if err != nil {
-		return Email{}, &ErrValidation{Issues: []string{ErrInvalidEmail}}
+		return Email{}, &errValidation{Issues: []string{errInvalidEmail}}
 	}
 
 	return Email{value: lowercasedEmail}, nil

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -6,23 +6,16 @@ import (
 	"strings"
 )
 
-type ErrValidation struct {
+type errValidation struct {
 	Issues []string
 }
 
-func (e *ErrValidation) Error() string {
+func (e *errValidation) Error() string {
 	return fmt.Sprintf("validation error: %s", strings.Join(e.Issues, ", "))
 }
 
-func NewValidationError(issues ...string) error {
-	if len(issues) == 0 {
-		return nil
-	}
-	return &ErrValidation{Issues: issues}
-}
-
 func ExtractValidationIssues(err error) []string {
-	var ve *ErrValidation
+	var ve *errValidation
 	if errors.As(err, &ve) {
 		return ve.Issues
 	}

--- a/internal/domain/task.go
+++ b/internal/domain/task.go
@@ -32,15 +32,15 @@ type (
 )
 
 func NewTaskID() TaskID {
-	return NewID[taskTag]()
+	return newID[taskTag]()
 }
 
 func ParseTaskID(s string) (TaskID, error) {
-	return ParseID[taskTag](s)
+	return parseID[taskTag](s)
 }
 
 func NewTaskIDFromUUID(u uuid.UUID) (TaskID, error) {
-	return NewIDFromUUID[taskTag](u)
+	return newIDFromUUID[taskTag](u)
 }
 
 type TaskName struct {
@@ -57,7 +57,7 @@ func NewTaskName(name string) (TaskName, error) {
 		issues = append(issues, ErrTaskNameTooLong)
 	}
 	if len(issues) > 0 {
-		return TaskName{}, &ErrValidation{Issues: issues}
+		return TaskName{}, &errValidation{Issues: issues}
 	}
 
 	return TaskName{value: trimmedName}, nil
@@ -83,7 +83,7 @@ func NewTaskDescription(description string) (TaskDescription, error) {
 	}
 
 	if len(issues) > 0 {
-		return TaskDescription{}, &ErrValidation{Issues: issues}
+		return TaskDescription{}, &errValidation{Issues: issues}
 	}
 
 	return TaskDescription{value: trimmedDescription}, nil
@@ -103,7 +103,7 @@ type TaskPosition struct {
 
 func NewTaskPosition(position int64) (TaskPosition, error) {
 	if position <= 0 || position > math.MaxInt32 {
-		return TaskPosition{}, &ErrValidation{Issues: []string{ErrTaskPositionValue}}
+		return TaskPosition{}, &errValidation{Issues: []string{ErrTaskPositionValue}}
 	}
 
 	return TaskPosition{value: int32(position)}, nil

--- a/internal/domain/telegram.go
+++ b/internal/domain/telegram.go
@@ -16,8 +16,8 @@ const (
 	ErrInvalidTelegramLinkToken = "Telegram link token must be a valid UUIDv7"
 	ErrInvalidTelegramChatID    = "Telegram chat ID must be a non-zero 64-bit integer"
 	ErrInvalidTelegramUsername  = "Telegram username must start with '@' and be 5-32 alphanumeric characters or underscores"
-	ErrInvalidTelegramToken     = "Telegram bot token must be in format digits:alphanumeric"
-	ErrInvalidTelegramMessage   = "Telegram message must be 1-4096 characters"
+	errInvalidTelegramToken     = "Telegram bot token must be in format digits:alphanumeric"
+	errInvalidTelegramMessage   = "Telegram message must be 1-4096 characters"
 )
 
 var (
@@ -35,7 +35,7 @@ func NewTelegramLinkToken(token string) (TelegramLinkToken, error) {
 
 	u, err := uuid.Parse(trimmed)
 	if err != nil || u.Version() != 7 {
-		return TelegramLinkToken{}, &ErrValidation{Issues: []string{ErrInvalidTelegramLinkToken}}
+		return TelegramLinkToken{}, &errValidation{Issues: []string{ErrInvalidTelegramLinkToken}}
 	}
 
 	return TelegramLinkToken{SecretString: secrecy.SecretString(trimmed)}, nil
@@ -48,7 +48,7 @@ type TelegramChatID struct {
 
 func NewTelegramChatID(id int64) (TelegramChatID, error) {
 	if id == 0 {
-		return TelegramChatID{}, &ErrValidation{Issues: []string{ErrInvalidTelegramChatID}}
+		return TelegramChatID{}, &errValidation{Issues: []string{ErrInvalidTelegramChatID}}
 	}
 	return TelegramChatID{value: id}, nil
 }
@@ -57,7 +57,7 @@ func ParseTelegramChatID(s string) (TelegramChatID, error) {
 	trimmed := strings.TrimSpace(s)
 	id, err := strconv.ParseInt(trimmed, 10, 64)
 	if err != nil {
-		return TelegramChatID{}, &ErrValidation{Issues: []string{ErrInvalidTelegramChatID}}
+		return TelegramChatID{}, &errValidation{Issues: []string{ErrInvalidTelegramChatID}}
 	}
 
 	return NewTelegramChatID(id)
@@ -83,7 +83,7 @@ type TelegramUsername struct {
 func NewTelegramUsername(username string) (TelegramUsername, error) {
 	trimmed := strings.TrimSpace(username)
 	if !telegramUsernameRegex.MatchString(trimmed) {
-		return TelegramUsername{}, &ErrValidation{Issues: []string{ErrInvalidTelegramUsername}}
+		return TelegramUsername{}, &errValidation{Issues: []string{ErrInvalidTelegramUsername}}
 	}
 	return TelegramUsername{value: trimmed}, nil
 }
@@ -104,7 +104,7 @@ type TelegramToken struct {
 func NewTelegramToken(token string) (TelegramToken, error) {
 	trimmed := strings.TrimSpace(token)
 	if !telegramTokenRegex.MatchString(trimmed) {
-		return TelegramToken{}, &ErrValidation{Issues: []string{ErrInvalidTelegramToken}}
+		return TelegramToken{}, &errValidation{Issues: []string{errInvalidTelegramToken}}
 	}
 	return TelegramToken{SecretString: secrecy.SecretString(trimmed)}, nil
 }
@@ -117,7 +117,7 @@ type TelegramMessage struct {
 func NewTelegramMessage(text string) (TelegramMessage, error) {
 	trimmed := strings.TrimSpace(text)
 	if len(trimmed) < 1 || len(trimmed) > 4096 {
-		return TelegramMessage{}, &ErrValidation{Issues: []string{ErrInvalidTelegramMessage}}
+		return TelegramMessage{}, &errValidation{Issues: []string{errInvalidTelegramMessage}}
 	}
 	return TelegramMessage{value: trimmed}, nil
 }

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	ErrPasswordTooShort string = "Password is too short"
-	ErrInvalidJWTToken  string = "Invalid JWT token"
+	errPasswordTooShort string = "Password is too short"
+	errInvalidJWTToken  string = "Invalid JWT token"
 )
 
 type User struct {
@@ -31,15 +31,15 @@ type (
 )
 
 func NewUserID() UserID {
-	return NewID[userID]()
+	return newID[userID]()
 }
 
 func ParseUserID(s string) (UserID, error) {
-	return ParseID[userID](s)
+	return parseID[userID](s)
 }
 
 func NewUserIDFromUUID(u uuid.UUID) (UserID, error) {
-	return NewIDFromUUID[userID](u)
+	return newIDFromUUID[userID](u)
 }
 
 type PasswordHash struct {
@@ -56,7 +56,7 @@ type UserPassword struct {
 
 func NewUserPassword(password string) (UserPassword, error) {
 	if len(password) < 6 || strings.TrimSpace(password) == "" {
-		return UserPassword{}, &ErrValidation{Issues: []string{ErrPasswordTooShort}}
+		return UserPassword{}, &errValidation{Issues: []string{errPasswordTooShort}}
 	}
 
 	return UserPassword{SecretString: secrecy.SecretString(password)}, nil
@@ -69,16 +69,16 @@ type AuthToken struct {
 func NewJWTString(token string) (AuthToken, error) {
 	trimmed := strings.TrimSpace(token)
 	if trimmed == "" {
-		return AuthToken{}, &ErrValidation{Issues: []string{ErrInvalidJWTToken}}
+		return AuthToken{}, &errValidation{Issues: []string{errInvalidJWTToken}}
 	}
 
 	parts := strings.Split(trimmed, ".")
 	if len(parts) != 3 {
-		return AuthToken{}, &ErrValidation{Issues: []string{ErrInvalidJWTToken}}
+		return AuthToken{}, &errValidation{Issues: []string{errInvalidJWTToken}}
 	}
 
 	if slices.Contains(parts, "") {
-		return AuthToken{}, &ErrValidation{Issues: []string{ErrInvalidJWTToken}}
+		return AuthToken{}, &errValidation{Issues: []string{errInvalidJWTToken}}
 	}
 
 	return AuthToken{SecretString: secrecy.SecretString(trimmed)}, nil

--- a/internal/domain/uuid.go
+++ b/internal/domain/uuid.go
@@ -12,12 +12,12 @@ type UUID[Tag any] struct {
 	value uuid.UUID
 }
 
-func NewID[Tag any]() UUID[Tag] {
+func newID[Tag any]() UUID[Tag] {
 	id, _ := uuid.NewV7()
 	return UUID[Tag]{value: id}
 }
 
-func ParseID[Tag any, Struct UUID[Tag]](s string) (Struct, error) {
+func parseID[Tag any, Struct UUID[Tag]](s string) (Struct, error) {
 	u, err := uuid.Parse(s)
 	if err != nil {
 		return Struct{}, fmt.Errorf("parse id %s: %w", reflect.TypeFor[Tag](), err)
@@ -28,7 +28,7 @@ func ParseID[Tag any, Struct UUID[Tag]](s string) (Struct, error) {
 	return Struct{value: u}, nil
 }
 
-func NewIDFromUUID[Tag any, Struct UUID[Tag]](u uuid.UUID) (Struct, error) {
+func newIDFromUUID[Tag any, Struct UUID[Tag]](u uuid.UUID) (Struct, error) {
 	if u == uuid.Nil {
 		return Struct{}, fmt.Errorf("nil UUID")
 	}

--- a/internal/driver/telegram_client.go
+++ b/internal/driver/telegram_client.go
@@ -10,21 +10,21 @@ import (
 	"goroutine/internal/domain"
 )
 
-type TelegramClient struct {
+type telegramClient struct {
 	token   domain.TelegramToken
 	baseURL string
 	http    *http.Client
 }
 
-func NewTelegramClient(baseURL string, token domain.TelegramToken) *TelegramClient {
-	return &TelegramClient{
+func NewTelegramClient(baseURL string, token domain.TelegramToken) *telegramClient {
+	return &telegramClient{
 		token:   token,
 		baseURL: baseURL,
 		http:    &http.Client{Timeout: 10 * time.Second},
 	}
 }
 
-func (c *TelegramClient) SendMessage(ctx context.Context, chatID int64, text domain.TelegramMessage) error {
+func (c *telegramClient) sendMessage(ctx context.Context, chatID int64, text domain.TelegramMessage) error {
 	q := url.Values{}
 	q.Set("chat_id", fmt.Sprintf("%d", chatID))
 	q.Set("text", text.String())
@@ -49,6 +49,6 @@ func (c *TelegramClient) SendMessage(ctx context.Context, chatID int64, text dom
 	return nil
 }
 
-func (c *TelegramClient) Notify(ctx context.Context, chatID domain.TelegramChatID, text domain.TelegramMessage) error {
-	return c.SendMessage(ctx, chatID.Int64(), text)
+func (c *telegramClient) Notify(ctx context.Context, chatID domain.TelegramChatID, text domain.TelegramMessage) error {
+	return c.sendMessage(ctx, chatID.Int64(), text)
 }

--- a/internal/driver/telegram_client_test.go
+++ b/internal/driver/telegram_client_test.go
@@ -49,9 +49,9 @@ func TestTelegramClient_SendMessage(t *testing.T) {
 			defer mock.Close()
 
 			client := driver.NewTelegramClient(mock.URL(), token)
-			err := client.SendMessage(
+			err := client.Notify(
 				context.Background(),
-				testutil.ValidTelegramChatID().Int64(),
+				chatID,
 				message,
 			)
 

--- a/internal/http/handler/auth.go
+++ b/internal/http/handler/auth.go
@@ -15,21 +15,21 @@ import (
 	"goroutine/internal/service"
 )
 
-type AuthService interface {
+type authService interface {
 	Register(ctx context.Context, email domain.Email, password domain.UserPassword) error
 	Login(ctx context.Context, email domain.Email, password domain.UserPassword) (domain.AuthToken, error)
 }
 
-type Auth struct {
+type auth struct {
 	logger      *slog.Logger
-	authService AuthService
+	authService authService
 	responder   *httpschema.ErrorResponder
 }
 
-func NewAuth(logger *slog.Logger, authService AuthService, responder *httpschema.ErrorResponder) *Auth {
+func NewAuth(logger *slog.Logger, authService authService, responder *httpschema.ErrorResponder) *auth {
 	moduleLogger := logging.WithModule(logger, "handler.auth")
 
-	return &Auth{
+	return &auth{
 		authService: authService,
 		logger:      moduleLogger,
 		responder:   responder,
@@ -54,7 +54,7 @@ type registerBody struct {
 // @Failure 409 {object} httpschema.DetailedError "USER_ALREADY_EXISTS"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/register [post]
-func (h *Auth) Register(w http.ResponseWriter, r *http.Request) {
+func (h *auth) Register(w http.ResponseWriter, r *http.Request) {
 	var body registerBody
 
 	err := decodeJSONLimited(r, &body)
@@ -113,7 +113,7 @@ type loginResponse struct {
 // @Failure 401 {object} httpschema.DetailedError "INVALID_CREDENTIALS or USER_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/login [post]
-func (h *Auth) Login(w http.ResponseWriter, r *http.Request) {
+func (h *auth) Login(w http.ResponseWriter, r *http.Request) {
 	var body loginBody
 
 	err := decodeJSONLimited(r, &body)
@@ -165,7 +165,7 @@ type whoAmIResponse struct {
 // @Failure 401 {object} httpschema.DetailedError "Unauthorized: INVALID_TOKEN (handler) or INVALID_AUTH_HEADER / INVALID_TOKEN (auth middleware)"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/whoami [get]
-func (h *Auth) WhoAmI(w http.ResponseWriter, r *http.Request) {
+func (h *auth) WhoAmI(w http.ResponseWriter, r *http.Request) {
 	uid, ok := r.Context().Value(httpschema.ContextKeyUserID).(domain.UserID)
 	if !ok {
 		h.responder.InternalError(w, r, errors.New("failed to get user id from context"))

--- a/internal/http/handler/boards.go
+++ b/internal/http/handler/boards.go
@@ -12,7 +12,7 @@ import (
 	"goroutine/internal/service"
 )
 
-type BoardsService interface {
+type boardsService interface {
 	Create(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error)
 	Get(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error)
 	GetAggregate(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (service.AggregateBoard, error)
@@ -21,16 +21,16 @@ type BoardsService interface {
 	Delete(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) error
 }
 
-type Boards struct {
+type boards struct {
 	logger        *slog.Logger
-	boardsService BoardsService
+	boardsService boardsService
 	responder     *httpschema.ErrorResponder
 }
 
-func NewBoards(logger *slog.Logger, boardsService BoardsService, responder *httpschema.ErrorResponder) *Boards {
+func NewBoards(logger *slog.Logger, boardsService boardsService, responder *httpschema.ErrorResponder) *boards {
 	moduleLogger := logging.WithModule(logger, "handler.boards")
 
-	return &Boards{logger: moduleLogger, boardsService: boardsService, responder: responder}
+	return &boards{logger: moduleLogger, boardsService: boardsService, responder: responder}
 }
 
 type createBoardBody struct {
@@ -113,7 +113,7 @@ type listBoardsResponse = []boardResponse
 // @Failure 401 {object} httpschema.DetailedError "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards [post]
-func (h *Boards) Create(w http.ResponseWriter, r *http.Request) {
+func (h *boards) Create(w http.ResponseWriter, r *http.Request) {
 	var body createBoardBody
 
 	err := decodeJSONLimited(r, &body)
@@ -162,7 +162,7 @@ func (h *Boards) Create(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httpschema.DetailedError "BOARD_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId} [get]
-func (h *Boards) Get(w http.ResponseWriter, r *http.Request) {
+func (h *boards) Get(w http.ResponseWriter, r *http.Request) {
 	rawID := r.PathValue("boardId")
 	boardID, err := domain.ParseBoardID(rawID)
 	if err != nil {
@@ -202,7 +202,7 @@ func (h *Boards) Get(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httpschema.DetailedError "BOARD_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId}/aggregate [get]
-func (h *Boards) GetAggregate(w http.ResponseWriter, r *http.Request) {
+func (h *boards) GetAggregate(w http.ResponseWriter, r *http.Request) {
 	rawID := r.PathValue("boardId")
 	boardID, err := domain.ParseBoardID(rawID)
 	if err != nil {
@@ -240,7 +240,7 @@ func (h *Boards) GetAggregate(w http.ResponseWriter, r *http.Request) {
 // @Failure 401 {object} httpschema.DetailedError "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards [get]
-func (h *Boards) ListByOwnerID(w http.ResponseWriter, r *http.Request) {
+func (h *boards) ListByOwnerID(w http.ResponseWriter, r *http.Request) {
 	userID, ok := extractUserIDOrHandleMissing(w, r, h.logger, h.responder)
 	if !ok {
 		return
@@ -276,7 +276,7 @@ func (h *Boards) ListByOwnerID(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httpschema.DetailedError "BOARD_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId} [patch]
-func (h *Boards) Update(w http.ResponseWriter, r *http.Request) {
+func (h *boards) Update(w http.ResponseWriter, r *http.Request) {
 	rawID := r.PathValue("boardId")
 	boardID, err := domain.ParseBoardID(rawID)
 	if err != nil {
@@ -345,7 +345,7 @@ func (h *Boards) Update(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httpschema.DetailedError "BOARD_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId} [delete]
-func (h *Boards) Delete(w http.ResponseWriter, r *http.Request) {
+func (h *boards) Delete(w http.ResponseWriter, r *http.Request) {
 	rawID := r.PathValue("boardId")
 	boardID, err := domain.ParseBoardID(rawID)
 	if err != nil {

--- a/internal/http/handler/columns.go
+++ b/internal/http/handler/columns.go
@@ -12,7 +12,7 @@ import (
 	"goroutine/internal/service"
 )
 
-type ColumnsService interface {
+type columnsService interface {
 	Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName, description domain.ColumnDescription) (domain.Column, error)
 	ListByBoardID(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error)
 	Update(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName, description *domain.ColumnDescription) (domain.Column, error)
@@ -20,16 +20,16 @@ type ColumnsService interface {
 	Delete(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error
 }
 
-type Columns struct {
+type columns struct {
 	logger         *slog.Logger
-	columnsService ColumnsService
+	columnsService columnsService
 	responder      *httpschema.ErrorResponder
 }
 
-func NewColumns(logger *slog.Logger, columnsService ColumnsService, responder *httpschema.ErrorResponder) *Columns {
+func NewColumns(logger *slog.Logger, columnsService columnsService, responder *httpschema.ErrorResponder) *columns {
 	moduleLogger := logging.WithModule(logger, "handler.columns")
 
-	return &Columns{logger: moduleLogger, columnsService: columnsService, responder: responder}
+	return &columns{logger: moduleLogger, columnsService: columnsService, responder: responder}
 }
 
 type createColumnBody struct {
@@ -88,7 +88,7 @@ func newColumnResponse(column *domain.Column) columnResponse {
 // @Failure 404 {object} httpschema.DetailedError "BOARD_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId}/columns [post]
-func (h *Columns) Create(w http.ResponseWriter, r *http.Request) {
+func (h *columns) Create(w http.ResponseWriter, r *http.Request) {
 	rawBoardID := r.PathValue("boardId")
 	boardID, err := domain.ParseBoardID(rawBoardID)
 	if err != nil {
@@ -146,7 +146,7 @@ func (h *Columns) Create(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httpschema.DetailedError "BOARD_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId}/columns [get]
-func (h *Columns) ListByBoardID(w http.ResponseWriter, r *http.Request) {
+func (h *columns) ListByBoardID(w http.ResponseWriter, r *http.Request) {
 	rawBoardID := r.PathValue("boardId")
 	boardID, err := domain.ParseBoardID(rawBoardID)
 	if err != nil {
@@ -194,7 +194,7 @@ func (h *Columns) ListByBoardID(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httpschema.DetailedError "COLUMN_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId}/columns/{columnId} [patch]
-func (h *Columns) Update(w http.ResponseWriter, r *http.Request) {
+func (h *columns) Update(w http.ResponseWriter, r *http.Request) {
 	rawBoardID := r.PathValue("boardId")
 	boardID, err := domain.ParseBoardID(rawBoardID)
 	if err != nil {
@@ -272,7 +272,7 @@ func (h *Columns) Update(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httpschema.DetailedError "COLUMN_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId}/columns/{columnId}/position [put]
-func (h *Columns) Move(w http.ResponseWriter, r *http.Request) {
+func (h *columns) Move(w http.ResponseWriter, r *http.Request) {
 	rawBoardID := r.PathValue("boardId")
 	boardID, err := domain.ParseBoardID(rawBoardID)
 	if err != nil {
@@ -342,7 +342,7 @@ func (h *Columns) Move(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httpschema.DetailedError "COLUMN_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId}/columns/{columnId} [delete]
-func (h *Columns) Delete(w http.ResponseWriter, r *http.Request) {
+func (h *columns) Delete(w http.ResponseWriter, r *http.Request) {
 	rawBoardID := r.PathValue("boardId")
 	boardID, err := domain.ParseBoardID(rawBoardID)
 	if err != nil {

--- a/internal/http/handler/handlers.go
+++ b/internal/http/handler/handlers.go
@@ -11,13 +11,13 @@ import (
 )
 
 type Handlers struct {
-	Auth     *Auth
-	Health   *Health
-	Boards   *Boards
-	Columns  *Columns
-	Tasks    *Tasks
-	User     *User
-	Telegram *Telegram
+	Auth     *auth
+	Health   *health
+	Boards   *boards
+	Columns  *columns
+	Tasks    *tasks
+	User     *user
+	Telegram *telegram
 }
 
 var errBodyTooLarge = errors.New("request body too large")

--- a/internal/http/handler/health.go
+++ b/internal/http/handler/health.go
@@ -8,14 +8,14 @@ import (
 	"goroutine/internal/logging"
 )
 
-type Health struct {
+type health struct {
 	logger *slog.Logger
 }
 
-func NewHealth(logger *slog.Logger) *Health {
+func NewHealth(logger *slog.Logger) *health {
 	moduleLogger := logging.WithModule(logger, "handler.health")
 
-	return &Health{
+	return &health{
 		logger: moduleLogger,
 	}
 }
@@ -27,6 +27,6 @@ func NewHealth(logger *slog.Logger) *Health {
 // @Produce json
 // @Success 200 {object} httpschema.Status
 // @Router /v1/health [get]
-func (h *Health) Health(w http.ResponseWriter, r *http.Request) {
+func (h *health) Health(w http.ResponseWriter, r *http.Request) {
 	httpschema.RespondJSON(w, h.logger, http.StatusOK, httpschema.Status{Status: "ok"})
 }

--- a/internal/http/handler/mocks_test.go
+++ b/internal/http/handler/mocks_test.go
@@ -64,12 +64,12 @@ func NewMockTaskService(t *testing.T) *MockTaskService {
 }
 
 func (m *MockAuthService) Register(ctx context.Context, email domain.Email, password domain.UserPassword) error {
-	testutil.AssertFuncNotNil(m.t, "AuthService.RegisterFunc", m.RegisterFunc)
+	testutil.AssertFuncNotNil(m.t, "authService.RegisterFunc", m.RegisterFunc)
 	return m.RegisterFunc(ctx, email, password)
 }
 
 func (m *MockAuthService) Login(ctx context.Context, email domain.Email, password domain.UserPassword) (domain.AuthToken, error) {
-	testutil.AssertFuncNotNil(m.t, "AuthService.LoginFunc", m.LoginFunc)
+	testutil.AssertFuncNotNil(m.t, "authService.LoginFunc", m.LoginFunc)
 	return m.LoginFunc(ctx, email, password)
 }
 
@@ -85,92 +85,92 @@ func NewMockUserService(t *testing.T) *MockUserService {
 }
 
 func (m *MockUserService) CreateTelegramLinkToken(ctx context.Context, userID domain.UserID) (domain.TelegramLinkToken, error) {
-	testutil.AssertFuncNotNil(m.t, "UserService.CreateTelegramLinkTokenFunc", m.CreateTelegramLinkTokenFunc)
+	testutil.AssertFuncNotNil(m.t, "userService.CreateTelegramLinkTokenFunc", m.CreateTelegramLinkTokenFunc)
 	return m.CreateTelegramLinkTokenFunc(ctx, userID)
 }
 
 func (m *MockUserService) LinkTelegramByToken(ctx context.Context, token domain.TelegramLinkToken, chatID domain.TelegramChatID, username domain.TelegramUsername) error {
-	testutil.AssertFuncNotNil(m.t, "UserService.LinkTelegramByTokenFunc", m.LinkTelegramByTokenFunc)
+	testutil.AssertFuncNotNil(m.t, "userService.LinkTelegramByTokenFunc", m.LinkTelegramByTokenFunc)
 	return m.LinkTelegramByTokenFunc(ctx, token, chatID, username)
 }
 
 func (m *MockBoardService) Create(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
-	testutil.AssertFuncNotNil(m.t, "BoardsService.CreateFunc", m.CreateFunc)
+	testutil.AssertFuncNotNil(m.t, "boardsService.CreateFunc", m.CreateFunc)
 	return m.CreateFunc(ctx, ownerID, name, description)
 }
 
 func (m *MockBoardService) Get(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
-	testutil.AssertFuncNotNil(m.t, "BoardsService.GetFunc", m.GetFunc)
+	testutil.AssertFuncNotNil(m.t, "boardsService.GetFunc", m.GetFunc)
 	return m.GetFunc(ctx, ownerID, boardID)
 }
 
 func (m *MockBoardService) GetAggregate(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) (service.AggregateBoard, error) {
-	testutil.AssertFuncNotNil(m.t, "BoardsService.GetAggregateFunc", m.GetAggregateFunc)
+	testutil.AssertFuncNotNil(m.t, "boardsService.GetAggregateFunc", m.GetAggregateFunc)
 	return m.GetAggregateFunc(ctx, ownerID, boardID)
 }
 
 func (m *MockBoardService) ListByOwnerID(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error) {
-	testutil.AssertFuncNotNil(m.t, "BoardsService.ListByOwnerIDFunc", m.ListByOwnerIDFunc)
+	testutil.AssertFuncNotNil(m.t, "boardsService.ListByOwnerIDFunc", m.ListByOwnerIDFunc)
 	return m.ListByOwnerIDFunc(ctx, ownerID)
 }
 
 func (m *MockBoardService) Update(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID, name *domain.BoardName, description *domain.BoardDescription) (domain.Board, error) {
-	testutil.AssertFuncNotNil(m.t, "BoardsService.UpdateFunc", m.UpdateFunc)
+	testutil.AssertFuncNotNil(m.t, "boardsService.UpdateFunc", m.UpdateFunc)
 	return m.UpdateFunc(ctx, ownerID, boardID, name, description)
 }
 
 func (m *MockBoardService) Delete(ctx context.Context, ownerID domain.UserID, boardID domain.BoardID) error {
-	testutil.AssertFuncNotNil(m.t, "BoardsService.DeleteFunc", m.DeleteFunc)
+	testutil.AssertFuncNotNil(m.t, "boardsService.DeleteFunc", m.DeleteFunc)
 	return m.DeleteFunc(ctx, ownerID, boardID)
 }
 
 func (m *MockColumnService) Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName, description domain.ColumnDescription) (domain.Column, error) {
-	testutil.AssertFuncNotNil(m.t, "ColumnsService.CreateFunc", m.CreateFunc)
+	testutil.AssertFuncNotNil(m.t, "columnsService.CreateFunc", m.CreateFunc)
 	return m.CreateFunc(ctx, callerID, boardID, name, description)
 }
 
 func (m *MockColumnService) ListByBoardID(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error) {
-	testutil.AssertFuncNotNil(m.t, "ColumnsService.ListByBoardIDFunc", m.ListByBoardIDFunc)
+	testutil.AssertFuncNotNil(m.t, "columnsService.ListByBoardIDFunc", m.ListByBoardIDFunc)
 	return m.ListByBoardIDFunc(ctx, callerID, boardID)
 }
 
 func (m *MockColumnService) Update(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name *domain.ColumnName, description *domain.ColumnDescription) (domain.Column, error) {
-	testutil.AssertFuncNotNil(m.t, "ColumnsService.UpdateFunc", m.UpdateFunc)
+	testutil.AssertFuncNotNil(m.t, "columnsService.UpdateFunc", m.UpdateFunc)
 	return m.UpdateFunc(ctx, callerID, boardID, columnID, name, description)
 }
 
 func (m *MockColumnService) Move(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, targetPosition domain.ColumnPosition) (domain.ColumnPosition, error) {
-	testutil.AssertFuncNotNil(m.t, "ColumnsService.MoveFunc", m.MoveFunc)
+	testutil.AssertFuncNotNil(m.t, "columnsService.MoveFunc", m.MoveFunc)
 	return m.MoveFunc(ctx, callerID, boardID, columnID, targetPosition)
 }
 
 func (m *MockColumnService) Delete(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) error {
-	testutil.AssertFuncNotNil(m.t, "ColumnsService.DeleteFunc", m.DeleteFunc)
+	testutil.AssertFuncNotNil(m.t, "columnsService.DeleteFunc", m.DeleteFunc)
 	return m.DeleteFunc(ctx, callerID, boardID, columnID)
 }
 
 func (m *MockTaskService) Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error) {
-	testutil.AssertFuncNotNil(m.t, "TasksService.CreateFunc", m.CreateFunc)
+	testutil.AssertFuncNotNil(m.t, "tasksService.CreateFunc", m.CreateFunc)
 	return m.CreateFunc(ctx, callerID, boardID, columnID, name, description)
 }
 
 func (m *MockTaskService) ListByColumnID(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) ([]domain.Task, error) {
-	testutil.AssertFuncNotNil(m.t, "TasksService.ListByColumnIDFunc", m.ListByColumnIDFunc)
+	testutil.AssertFuncNotNil(m.t, "tasksService.ListByColumnIDFunc", m.ListByColumnIDFunc)
 	return m.ListByColumnIDFunc(ctx, callerID, boardID, columnID)
 }
 
 func (m *MockTaskService) Update(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error) {
-	testutil.AssertFuncNotNil(m.t, "TasksService.UpdateFunc", m.UpdateFunc)
+	testutil.AssertFuncNotNil(m.t, "tasksService.UpdateFunc", m.UpdateFunc)
 	return m.UpdateFunc(ctx, callerID, boardID, columnID, taskID, name, description)
 }
 
 func (m *MockTaskService) Move(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, targetColumnID domain.ColumnID, targetPosition domain.TaskPosition) (domain.ColumnID, domain.TaskPosition, error) {
-	testutil.AssertFuncNotNil(m.t, "TasksService.MoveFunc", m.MoveFunc)
+	testutil.AssertFuncNotNil(m.t, "tasksService.MoveFunc", m.MoveFunc)
 	return m.MoveFunc(ctx, callerID, boardID, columnID, taskID, targetColumnID, targetPosition)
 }
 
 func (m *MockTaskService) Delete(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error {
-	testutil.AssertFuncNotNil(m.t, "TasksService.DeleteFunc", m.DeleteFunc)
+	testutil.AssertFuncNotNil(m.t, "tasksService.DeleteFunc", m.DeleteFunc)
 	return m.DeleteFunc(ctx, callerID, boardID, columnID, taskID)
 }
 
@@ -185,6 +185,6 @@ func NewMockNotifier(t *testing.T) *MockNotifier {
 }
 
 func (m *MockNotifier) Notify(ctx context.Context, chatID domain.TelegramChatID, text domain.TelegramMessage) error {
-	testutil.AssertFuncNotNil(m.t, "Notifier.NotifyFunc", m.NotifyFunc)
+	testutil.AssertFuncNotNil(m.t, "notifier.NotifyFunc", m.NotifyFunc)
 	return m.NotifyFunc(ctx, chatID, text)
 }

--- a/internal/http/handler/tasks.go
+++ b/internal/http/handler/tasks.go
@@ -12,7 +12,7 @@ import (
 	"goroutine/internal/service"
 )
 
-type TasksService interface {
+type tasksService interface {
 	Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error)
 	ListByColumnID(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID) ([]domain.Task, error)
 	Update(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, name *domain.TaskName, description *domain.TaskDescription) (domain.Task, error)
@@ -20,16 +20,16 @@ type TasksService interface {
 	Delete(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error
 }
 
-type Tasks struct {
+type tasks struct {
 	logger       *slog.Logger
-	tasksService TasksService
+	tasksService tasksService
 	responder    *httpschema.ErrorResponder
 }
 
-func NewTasks(logger *slog.Logger, tasksService TasksService, responder *httpschema.ErrorResponder) *Tasks {
+func NewTasks(logger *slog.Logger, tasksService tasksService, responder *httpschema.ErrorResponder) *tasks {
 	moduleLogger := logging.WithModule(logger, "handler.tasks")
 
-	return &Tasks{logger: moduleLogger, tasksService: tasksService, responder: responder}
+	return &tasks{logger: moduleLogger, tasksService: tasksService, responder: responder}
 }
 
 type createTaskBody struct {
@@ -91,7 +91,7 @@ func newTaskResponse(task *domain.Task) taskResponse {
 // @Failure 404 {object} httpschema.DetailedError "COLUMN_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId}/columns/{columnId}/tasks [post]
-func (h *Tasks) Create(w http.ResponseWriter, r *http.Request) {
+func (h *tasks) Create(w http.ResponseWriter, r *http.Request) {
 	boardID, columnID, ok := h.parseBoardAndColumnID(w, r)
 	if !ok {
 		return
@@ -148,7 +148,7 @@ func (h *Tasks) Create(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httpschema.DetailedError "COLUMN_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId}/columns/{columnId}/tasks [get]
-func (h *Tasks) ListByColumnID(w http.ResponseWriter, r *http.Request) {
+func (h *tasks) ListByColumnID(w http.ResponseWriter, r *http.Request) {
 	boardID, columnID, ok := h.parseBoardAndColumnID(w, r)
 	if !ok {
 		return
@@ -195,7 +195,7 @@ func (h *Tasks) ListByColumnID(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httpschema.DetailedError "TASK_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId} [patch]
-func (h *Tasks) Update(w http.ResponseWriter, r *http.Request) {
+func (h *tasks) Update(w http.ResponseWriter, r *http.Request) {
 	boardID, columnID, taskID, ok := h.parseBoardColumnAndTaskID(w, r)
 	if !ok {
 		return
@@ -264,7 +264,7 @@ func (h *Tasks) Update(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httpschema.DetailedError "TASK_NOT_FOUND or COLUMN_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}/position [put]
-func (h *Tasks) Move(w http.ResponseWriter, r *http.Request) {
+func (h *tasks) Move(w http.ResponseWriter, r *http.Request) {
 	boardID, columnID, taskID, ok := h.parseBoardColumnAndTaskID(w, r)
 	if !ok {
 		return
@@ -337,7 +337,7 @@ func (h *Tasks) Move(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httpschema.DetailedError "TASK_NOT_FOUND"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId} [delete]
-func (h *Tasks) Delete(w http.ResponseWriter, r *http.Request) {
+func (h *tasks) Delete(w http.ResponseWriter, r *http.Request) {
 	boardID, columnID, taskID, ok := h.parseBoardColumnAndTaskID(w, r)
 	if !ok {
 		return
@@ -361,7 +361,7 @@ func (h *Tasks) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *Tasks) parseBoardAndColumnID(w http.ResponseWriter, r *http.Request) (boardID domain.BoardID, columnID domain.ColumnID, ok bool) {
+func (h *tasks) parseBoardAndColumnID(w http.ResponseWriter, r *http.Request) (boardID domain.BoardID, columnID domain.ColumnID, ok bool) {
 	rawBoardID := r.PathValue("boardId")
 	boardID, err := domain.ParseBoardID(rawBoardID)
 	if err != nil {
@@ -379,7 +379,7 @@ func (h *Tasks) parseBoardAndColumnID(w http.ResponseWriter, r *http.Request) (b
 	return boardID, columnID, true
 }
 
-func (h *Tasks) parseBoardColumnAndTaskID(w http.ResponseWriter, r *http.Request) (boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, ok bool) {
+func (h *tasks) parseBoardColumnAndTaskID(w http.ResponseWriter, r *http.Request) (boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID, ok bool) {
 	boardID, columnID, ok = h.parseBoardAndColumnID(w, r)
 	if !ok {
 		return domain.BoardID{}, domain.ColumnID{}, domain.TaskID{}, false

--- a/internal/http/handler/telegram.go
+++ b/internal/http/handler/telegram.go
@@ -13,24 +13,24 @@ import (
 	"goroutine/internal/service"
 )
 
-type TelegramUserService interface {
+type telegramUserService interface {
 	LinkTelegramByToken(ctx context.Context, token domain.TelegramLinkToken, chatID domain.TelegramChatID, username domain.TelegramUsername) error
 }
 
-type Notifier interface {
+type notifier interface {
 	Notify(ctx context.Context, chatID domain.TelegramChatID, text domain.TelegramMessage) error
 }
 
-type Telegram struct {
-	userService TelegramUserService
-	notifier    Notifier
+type telegram struct {
+	userService telegramUserService
+	notifier    notifier
 	logger      *slog.Logger
 }
 
-func NewTelegram(logger *slog.Logger, userService TelegramUserService, notifier Notifier) *Telegram {
+func NewTelegram(logger *slog.Logger, userService telegramUserService, notifier notifier) *telegram {
 	moduleLogger := logging.WithModule(logger, "handler.telegram")
 
-	return &Telegram{
+	return &telegram{
 		logger:      moduleLogger,
 		userService: userService,
 		notifier:    notifier,
@@ -45,7 +45,7 @@ func NewTelegram(logger *slog.Logger, userService TelegramUserService, notifier 
 // @Produce json
 // @Success 200 "Always returns 200 OK per Telegram webhook protocol"
 // @Router /webhook/telegram [post]
-func (h *Telegram) Webhook(w http.ResponseWriter, r *http.Request) {
+func (h *telegram) Webhook(w http.ResponseWriter, r *http.Request) {
 	const maxBodySize = 10 * 1024 // 10KB is more than enough for a Telegram update
 
 	var update struct {

--- a/internal/http/handler/user.go
+++ b/internal/http/handler/user.go
@@ -10,20 +10,20 @@ import (
 	"goroutine/internal/logging"
 )
 
-type UserService interface {
+type userService interface {
 	CreateTelegramLinkToken(ctx context.Context, userID domain.UserID) (domain.TelegramLinkToken, error)
 }
 
-type User struct {
+type user struct {
 	logger      *slog.Logger
-	userService UserService
+	userService userService
 	responder   *httpschema.ErrorResponder
 }
 
-func NewUser(logger *slog.Logger, userService UserService, responder *httpschema.ErrorResponder) *User {
+func NewUser(logger *slog.Logger, userService userService, responder *httpschema.ErrorResponder) *user {
 	moduleLogger := logging.WithModule(logger, "handler.user")
 
-	return &User{
+	return &user{
 		logger:      moduleLogger,
 		userService: userService,
 		responder:   responder,
@@ -44,7 +44,7 @@ type telegramLinkTokenResponse struct {
 // @Failure 401 {object} httpschema.DetailedError "Unauthorized: INVALID_TOKEN or INVALID_AUTH_HEADER"
 // @Failure 500 {object} httpschema.Error "Internal server error"
 // @Router /v1/users/me/telegram/link [post]
-func (u *User) CreateTelegramLinkToken(w http.ResponseWriter, r *http.Request) {
+func (u *user) CreateTelegramLinkToken(w http.ResponseWriter, r *http.Request) {
 	userID, ok := extractUserIDOrHandleMissing(w, r, u.logger, u.responder)
 	if !ok {
 		return

--- a/internal/http/httpschema/code_map.go
+++ b/internal/http/httpschema/code_map.go
@@ -15,7 +15,7 @@ var codeMap = map[string]string{
 	"PAYLOAD_TOO_LARGE":     "Request body too large",
 }
 
-func MapCodeToDescription(code string) string {
+func mapCodeToDescription(code string) string {
 	description, ok := codeMap[code]
 	if !ok {
 		return "Unknown error"

--- a/internal/http/httpschema/code_map_test.go
+++ b/internal/http/httpschema/code_map_test.go
@@ -1,9 +1,7 @@
-package httpschema_test
+package httpschema
 
 import (
 	"testing"
-
-	"goroutine/internal/http/httpschema"
 )
 
 func TestMapCodeToDescription(t *testing.T) {
@@ -41,7 +39,7 @@ func TestMapCodeToDescription(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			description := httpschema.MapCodeToDescription(tt.code)
+			description := mapCodeToDescription(tt.code)
 			if description != tt.description {
 				t.Errorf("got %q, want %q", description, tt.description)
 			}

--- a/internal/http/httpschema/error_responder.go
+++ b/internal/http/httpschema/error_responder.go
@@ -38,53 +38,49 @@ func (r *ErrorResponder) InternalError(w http.ResponseWriter, req *http.Request,
 		return
 	}
 	r.logger.ErrorContext(req.Context(), "Internal server error", slog.String("err", err.Error()))
-	r.Error(w, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR")
+	r.error(w, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR")
 }
 
 func (r *ErrorResponder) PayloadTooLarge(w http.ResponseWriter) {
-	r.DetailedError(w, http.StatusRequestEntityTooLarge, "PAYLOAD_TOO_LARGE", []Detail{
+	r.detailedError(w, http.StatusRequestEntityTooLarge, "PAYLOAD_TOO_LARGE", []Detail{
 		{Field: "body", Issues: []string{"Please stop spamming >_<"}},
 	})
 }
 
 func (r *ErrorResponder) BoardNotFound(w http.ResponseWriter, details []Detail) {
-	r.DetailedError(w, http.StatusNotFound, "BOARD_NOT_FOUND", details)
+	r.detailedError(w, http.StatusNotFound, "BOARD_NOT_FOUND", details)
 }
 
 func (r *ErrorResponder) ColumnNotFound(w http.ResponseWriter, details []Detail) {
-	r.DetailedError(w, http.StatusNotFound, "COLUMN_NOT_FOUND", details)
+	r.detailedError(w, http.StatusNotFound, "COLUMN_NOT_FOUND", details)
 }
 
 func (r *ErrorResponder) TaskNotFound(w http.ResponseWriter, details []Detail) {
-	r.DetailedError(w, http.StatusNotFound, "TASK_NOT_FOUND", details)
-}
-
-func (r *ErrorResponder) IndexOutOfBounds(w http.ResponseWriter, details []Detail) {
-	r.DetailedError(w, http.StatusBadRequest, "INDEX_OUT_OF_BOUNDS", details)
+	r.detailedError(w, http.StatusNotFound, "TASK_NOT_FOUND", details)
 }
 
 func (r *ErrorResponder) UserNotFound(w http.ResponseWriter, details []Detail) {
-	r.DetailedError(w, http.StatusUnauthorized, "USER_NOT_FOUND", details)
+	r.detailedError(w, http.StatusUnauthorized, "USER_NOT_FOUND", details)
 }
 
 func (r *ErrorResponder) ValidationError(w http.ResponseWriter, details []Detail) {
-	r.DetailedError(w, http.StatusBadRequest, "VALIDATION_ERROR", details)
+	r.detailedError(w, http.StatusBadRequest, "VALIDATION_ERROR", details)
 }
 
 func (r *ErrorResponder) InvalidCredentials(w http.ResponseWriter, details []Detail) {
-	r.DetailedError(w, http.StatusUnauthorized, "INVALID_CREDENTIALS", details)
+	r.detailedError(w, http.StatusUnauthorized, "INVALID_CREDENTIALS", details)
 }
 
 func (r *ErrorResponder) UserAlreadyExists(w http.ResponseWriter, details []Detail) {
-	r.DetailedError(w, http.StatusConflict, "USER_ALREADY_EXISTS", details)
+	r.detailedError(w, http.StatusConflict, "USER_ALREADY_EXISTS", details)
 }
 
 func (r *ErrorResponder) InvalidToken(w http.ResponseWriter, details []Detail) {
-	r.DetailedError(w, http.StatusUnauthorized, "INVALID_TOKEN", details)
+	r.detailedError(w, http.StatusUnauthorized, "INVALID_TOKEN", details)
 }
 
 func (r *ErrorResponder) InvalidAuthHeader(w http.ResponseWriter, details []Detail) {
-	r.DetailedError(w, http.StatusUnauthorized, "INVALID_AUTH_HEADER", details)
+	r.detailedError(w, http.StatusUnauthorized, "INVALID_AUTH_HEADER", details)
 }
 
 type Error struct {
@@ -103,7 +99,7 @@ type Detail struct {
 	Issues []string `json:"issues" example:"must be a valid email,too short"`
 }
 
-func (r *ErrorResponder) NewError(code, message string) *Error {
+func (r *ErrorResponder) newError(code, message string) *Error {
 	return &Error{
 		Code:      code,
 		Message:   message,
@@ -111,17 +107,17 @@ func (r *ErrorResponder) NewError(code, message string) *Error {
 	}
 }
 
-func (r *ErrorResponder) NewDetailedError(code string, details []Detail) *DetailedError {
+func (r *ErrorResponder) newDetailedError(code string, details []Detail) *DetailedError {
 	return &DetailedError{
-		Error:   *r.NewError(code, MapCodeToDescription(code)),
+		Error:   *r.newError(code, mapCodeToDescription(code)),
 		Details: details,
 	}
 }
 
-func (r *ErrorResponder) Error(w http.ResponseWriter, statusCode int, code string) {
-	RespondJSON(w, r.logger, statusCode, r.NewError(code, MapCodeToDescription(code)))
+func (r *ErrorResponder) error(w http.ResponseWriter, statusCode int, code string) {
+	RespondJSON(w, r.logger, statusCode, r.newError(code, mapCodeToDescription(code)))
 }
 
-func (r *ErrorResponder) DetailedError(w http.ResponseWriter, statusCode int, code string, details []Detail) {
-	RespondJSON(w, r.logger, statusCode, r.NewDetailedError(code, details))
+func (r *ErrorResponder) detailedError(w http.ResponseWriter, statusCode int, code string, details []Detail) {
+	RespondJSON(w, r.logger, statusCode, r.newDetailedError(code, details))
 }

--- a/internal/http/httpschema/log_extractors.go
+++ b/internal/http/httpschema/log_extractors.go
@@ -8,14 +8,14 @@ import (
 	"goroutine/internal/logging"
 )
 
-func UserIDExtractor(ctx context.Context) []slog.Attr {
+func userIDExtractor(ctx context.Context) []slog.Attr {
 	if userID, ok := ctx.Value(ContextKeyUserID).(domain.UserID); ok {
 		return []slog.Attr{slog.Any("user_id", userID)}
 	}
 	return nil
 }
 
-func RequestIDExtractor(ctx context.Context) []slog.Attr {
+func requestIDExtractor(ctx context.Context) []slog.Attr {
 	if reqID, ok := ctx.Value(ContextKeyRequestID).(string); ok {
 		return []slog.Attr{slog.String("request_id", reqID)}
 	}
@@ -24,7 +24,7 @@ func RequestIDExtractor(ctx context.Context) []slog.Attr {
 
 func AllExtractors() []logging.ContextExtractor {
 	return []logging.ContextExtractor{
-		UserIDExtractor,
-		RequestIDExtractor,
+		userIDExtractor,
+		requestIDExtractor,
 	}
 }

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -11,23 +11,23 @@ import (
 	"goroutine/internal/logging"
 )
 
-type TokenVerifier interface {
+type tokenVerifier interface {
 	VerifyToken(ctx context.Context, token domain.AuthToken) (domain.UserID, error)
 }
 
-type Auth struct {
+type auth struct {
 	logger    *slog.Logger
-	verifier  TokenVerifier
+	verifier  tokenVerifier
 	responder *httpschema.ErrorResponder
 }
 
-func NewAuth(logger *slog.Logger, verifier TokenVerifier, responder *httpschema.ErrorResponder) *Auth {
+func NewAuth(logger *slog.Logger, verifier tokenVerifier, responder *httpschema.ErrorResponder) *auth {
 	moduleLogger := logging.WithModule(logger, "middleware.auth")
 
-	return &Auth{logger: moduleLogger, verifier: verifier, responder: responder}
+	return &auth{logger: moduleLogger, verifier: verifier, responder: responder}
 }
 
-func (m *Auth) Wrap(next http.Handler) http.Handler {
+func (m *auth) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		header := r.Header.Get("Authorization")
 

--- a/internal/http/middleware/cors.go
+++ b/internal/http/middleware/cors.go
@@ -10,24 +10,24 @@ import (
 // Every method used by NewRouter + OPTIONS for preflight
 const corsAllowedMethods = "DELETE, GET, OPTIONS, PATCH, POST, PUT"
 
-type CORS struct {
+type cors struct {
 	allowedOrigins map[string]struct{}
 }
 
-func NewCORS(logger *slog.Logger, allowedOrigins map[string]struct{}) *CORS {
+func NewCORS(logger *slog.Logger, allowedOrigins map[string]struct{}) *cors {
 	moduleLogger := logging.WithModule(logger, "middleware.cors")
 
 	for origin := range allowedOrigins {
 		if origin == "*" {
 			moduleLogger.Warn("CORS middleware is too permissive, allowing any origin")
-			return &CORS{allowedOrigins: allowedOrigins}
+			return &cors{allowedOrigins: allowedOrigins}
 		}
 	}
 
-	return &CORS{allowedOrigins: allowedOrigins}
+	return &cors{allowedOrigins: allowedOrigins}
 }
 
-func (m *CORS) Wrap(next http.Handler) http.Handler {
+func (m *cors) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Vary", "Origin")
 

--- a/internal/http/middleware/metrics.go
+++ b/internal/http/middleware/metrics.go
@@ -10,13 +10,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type Metrics struct {
+type metrics struct {
 	HttpRequests *prometheus.CounterVec
 	HttpDuration *prometheus.HistogramVec
 }
 
-func NewMetrics(reg prometheus.Registerer) *Metrics {
-	m := Metrics{
+func NewMetrics(reg prometheus.Registerer) *metrics {
+	m := metrics{
 		HttpRequests: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "http_requests_total",
@@ -38,22 +38,22 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	return &m
 }
 
-type StatusSpyWriter struct {
+type statusSpyWriter struct {
 	http.ResponseWriter
 	StatusCode int
 }
 
-func (w *StatusSpyWriter) WriteHeader(code int) {
+func (w *statusSpyWriter) WriteHeader(code int) {
 	w.StatusCode = code
 	w.ResponseWriter.WriteHeader(code)
 }
 
-func (m *Metrics) Wrap(next http.Handler) http.Handler {
+func (m *metrics) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		abstractPath := AbstractMetricPath(r.URL.Path)
 
 		startTime := time.Now()
-		spy := &StatusSpyWriter{ResponseWriter: w, StatusCode: http.StatusOK}
+		spy := &statusSpyWriter{ResponseWriter: w, StatusCode: http.StatusOK}
 
 		next.ServeHTTP(spy, r)
 

--- a/internal/http/middleware/middlewares.go
+++ b/internal/http/middleware/middlewares.go
@@ -2,14 +2,14 @@ package middleware
 
 import "net/http"
 
-type Middleware interface {
+type middleware interface {
 	Wrap(next http.Handler) http.Handler
 }
 
 type Middlewares struct {
-	Metrics   Middleware
-	CORS      Middleware
-	Auth      Middleware
-	RequestID Middleware
-	Timeout   Middleware
+	Metrics   middleware
+	CORS      middleware
+	Auth      middleware
+	RequestID middleware
+	Timeout   middleware
 }

--- a/internal/http/middleware/requestid.go
+++ b/internal/http/middleware/requestid.go
@@ -10,24 +10,24 @@ import (
 	"goroutine/internal/logging"
 )
 
-type GenerateRequestIDFn func() string
+type generateRequestIDFn func() string
 
-type RequestID struct {
+type requestID struct {
 	logger *slog.Logger
-	gen    GenerateRequestIDFn
+	gen    generateRequestIDFn
 }
 
-func MustNewRequestID(logger *slog.Logger, gen GenerateRequestIDFn) *RequestID {
+func MustNewRequestID(logger *slog.Logger, gen generateRequestIDFn) *requestID {
 	if gen == nil {
 		panic("BUG: gen is nil")
 	}
 
 	moduleLogger := logging.WithModule(logger, "middleware.requestid")
 
-	return &RequestID{logger: moduleLogger, gen: gen}
+	return &requestID{logger: moduleLogger, gen: gen}
 }
 
-func (m *RequestID) Wrap(next http.Handler) http.Handler {
+func (m *requestID) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqID := strings.TrimSpace(r.Header.Get("X-Request-Id"))
 		if reqID == "" {

--- a/internal/http/middleware/timeout.go
+++ b/internal/http/middleware/timeout.go
@@ -6,16 +6,16 @@ import (
 	"time"
 )
 
-type Timeout struct {
+type timeout struct {
 	Duration time.Duration
 }
 
-func NewTimeout(d time.Duration) *Timeout {
-	return &Timeout{Duration: d}
+func NewTimeout(d time.Duration) *timeout {
+	return &timeout{Duration: d}
 }
 
 // Prevents unexpected resource leaks by forcing context cancellation after specified duration
-func (m *Timeout) Wrap(next http.Handler) http.Handler {
+func (m *timeout) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), m.Duration)
 		defer cancel()

--- a/internal/http/route.go
+++ b/internal/http/route.go
@@ -45,7 +45,7 @@ func NewRouter(handlers *handler.Handlers, middlewares *middleware.Middlewares) 
 	mux.Handle("PUT /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}/position", protected(handlers.Tasks.Move))
 	mux.Handle("DELETE /v1/boards/{boardId}/columns/{columnId}/tasks/{taskId}", protected(handlers.Tasks.Delete))
 	mux.Handle("POST /webhook/telegram", public(handlers.Telegram.Webhook))
-	mux.Handle("GET "+swaggerBasePath, NewSwaggerHandler(swaggerBasePath, loginPath))
+	mux.Handle("GET "+swaggerBasePath, newSwaggerHandler(swaggerBasePath, loginPath))
 
 	return middlewares.Timeout.Wrap(middlewares.RequestID.Wrap(middlewares.CORS.Wrap(mux)))
 }

--- a/internal/http/swagger.go
+++ b/internal/http/swagger.go
@@ -6,7 +6,7 @@ import (
 	httpSwagger "github.com/swaggo/http-swagger/v2"
 )
 
-func SwaggerAutoAuthOnLoginScript(loginPath string) string {
+func swaggerAutoAuthOnLoginScript(loginPath string) string {
 	return `
 		function(response) {
 			try {
@@ -30,12 +30,12 @@ func SwaggerAutoAuthOnLoginScript(loginPath string) string {
 	`
 }
 
-func NewSwaggerHandler(basePath, loginPath string) http.Handler {
+func newSwaggerHandler(basePath, loginPath string) http.Handler {
 	return httpSwagger.Handler(
 		httpSwagger.URL(basePath+"doc.json"),
 		httpSwagger.PersistAuthorization(true), // Doesn't work with auto-authorize at /login
 		httpSwagger.UIConfig(map[string]string{
-			"responseInterceptor": SwaggerAutoAuthOnLoginScript(loginPath),
+			"responseInterceptor": swaggerAutoAuthOnLoginScript(loginPath),
 		}),
 	)
 }

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -10,17 +10,17 @@ import (
 
 type ContextExtractor func(ctx context.Context) []slog.Attr
 
-type ContextHandler struct {
+type contextHandler struct {
 	Base       slog.Handler
 	extractors []ContextExtractor
 }
 
-func (h *ContextHandler) Enabled(ctx context.Context, level slog.Level) bool {
+func (h *contextHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	return h.Base.Enabled(ctx, level)
 }
 
 //nolint:gocritic // r must be passed by value to implement slog.Handler
-func (h *ContextHandler) Handle(ctx context.Context, r slog.Record) error {
+func (h *contextHandler) Handle(ctx context.Context, r slog.Record) error {
 	for _, extractor := range h.extractors {
 		if attrs := extractor(ctx); len(attrs) > 0 {
 			r.AddAttrs(attrs...)
@@ -29,15 +29,15 @@ func (h *ContextHandler) Handle(ctx context.Context, r slog.Record) error {
 	return h.Base.Handle(ctx, r)
 }
 
-func (h *ContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &ContextHandler{
+func (h *contextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &contextHandler{
 		Base:       h.Base.WithAttrs(attrs),
 		extractors: h.extractors,
 	}
 }
 
-func (h *ContextHandler) WithGroup(name string) slog.Handler {
-	return &ContextHandler{
+func (h *contextHandler) WithGroup(name string) slog.Handler {
+	return &contextHandler{
 		Base:       h.Base.WithGroup(name),
 		extractors: h.extractors,
 	}
@@ -54,7 +54,7 @@ func NewLogger(env, levelStr string, extractors ...ContextExtractor) *slog.Logge
 	}
 
 	if len(extractors) > 0 {
-		handler = &ContextHandler{
+		handler = &contextHandler{
 			Base:       handler,
 			extractors: extractors,
 		}

--- a/internal/repository/board.go
+++ b/internal/repository/board.go
@@ -132,19 +132,19 @@ func ScanBoard(row interface{ Scan(...any) error }) (domain.Board, error) {
 	}
 	name, err := domain.NewBoardName(rawName)
 	if err != nil {
-		return domain.Board{}, fmt.Errorf("scan board: name: %v: %w", err, ErrDataCorrupted)
+		return domain.Board{}, fmt.Errorf("scan board: name: %v: %w", err, errDataCorrupted)
 	}
 	desc, err := domain.NewBoardDescription(rawDesc)
 	if err != nil {
-		return domain.Board{}, fmt.Errorf("scan board: description: %v: %w", err, ErrDataCorrupted)
+		return domain.Board{}, fmt.Errorf("scan board: description: %v: %w", err, errDataCorrupted)
 	}
 	id, err := domain.NewBoardIDFromUUID(rawID)
 	if err != nil {
-		return domain.Board{}, fmt.Errorf("scan board: id: %v: %w", err, ErrDataCorrupted)
+		return domain.Board{}, fmt.Errorf("scan board: id: %v: %w", err, errDataCorrupted)
 	}
 	ownerID, err := domain.NewUserIDFromUUID(rawOwnerID)
 	if err != nil {
-		return domain.Board{}, fmt.Errorf("scan board: owner id: %v: %w", err, ErrDataCorrupted)
+		return domain.Board{}, fmt.Errorf("scan board: owner id: %v: %w", err, errDataCorrupted)
 	}
 	return domain.Board{
 		ID:          id,

--- a/internal/repository/column.go
+++ b/internal/repository/column.go
@@ -404,23 +404,23 @@ func ScanColumn(row interface{ Scan(...any) error }) (domain.Column, error) {
 	}
 	name, err := domain.NewColumnName(rawName)
 	if err != nil {
-		return domain.Column{}, fmt.Errorf("scan column: name: %v: %w", err, ErrDataCorrupted)
+		return domain.Column{}, fmt.Errorf("scan column: name: %v: %w", err, errDataCorrupted)
 	}
 	desc, err := domain.NewColumnDescription(rawDesc)
 	if err != nil {
-		return domain.Column{}, fmt.Errorf("scan column: description: %v: %w", err, ErrDataCorrupted)
+		return domain.Column{}, fmt.Errorf("scan column: description: %v: %w", err, errDataCorrupted)
 	}
 	pos, err := domain.NewColumnPosition(rawPos)
 	if err != nil {
-		return domain.Column{}, fmt.Errorf("scan column: position: %v: %w", err, ErrDataCorrupted)
+		return domain.Column{}, fmt.Errorf("scan column: position: %v: %w", err, errDataCorrupted)
 	}
 	id, err := domain.NewColumnIDFromUUID(rawID)
 	if err != nil {
-		return domain.Column{}, fmt.Errorf("scan column: id: %v: %w", err, ErrDataCorrupted)
+		return domain.Column{}, fmt.Errorf("scan column: id: %v: %w", err, errDataCorrupted)
 	}
 	boardID, err := domain.NewBoardIDFromUUID(rawBoardID)
 	if err != nil {
-		return domain.Column{}, fmt.Errorf("scan column: board id: %v: %w", err, ErrDataCorrupted)
+		return domain.Column{}, fmt.Errorf("scan column: board id: %v: %w", err, errDataCorrupted)
 	}
 	return domain.Column{
 		ID:          id,

--- a/internal/repository/errors.go
+++ b/internal/repository/errors.go
@@ -6,7 +6,7 @@ var (
 	ErrRowNotFound      = errors.New("row not found")
 	ErrUniqueViolation  = errors.New("attempt to insert unique value twice")
 	ErrIndexOutOfBounds = errors.New("index out of bounds")
-	ErrDataCorrupted    = errors.New("invalid data appeared in the database")
+	errDataCorrupted    = errors.New("invalid data appeared in the database")
 
 	ErrKeyExists   = errors.New("key already exists")
 	ErrKeyNotFound = errors.New("key not found")

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -545,23 +545,23 @@ func ScanTask(row interface{ Scan(...any) error }) (domain.Task, error) {
 	}
 	name, err := domain.NewTaskName(rawName)
 	if err != nil {
-		return domain.Task{}, fmt.Errorf("scan task: name: %v: %w", err, ErrDataCorrupted)
+		return domain.Task{}, fmt.Errorf("scan task: name: %v: %w", err, errDataCorrupted)
 	}
 	desc, err := domain.NewTaskDescription(rawDesc)
 	if err != nil {
-		return domain.Task{}, fmt.Errorf("scan task: description: %v: %w", err, ErrDataCorrupted)
+		return domain.Task{}, fmt.Errorf("scan task: description: %v: %w", err, errDataCorrupted)
 	}
 	pos, err := domain.NewTaskPosition(rawPos)
 	if err != nil {
-		return domain.Task{}, fmt.Errorf("scan task: position: %v: %w", err, ErrDataCorrupted)
+		return domain.Task{}, fmt.Errorf("scan task: position: %v: %w", err, errDataCorrupted)
 	}
 	id, err := domain.NewTaskIDFromUUID(rawID)
 	if err != nil {
-		return domain.Task{}, fmt.Errorf("scan task: id: %v: %w", err, ErrDataCorrupted)
+		return domain.Task{}, fmt.Errorf("scan task: id: %v: %w", err, errDataCorrupted)
 	}
 	columnID, err := domain.NewColumnIDFromUUID(rawColumnID)
 	if err != nil {
-		return domain.Task{}, fmt.Errorf("scan task: column id: %v: %w", err, ErrDataCorrupted)
+		return domain.Task{}, fmt.Errorf("scan task: column id: %v: %w", err, errDataCorrupted)
 	}
 	return domain.Task{
 		ID:          id,

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -86,14 +86,14 @@ func ScanUser(row interface{ Scan(...any) error }) (domain.User, error) {
 
 	email, err := domain.NewEmail(rawEmail)
 	if err != nil {
-		return domain.User{}, fmt.Errorf("scan user: email: %v: %w", err, ErrDataCorrupted)
+		return domain.User{}, fmt.Errorf("scan user: email: %v: %w", err, errDataCorrupted)
 	}
 
 	var chatID domain.TelegramChatID
 	if rawTelegramChatID != nil {
 		chatID, err = domain.NewTelegramChatID(*rawTelegramChatID)
 		if err != nil {
-			return domain.User{}, fmt.Errorf("scan user: telegram chat id: %v: %w", err, ErrDataCorrupted)
+			return domain.User{}, fmt.Errorf("scan user: telegram chat id: %v: %w", err, errDataCorrupted)
 		}
 	}
 
@@ -101,14 +101,14 @@ func ScanUser(row interface{ Scan(...any) error }) (domain.User, error) {
 	if rawTelegramUsername != nil {
 		username, err = domain.NewTelegramUsername(*rawTelegramUsername)
 		if err != nil {
-			return domain.User{}, fmt.Errorf("scan user: telegram username: %v: %w", err, ErrDataCorrupted)
+			return domain.User{}, fmt.Errorf("scan user: telegram username: %v: %w", err, errDataCorrupted)
 		}
 	}
 
 	var id domain.UserID
 	id, err = domain.NewUserIDFromUUID(rawID)
 	if err != nil {
-		return domain.User{}, fmt.Errorf("scan user: id: %v: %w", err, ErrDataCorrupted)
+		return domain.User{}, fmt.Errorf("scan user: id: %v: %w", err, errDataCorrupted)
 	}
 
 	return domain.User{

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -16,7 +16,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-type AuthUserRepository interface {
+type authUserRepository interface {
 	Create(ctx context.Context, email domain.Email, hash domain.PasswordHash) error
 	GetByEmail(ctx context.Context, email domain.Email) (domain.User, error)
 }
@@ -27,19 +27,19 @@ type JWTOptions struct {
 	SigningMethod jwt.SigningMethod
 }
 
-type Auth struct {
-	userRepo   AuthUserRepository
+type auth struct {
+	userRepo   authUserRepository
 	jwtOptions JWTOptions
 }
 
-func NewAuth(userRepo AuthUserRepository, opts JWTOptions) *Auth {
-	return &Auth{
+func NewAuth(userRepo authUserRepository, opts JWTOptions) *auth {
+	return &auth{
 		userRepo:   userRepo,
 		jwtOptions: opts,
 	}
 }
 
-func (s *Auth) Register(ctx context.Context, email domain.Email, password domain.UserPassword) error {
+func (s *auth) Register(ctx context.Context, email domain.Email, password domain.UserPassword) error {
 	hash, err := argon2id.CreateHash(password.RevealSecret(), argon2id.DefaultParams)
 	if err != nil {
 		return fmt.Errorf("auth service: register: hash password: %v: %w", err, ErrInternal)
@@ -56,7 +56,7 @@ func (s *Auth) Register(ctx context.Context, email domain.Email, password domain
 	return nil
 }
 
-func (s *Auth) Login(ctx context.Context, email domain.Email, password domain.UserPassword) (domain.AuthToken, error) {
+func (s *auth) Login(ctx context.Context, email domain.Email, password domain.UserPassword) (domain.AuthToken, error) {
 	user, err := s.userRepo.GetByEmail(ctx, email)
 	if errors.Is(err, repository.ErrRowNotFound) {
 		return domain.AuthToken{}, fmt.Errorf("auth service: login: hash by email: %w", ErrUserNotFound)
@@ -80,7 +80,7 @@ func (s *Auth) Login(ctx context.Context, email domain.Email, password domain.Us
 	return token, nil
 }
 
-func (s *Auth) CreateToken(userID domain.UserID, exp time.Duration) (domain.AuthToken, error) {
+func (s *auth) CreateToken(userID domain.UserID, exp time.Duration) (domain.AuthToken, error) {
 	claims := jwt.MapClaims{
 		"sub": userID.String(),
 		"exp": time.Now().Add(exp).Unix(),
@@ -102,7 +102,7 @@ func (s *Auth) CreateToken(userID domain.UserID, exp time.Duration) (domain.Auth
 	return jwtToken, nil
 }
 
-func (s *Auth) VerifyToken(ctx context.Context, token domain.AuthToken) (domain.UserID, error) {
+func (s *auth) VerifyToken(ctx context.Context, token domain.AuthToken) (domain.UserID, error) {
 	tokenString := token.RevealSecret()
 	parsedToken, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 		if token.Method.Alg() != s.jwtOptions.SigningMethod.Alg() {

--- a/internal/service/board.go
+++ b/internal/service/board.go
@@ -10,7 +10,7 @@ import (
 	"goroutine/internal/repository"
 )
 
-type BoardRepository interface {
+type boardRepository interface {
 	Create(ctx context.Context, ownerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error)
 	Get(ctx context.Context, boardID domain.BoardID) (domain.Board, error)
 	ListByOwnerID(ctx context.Context, ownerID domain.UserID) ([]domain.Board, error)
@@ -18,22 +18,22 @@ type BoardRepository interface {
 	Delete(ctx context.Context, boardID domain.BoardID) error
 }
 
-type BoardColumnRepository interface {
+type boardColumnRepository interface {
 	ListByBoardID(ctx context.Context, boardID domain.BoardID) ([]domain.Column, error)
 }
 
-type BoardTaskRepository interface {
+type boardTaskRepository interface {
 	ListByBoardID(ctx context.Context, boardID domain.BoardID) ([]domain.Task, error)
 }
 
-type Board struct {
-	boardRepo  BoardRepository
-	columnRepo BoardColumnRepository
-	taskRepo   BoardTaskRepository
+type board struct {
+	boardRepo  boardRepository
+	columnRepo boardColumnRepository
+	taskRepo   boardTaskRepository
 }
 
-func NewBoard(boardRepo BoardRepository, columnRepo BoardColumnRepository, taskRepo BoardTaskRepository) *Board {
-	return &Board{boardRepo: boardRepo, columnRepo: columnRepo, taskRepo: taskRepo}
+func NewBoard(boardRepo boardRepository, columnRepo boardColumnRepository, taskRepo boardTaskRepository) *board {
+	return &board{boardRepo: boardRepo, columnRepo: columnRepo, taskRepo: taskRepo}
 }
 
 type AggregateBoard struct {
@@ -46,7 +46,7 @@ type AggregateColumn struct {
 	Tasks  []domain.Task
 }
 
-func (s *Board) Create(ctx context.Context, callerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
+func (s *board) Create(ctx context.Context, callerID domain.UserID, name domain.BoardName, description domain.BoardDescription) (domain.Board, error) {
 	board, err := s.boardRepo.Create(ctx, callerID, name, description)
 	if err != nil {
 		return domain.Board{}, fmt.Errorf("board service: create: %v: %w", err, ErrInternal)
@@ -55,7 +55,7 @@ func (s *Board) Create(ctx context.Context, callerID domain.UserID, name domain.
 	return board, nil
 }
 
-func (s *Board) ListByOwnerID(ctx context.Context, callerID domain.UserID) ([]domain.Board, error) {
+func (s *board) ListByOwnerID(ctx context.Context, callerID domain.UserID) ([]domain.Board, error) {
 	boards, err := s.boardRepo.ListByOwnerID(ctx, callerID)
 	if err != nil {
 		return nil, fmt.Errorf("board service: list by owner id: %v: %w", err, ErrInternal)
@@ -64,7 +64,7 @@ func (s *Board) ListByOwnerID(ctx context.Context, callerID domain.UserID) ([]do
 	return boards, nil
 }
 
-func (s *Board) Get(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
+func (s *board) Get(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) (domain.Board, error) {
 	board, err := s.boardRepo.Get(ctx, boardID)
 	if err != nil {
 		if errors.Is(err, repository.ErrRowNotFound) {
@@ -79,7 +79,7 @@ func (s *Board) Get(ctx context.Context, callerID domain.UserID, boardID domain.
 	return board, nil
 }
 
-func (s *Board) GetAggregate(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) (AggregateBoard, error) {
+func (s *board) GetAggregate(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) (AggregateBoard, error) {
 	board, err := s.boardRepo.Get(ctx, boardID)
 	if err != nil {
 		if errors.Is(err, repository.ErrRowNotFound) {
@@ -134,7 +134,7 @@ func (s *Board) GetAggregate(ctx context.Context, callerID domain.UserID, boardI
 	return aggregate, nil
 }
 
-func (s *Board) Update(
+func (s *board) Update(
 	ctx context.Context,
 	callerID domain.UserID,
 	boardID domain.BoardID,
@@ -167,7 +167,7 @@ func (s *Board) Update(
 	return updated, nil
 }
 
-func (s *Board) Delete(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) error {
+func (s *board) Delete(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) error {
 	board, err := s.boardRepo.Get(ctx, boardID)
 	if err != nil {
 		if errors.Is(err, repository.ErrRowNotFound) {

--- a/internal/service/column.go
+++ b/internal/service/column.go
@@ -9,7 +9,7 @@ import (
 	"goroutine/internal/repository"
 )
 
-type ColumnRepository interface {
+type columnRepository interface {
 	Create(ctx context.Context, boardID domain.BoardID, name domain.ColumnName, description domain.ColumnDescription) (domain.Column, error)
 	ListByBoardID(ctx context.Context, boardID domain.BoardID) ([]domain.Column, error)
 	Get(ctx context.Context, columnID domain.ColumnID) (domain.Column, error)
@@ -18,20 +18,20 @@ type ColumnRepository interface {
 	Delete(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID) error
 }
 
-type ColumnBoardRepository interface {
+type columnBoardRepository interface {
 	Get(ctx context.Context, boardID domain.BoardID) (domain.Board, error)
 }
 
-type Column struct {
-	columnRepo ColumnRepository
-	boardRepo  ColumnBoardRepository
+type column struct {
+	columnRepo columnRepository
+	boardRepo  columnBoardRepository
 }
 
-func NewColumn(columnRepo ColumnRepository, boardRepo ColumnBoardRepository) *Column {
-	return &Column{columnRepo: columnRepo, boardRepo: boardRepo}
+func NewColumn(columnRepo columnRepository, boardRepo columnBoardRepository) *column {
+	return &column{columnRepo: columnRepo, boardRepo: boardRepo}
 }
 
-func (s *Column) Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName, description domain.ColumnDescription) (domain.Column, error) {
+func (s *column) Create(ctx context.Context, callerID domain.UserID, boardID domain.BoardID, name domain.ColumnName, description domain.ColumnDescription) (domain.Column, error) {
 	board, err := s.boardRepo.Get(ctx, boardID)
 	if err != nil {
 		if errors.Is(err, repository.ErrRowNotFound) {
@@ -51,7 +51,7 @@ func (s *Column) Create(ctx context.Context, callerID domain.UserID, boardID dom
 	return column, nil
 }
 
-func (s *Column) ListByBoardID(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error) {
+func (s *column) ListByBoardID(ctx context.Context, callerID domain.UserID, boardID domain.BoardID) ([]domain.Column, error) {
 	board, err := s.boardRepo.Get(ctx, boardID)
 	if err != nil {
 		if errors.Is(err, repository.ErrRowNotFound) {
@@ -72,7 +72,7 @@ func (s *Column) ListByBoardID(ctx context.Context, callerID domain.UserID, boar
 	return columns, nil
 }
 
-func (s *Column) Update(
+func (s *column) Update(
 	ctx context.Context,
 	callerID domain.UserID,
 	boardID domain.BoardID,
@@ -117,7 +117,7 @@ func (s *Column) Update(
 	return updated, nil
 }
 
-func (s *Column) Delete(
+func (s *column) Delete(
 	ctx context.Context,
 	callerID domain.UserID,
 	boardID domain.BoardID,
@@ -145,7 +145,7 @@ func (s *Column) Delete(
 	return nil
 }
 
-func (s *Column) Move(
+func (s *column) Move(
 	ctx context.Context,
 	callerID domain.UserID,
 	boardID domain.BoardID,

--- a/internal/service/task.go
+++ b/internal/service/task.go
@@ -9,7 +9,7 @@ import (
 	"goroutine/internal/repository"
 )
 
-type TaskRepository interface {
+type taskRepository interface {
 	Create(ctx context.Context, columnID domain.ColumnID, name domain.TaskName, description domain.TaskDescription) (domain.Task, error)
 	ListByColumnID(ctx context.Context, columnID domain.ColumnID) ([]domain.Task, error)
 	Get(ctx context.Context, taskID domain.TaskID) (domain.Task, error)
@@ -18,29 +18,29 @@ type TaskRepository interface {
 	Delete(ctx context.Context, boardID domain.BoardID, columnID domain.ColumnID, taskID domain.TaskID) error
 }
 
-type TaskBoardRepository interface {
+type taskBoardRepository interface {
 	Get(ctx context.Context, boardID domain.BoardID) (domain.Board, error)
 }
 
-type TaskColumnRepository interface {
+type taskColumnRepository interface {
 	Get(ctx context.Context, columnID domain.ColumnID) (domain.Column, error)
 }
 
-type Task struct {
-	taskRepo   TaskRepository
-	boardRepo  TaskBoardRepository
-	columnRepo TaskColumnRepository
+type task struct {
+	taskRepo   taskRepository
+	boardRepo  taskBoardRepository
+	columnRepo taskColumnRepository
 }
 
-func NewTask(taskRepo TaskRepository, boardRepo TaskBoardRepository, columnRepo TaskColumnRepository) *Task {
-	return &Task{
+func NewTask(taskRepo taskRepository, boardRepo taskBoardRepository, columnRepo taskColumnRepository) *task {
+	return &task{
 		taskRepo:   taskRepo,
 		boardRepo:  boardRepo,
 		columnRepo: columnRepo,
 	}
 }
 
-func (s *Task) Create(
+func (s *task) Create(
 	ctx context.Context,
 	callerID domain.UserID,
 	boardID domain.BoardID,
@@ -78,7 +78,7 @@ func (s *Task) Create(
 	return task, nil
 }
 
-func (s *Task) ListByColumnID(
+func (s *task) ListByColumnID(
 	ctx context.Context,
 	callerID domain.UserID,
 	boardID domain.BoardID,
@@ -114,7 +114,7 @@ func (s *Task) ListByColumnID(
 	return tasks, nil
 }
 
-func (s *Task) Update(
+func (s *task) Update(
 	ctx context.Context,
 	callerID domain.UserID,
 	boardID domain.BoardID,
@@ -171,7 +171,7 @@ func (s *Task) Update(
 	return updated, nil
 }
 
-func (s *Task) Delete(
+func (s *task) Delete(
 	ctx context.Context,
 	callerID domain.UserID,
 	boardID domain.BoardID,
@@ -222,7 +222,7 @@ func (s *Task) Delete(
 	return nil
 }
 
-func (s *Task) Move(
+func (s *task) Move(
 	ctx context.Context,
 	callerID domain.UserID,
 	boardID domain.BoardID,

--- a/internal/service/time.go
+++ b/internal/service/time.go
@@ -2,20 +2,16 @@ package service
 
 import "time"
 
-const RFC3339MillisLayout = "2006-01-02T15:04:05.000Z07:00"
-
-type TimeStrFunc func() string
+const rfc3339MillisLayout = "2006-01-02T15:04:05.000Z07:00"
 
 func FormatRFC3339Millis(t time.Time) string {
-	return t.UTC().Format(RFC3339MillisLayout)
+	return t.UTC().Format(rfc3339MillisLayout)
 }
 
 func TimeNowRFC3339Millis() string {
-	return FormatRFC3339Millis(TimeNow())
+	return FormatRFC3339Millis(timeNow())
 }
 
-type TimeFunc func() time.Time
-
-func TimeNow() time.Time {
+func timeNow() time.Time {
 	return time.Now().UTC()
 }

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -9,30 +9,30 @@ import (
 	"goroutine/internal/repository"
 )
 
-type UserRepository interface {
+type userRepository interface {
 	UpdateTelegramInfo(ctx context.Context, userID domain.UserID, chatID domain.TelegramChatID, username domain.TelegramUsername) error
 }
 
-type TelegramTokenRepository interface {
+type telegramTokenRepository interface {
 	InsertLinkToken(ctx context.Context, token domain.TelegramLinkToken, userID domain.UserID) error
 	ConsumeTelegramLinkToken(ctx context.Context, token domain.TelegramLinkToken) (domain.UserID, error)
 }
 
-type User struct {
-	userRepo            UserRepository
-	tokenRepo           TelegramTokenRepository
+type user struct {
+	userRepo            userRepository
+	tokenRepo           telegramTokenRepository
 	telegramLinkTokenFn func() domain.TelegramLinkToken
 }
 
-func NewUser(userRepo UserRepository, tokenRepo TelegramTokenRepository, telegramLinkTokenFn func() domain.TelegramLinkToken) *User {
-	return &User{
+func NewUser(userRepo userRepository, tokenRepo telegramTokenRepository, telegramLinkTokenFn func() domain.TelegramLinkToken) *user {
+	return &user{
 		userRepo:            userRepo,
 		tokenRepo:           tokenRepo,
 		telegramLinkTokenFn: telegramLinkTokenFn,
 	}
 }
 
-func (s *User) CreateTelegramLinkToken(ctx context.Context, userID domain.UserID) (domain.TelegramLinkToken, error) {
+func (s *user) CreateTelegramLinkToken(ctx context.Context, userID domain.UserID) (domain.TelegramLinkToken, error) {
 	token := s.telegramLinkTokenFn()
 
 	err := s.tokenRepo.InsertLinkToken(ctx, token, userID)
@@ -46,7 +46,7 @@ func (s *User) CreateTelegramLinkToken(ctx context.Context, userID domain.UserID
 	return token, nil
 }
 
-func (s *User) LinkTelegramByToken(ctx context.Context, token domain.TelegramLinkToken, chatID domain.TelegramChatID, username domain.TelegramUsername) error {
+func (s *user) LinkTelegramByToken(ctx context.Context, token domain.TelegramLinkToken, chatID domain.TelegramChatID, username domain.TelegramUsername) error {
 	userID, err := s.tokenRepo.ConsumeTelegramLinkToken(ctx, token)
 	if err != nil {
 		if errors.Is(err, repository.ErrKeyNotFound) {

--- a/internal/testutil/cmp.go
+++ b/internal/testutil/cmp.go
@@ -12,13 +12,13 @@ import (
 	"goroutine/internal/domain"
 )
 
-type SecretValue interface {
+type secretValue interface {
 	fmt.Stringer
 	LogValue() slog.Value
 	MarshalJSON() ([]byte, error)
 }
 
-func AssertSecretHidden(t *testing.T, raw string, secret SecretValue) {
+func AssertSecretHidden(t *testing.T, raw string, secret secretValue) {
 	t.Helper()
 
 	rawLower := strings.ToLower(raw)

--- a/internal/testutil/data.go
+++ b/internal/testutil/data.go
@@ -15,7 +15,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-func MustLoadDevEnv() {
+func mustLoadDevEnv() {
 	err := godotenv.Load("../../.env.dev")
 	if err == nil {
 		return
@@ -32,13 +32,9 @@ func Fixed5mFromNow() time.Time { return FixedNow().Add(5 * time.Minute) }
 
 const TimeFormat = "2006-01-02T15:04:05.000Z07:00"
 
-func Fixed5mFromNowStr() string {
-	return Fixed5mFromNow().UTC().Format(TimeFormat)
-}
-
 func FixedNowStr() string { return FixedNow().UTC().Format(TimeFormat) }
 
-func Must[A any, T any](fn func(A) (T, error), arg A) T {
+func must[A any, T any](fn func(A) (T, error), arg A) T {
 	v, err := fn(arg)
 	if err != nil {
 		panic(err)
@@ -50,12 +46,12 @@ const validUUIDv7 = "018e1000-0000-7000-8000-000000000000"
 
 func NewValidColumnPosition(t *testing.T, n int64) domain.ColumnPosition {
 	t.Helper()
-	return Must(domain.NewColumnPosition, n)
+	return must(domain.NewColumnPosition, n)
 }
 
 func NewValidTaskPosition(t *testing.T, n int64) domain.TaskPosition {
 	t.Helper()
-	return Must(domain.NewTaskPosition, n)
+	return must(domain.NewTaskPosition, n)
 }
 
 func NewValidColumn(t *testing.T, boardID domain.BoardID, name string, position int64) domain.Column {
@@ -63,8 +59,8 @@ func NewValidColumn(t *testing.T, boardID domain.BoardID, name string, position 
 
 	column := ValidColumn(boardID)
 
-	domainName := Must(domain.NewColumnName, name)
-	domainPosition := Must(domain.NewColumnPosition, position)
+	domainName := must(domain.NewColumnName, name)
+	domainPosition := must(domain.NewColumnPosition, position)
 
 	column.Name = domainName
 	column.Position = domainPosition
@@ -77,9 +73,9 @@ func NewValidTask(t *testing.T, columnID domain.ColumnID, name, description stri
 
 	task := ValidTask(columnID)
 
-	domainName := Must(domain.NewTaskName, name)
-	domainDescription := Must(domain.NewTaskDescription, description)
-	domainPosition := Must(domain.NewTaskPosition, position)
+	domainName := must(domain.NewTaskName, name)
+	domainDescription := must(domain.NewTaskDescription, description)
+	domainPosition := must(domain.NewTaskPosition, position)
 
 	task.Name = domainName
 	task.Description = domainDescription
@@ -93,15 +89,15 @@ func Valid25KBJSON() json.RawMessage {
 }
 
 func ValidUserID() domain.UserID {
-	return Must(domain.ParseUserID, validUUIDv7)
+	return must(domain.ParseUserID, validUUIDv7)
 }
 
 func ValidEmail() domain.Email {
-	return Must(domain.NewEmail, "test@example.com")
+	return must(domain.NewEmail, "test@example.com")
 }
 
 func ValidPassword() domain.UserPassword {
-	return Must(domain.NewUserPassword, "qwerty")
+	return must(domain.NewUserPassword, "qwerty")
 }
 
 func ValidPasswordHash() domain.PasswordHash {
@@ -113,35 +109,35 @@ func AnotherValidPasswordHash() domain.PasswordHash {
 }
 
 func ValidBoardName() domain.BoardName {
-	return Must(domain.NewBoardName, "Test Board")
+	return must(domain.NewBoardName, "Test Board")
 }
 
 func ValidBoardDescription() domain.BoardDescription {
-	return Must(domain.NewBoardDescription, "Test Board Description")
+	return must(domain.NewBoardDescription, "Test Board Description")
 }
 
-func ValidColumnName() domain.ColumnName {
-	return Must(domain.NewColumnName, "To Do")
+func validColumnName() domain.ColumnName {
+	return must(domain.NewColumnName, "To Do")
 }
 
-func ValidColumnPosition() domain.ColumnPosition {
-	return Must(domain.NewColumnPosition, 1)
+func validColumnPosition() domain.ColumnPosition {
+	return must(domain.NewColumnPosition, 1)
 }
 
 func ValidColumnDescription() domain.ColumnDescription {
-	return Must(domain.NewColumnDescription, "Test Column Description")
+	return must(domain.NewColumnDescription, "Test Column Description")
 }
 
-func ValidTaskName() domain.TaskName {
-	return Must(domain.NewTaskName, "Write tests")
+func validTaskName() domain.TaskName {
+	return must(domain.NewTaskName, "Write tests")
 }
 
-func ValidTaskDescription() domain.TaskDescription {
-	return Must(domain.NewTaskDescription, "Cover the new endpoint with tests")
+func validTaskDescription() domain.TaskDescription {
+	return must(domain.NewTaskDescription, "Cover the new endpoint with tests")
 }
 
-func ValidTaskPosition() domain.TaskPosition {
-	return Must(domain.NewTaskPosition, 1)
+func validTaskPosition() domain.TaskPosition {
+	return must(domain.NewTaskPosition, 1)
 }
 
 func ValidJWTSecret() secrecy.SecretString {
@@ -176,9 +172,9 @@ func ValidBoard() domain.Board {
 }
 
 func ValidColumn(boardID domain.BoardID) domain.Column {
-	name := ValidColumnName()
+	name := validColumnName()
 	description := ValidColumnDescription()
-	position := ValidColumnPosition()
+	position := validColumnPosition()
 	pseudoNow := FixedNow()
 
 	return domain.Column{
@@ -193,9 +189,9 @@ func ValidColumn(boardID domain.BoardID) domain.Column {
 }
 
 func ValidTask(columnID domain.ColumnID) domain.Task {
-	name := ValidTaskName()
-	description := ValidTaskDescription()
-	position := ValidTaskPosition()
+	name := validTaskName()
+	description := validTaskDescription()
+	position := validTaskPosition()
 	pseudoNow := FixedNow()
 
 	return domain.Task{
@@ -210,34 +206,34 @@ func ValidTask(columnID domain.ColumnID) domain.Task {
 }
 
 func ValidTelegramToken() domain.TelegramToken {
-	return Must(domain.NewTelegramToken, "8927121804:MOCKhk1QdJpRJdISscC0COr19kH79_4f9vw")
+	return must(domain.NewTelegramToken, "8927121804:MOCKhk1QdJpRJdISscC0COr19kH79_4f9vw")
 }
 
 func AnotherValidTelegramToken() domain.TelegramToken {
-	return Must(domain.NewTelegramToken, "8927121804:MOCKtw0QdJpRJdISscC0COr19kH79_4f9vw")
+	return must(domain.NewTelegramToken, "8927121804:MOCKtw0QdJpRJdISscC0COr19kH79_4f9vw")
 }
 
 func ValidTelegramLinkToken() domain.TelegramLinkToken {
-	return Must(domain.NewTelegramLinkToken, validUUIDv7)
+	return must(domain.NewTelegramLinkToken, validUUIDv7)
 }
 
 func ValidTelegramChatID() domain.TelegramChatID {
-	return Must(domain.NewTelegramChatID, int64(123456789))
+	return must(domain.NewTelegramChatID, int64(123456789))
 }
 
 func ValidTelegramUsername() domain.TelegramUsername {
-	return Must(domain.NewTelegramUsername, "@testuser")
+	return must(domain.NewTelegramUsername, "@testuser")
 }
 
 func ValidTelegramMessage() domain.TelegramMessage {
-	return Must(domain.NewTelegramMessage, "Hello, world!")
+	return must(domain.NewTelegramMessage, "Hello, world!")
 }
 
 func UpdateValidColumn(t *testing.T, base *domain.Column, name, description string, updatedAt time.Time) domain.Column {
 	t.Helper()
 
-	domainName := Must(domain.NewColumnName, name)
-	domainDescription := Must(domain.NewColumnDescription, description)
+	domainName := must(domain.NewColumnName, name)
+	domainDescription := must(domain.NewColumnDescription, description)
 
 	return domain.Column{
 		ID:          base.ID,
@@ -252,8 +248,8 @@ func UpdateValidColumn(t *testing.T, base *domain.Column, name, description stri
 
 func UpdateValidBoard(t *testing.T, base *domain.Board, name, description string, updatedAt time.Time) domain.Board {
 	t.Helper()
-	domainName := Must(domain.NewBoardName, name)
-	domainDescription := Must(domain.NewBoardDescription, description)
+	domainName := must(domain.NewBoardName, name)
+	domainDescription := must(domain.NewBoardDescription, description)
 
 	return domain.Board{
 		ID:          base.ID,
@@ -268,8 +264,8 @@ func UpdateValidBoard(t *testing.T, base *domain.Board, name, description string
 func UpdateValidTask(t *testing.T, base *domain.Task, name, description string, updatedAt time.Time) domain.Task {
 	t.Helper()
 
-	domainName := Must(domain.NewTaskName, name)
-	domainDescription := Must(domain.NewTaskDescription, description)
+	domainName := must(domain.NewTaskName, name)
+	domainDescription := must(domain.NewTaskDescription, description)
 
 	return domain.Task{
 		ID:          base.ID,

--- a/internal/testutil/http.go
+++ b/internal/testutil/http.go
@@ -24,17 +24,6 @@ func AssertContentType(t *testing.T, rr *httptest.ResponseRecorder, want string)
 	}
 }
 
-func MarshalJSONBody(t *testing.T, body any) string {
-	t.Helper()
-
-	b, err := json.Marshal(body)
-	if err != nil {
-		t.Fatalf("json.Marshal() error = %v", err)
-	}
-
-	return string(b)
-}
-
 func NewJSONRequestAndRecorder(t *testing.T, method, url string, body any) (*http.Request, *httptest.ResponseRecorder) {
 	t.Helper()
 

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -15,7 +15,7 @@ import (
 
 func SetupPostgres(t *testing.T, migrationsDir string) *pgxpool.Pool {
 	t.Helper()
-	MustLoadDevEnv()
+	mustLoadDevEnv()
 	logger := NewLogger(t)
 
 	pool, err := app.SetupPostgresFromEnv(logger, migrationsDir)
@@ -24,20 +24,6 @@ func SetupPostgres(t *testing.T, migrationsDir string) *pgxpool.Pool {
 	}
 
 	return pool
-}
-
-func TruncateTable(t *testing.T, pool *pgxpool.Pool, name string) {
-	t.Helper()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	query := fmt.Sprintf("TRUNCATE TABLE %s RESTART IDENTITY CASCADE", pgx.Identifier{name}.Sanitize())
-
-	_, err := pool.Exec(ctx, query)
-	if err != nil {
-		t.Fatalf("TRUNCATE TABLE %q error = %v", name, err)
-	}
 }
 
 // TruncateAllTables clears application tables in dependency order (FK-safe).

--- a/internal/testutil/redis.go
+++ b/internal/testutil/redis.go
@@ -11,7 +11,7 @@ import (
 
 func SetupRedis(t *testing.T) *redis.Client {
 	t.Helper()
-	MustLoadDevEnv()
+	mustLoadDevEnv()
 	logger := NewLogger(t)
 
 	client, err := app.SetupRedisFromEnv(logger)

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -15,11 +15,11 @@ import (
 )
 
 func TestAuth_HappyPath(t *testing.T) {
-	p := Prelude(t)
+	p := prelude(t)
 
 	testutil.TruncateAllTables(t, p.Pool)
 
-	ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
+	ac := createUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
 
 	parts := strings.Split(ac.Token, ".")
 	if len(parts) != 3 {

--- a/tests/board_test.go
+++ b/tests/board_test.go
@@ -16,7 +16,7 @@ import (
 
 const timeFormat = "2006-01-02T15:04:05.000Z07:00"
 
-type BoardJSON struct {
+type boardJSON struct {
 	ID          string `json:"id"`
 	OwnerID     string `json:"ownerId"`
 	Name        string `json:"name"`
@@ -25,23 +25,23 @@ type BoardJSON struct {
 	UpdatedAt   string `json:"updatedAt"`
 }
 
-type AggregateColumnJSON struct {
-	ColumnJSON
-	Tasks []TaskJSON `json:"tasks"`
+type aggregateColumnJSON struct {
+	columnJSON
+	Tasks []taskJSON `json:"tasks"`
 }
 
-type BoardAggregateJSON struct {
-	BoardJSON
-	Columns []AggregateColumnJSON `json:"columns"`
+type boardAggregateJSON struct {
+	boardJSON
+	Columns []aggregateColumnJSON `json:"columns"`
 }
 
 func TestBoard_HappyPath(t *testing.T) {
-	p := Prelude(t)
+	p := prelude(t)
 
 	testutil.TruncateAllTables(t, p.Pool)
 
 	// 1. Register (already done via ac client)
-	ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
+	ac := createUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
 
 	name := testutil.ValidBoardName().String()
 	description := testutil.ValidBoardDescription().String()
@@ -94,7 +94,7 @@ func TestBoard_HappyPath(t *testing.T) {
 	}
 
 	getByIDBoard := parseBoard(t, oneResp)
-	if diff := cmp.Diff(createdBoard, getByIDBoard); diff != "" {
+	if diff := cmp.Diff(createdBoard, getByIDBoard, cmp.AllowUnexported(boardJSON{})); diff != "" {
 		t.Errorf("Get by id mismatch (-want +got):\n%s", diff)
 	}
 
@@ -112,13 +112,13 @@ func TestBoard_HappyPath(t *testing.T) {
 	if len(listedBoards) != 1 {
 		t.Fatalf("got %d boards in list, want 1", len(listedBoards))
 	}
-	if diff := cmp.Diff(createdBoard, listedBoards[0]); diff != "" {
+	if diff := cmp.Diff(createdBoard, listedBoards[0], cmp.AllowUnexported(boardJSON{})); diff != "" {
 		t.Errorf("List item mismatch (-want +got):\n%s", diff)
 	}
 
 	// 5. Update by id with name only, store response in updatedNameBoard, validate fields, and ensure updatedAt advanced
 	updatedName := "Updated Name Only"
-	WaitForTimestampTicker(t)
+	waitForTimestampTicker(t)
 	updateNameResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+createdBoard.ID, map[string]string{
 		"name": updatedName,
 	})
@@ -135,7 +135,7 @@ func TestBoard_HappyPath(t *testing.T) {
 	checkBoard := updatedNameBoard
 	checkBoard.Name = createdBoard.Name
 	checkBoard.UpdatedAt = createdBoard.UpdatedAt
-	if diff := cmp.Diff(createdBoard, checkBoard); diff != "" {
+	if diff := cmp.Diff(createdBoard, checkBoard, cmp.AllowUnexported(boardJSON{})); diff != "" {
 		t.Errorf("Update() diff (-want +got):\n%s", diff)
 	}
 
@@ -161,7 +161,7 @@ func TestBoard_HappyPath(t *testing.T) {
 	}
 
 	getByIDBoardAfterUpdate := parseBoard(t, afterUpdateResp)
-	if diff := cmp.Diff(updatedNameBoard, getByIDBoardAfterUpdate); diff != "" {
+	if diff := cmp.Diff(updatedNameBoard, getByIDBoardAfterUpdate, cmp.AllowUnexported(boardJSON{})); diff != "" {
 		t.Errorf("Get by id after update mismatch (-want +got):\n%s", diff)
 	}
 
@@ -190,13 +190,13 @@ func TestBoard_HappyPath(t *testing.T) {
 	}
 	gotAgg := parseBoardAggregate(t, aggResp)
 
-	wantAgg := BoardAggregateJSON{
-		BoardJSON: getByIDBoardAfterUpdate,
-		Columns: []AggregateColumnJSON{
-			{ColumnJSON: col, Tasks: []TaskJSON{task}},
+	wantAgg := boardAggregateJSON{
+		boardJSON: getByIDBoardAfterUpdate,
+		Columns: []aggregateColumnJSON{
+			{columnJSON: col, Tasks: []taskJSON{task}},
 		},
 	}
-	if diff := cmp.Diff(wantAgg, gotAgg); diff != "" {
+	if diff := cmp.Diff(wantAgg, gotAgg, cmp.AllowUnexported(boardAggregateJSON{}, boardJSON{}, aggregateColumnJSON{}, columnJSON{}, taskJSON{})); diff != "" {
 		t.Errorf("aggregate vs POST responses (-want +got):\n%s", diff)
 	}
 
@@ -224,9 +224,9 @@ func TestBoard_HappyPath(t *testing.T) {
 	}
 }
 
-func parseBoard(t *testing.T, resp *http.Response) BoardJSON {
+func parseBoard(t *testing.T, resp *http.Response) boardJSON {
 	t.Helper()
-	var b BoardJSON
+	var b boardJSON
 	err := json.NewDecoder(resp.Body).Decode(&b)
 	if err != nil {
 		t.Fatalf("Board Decode() error = %v", err)
@@ -234,9 +234,9 @@ func parseBoard(t *testing.T, resp *http.Response) BoardJSON {
 	return b
 }
 
-func parseBoardsList(t *testing.T, resp *http.Response) []BoardJSON {
+func parseBoardsList(t *testing.T, resp *http.Response) []boardJSON {
 	t.Helper()
-	var b []BoardJSON
+	var b []boardJSON
 	err := json.NewDecoder(resp.Body).Decode(&b)
 	if err != nil {
 		t.Fatalf("Boards list Decode() error = %v", err)
@@ -244,9 +244,9 @@ func parseBoardsList(t *testing.T, resp *http.Response) []BoardJSON {
 	return b
 }
 
-func parseBoardAggregate(t *testing.T, resp *http.Response) BoardAggregateJSON {
+func parseBoardAggregate(t *testing.T, resp *http.Response) boardAggregateJSON {
 	t.Helper()
-	var b BoardAggregateJSON
+	var b boardAggregateJSON
 	err := json.NewDecoder(resp.Body).Decode(&b)
 	if err != nil {
 		t.Fatalf("Board aggregate Decode() error = %v", err)

--- a/tests/column_test.go
+++ b/tests/column_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 )
 
-type ColumnJSON struct {
+type columnJSON struct {
 	ID          string `json:"id"`
 	BoardID     string `json:"boardId"`
 	Name        string `json:"name"`
@@ -24,17 +24,17 @@ type ColumnJSON struct {
 	UpdatedAt   string `json:"updatedAt"`
 }
 
-type ColumnPositionJSON struct {
+type columnPositionJSON struct {
 	Position int64 `json:"position"`
 }
 
 func TestColumn_HappyPath(t *testing.T) {
-	p := Prelude(t)
+	p := prelude(t)
 
 	testutil.TruncateAllTables(t, p.Pool)
 
 	// 1. Register (already done via ac client)
-	ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
+	ac := createUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
 
 	boardName := testutil.ValidBoardName().String()
 	boardDescription := testutil.ValidBoardDescription().String()
@@ -111,13 +111,13 @@ func TestColumn_HappyPath(t *testing.T) {
 	if len(listedColumns) != 1 {
 		t.Fatalf("got %d columns in list, want 1", len(listedColumns))
 	}
-	if diff := cmp.Diff(createdColumn, listedColumns[0]); diff != "" {
+	if diff := cmp.Diff(createdColumn, listedColumns[0], cmp.AllowUnexported(columnJSON{})); diff != "" {
 		t.Errorf("List item mismatch (-want +got):\n%s", diff)
 	}
 
 	// 4. Update by id with name only, store response in updatedNameColumn, validate fields, and ensure updatedAt advanced
 	updatedName := "Updated Name Only"
-	WaitForTimestampTicker(t)
+	waitForTimestampTicker(t)
 	updateNameResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+board.ID+"/columns/"+createdColumn.ID, map[string]string{
 		"name": updatedName,
 	})
@@ -134,7 +134,7 @@ func TestColumn_HappyPath(t *testing.T) {
 	checkColumn := updatedNameColumn
 	checkColumn.Name = createdColumn.Name
 	checkColumn.UpdatedAt = createdColumn.UpdatedAt
-	if diff := cmp.Diff(createdColumn, checkColumn); diff != "" {
+	if diff := cmp.Diff(createdColumn, checkColumn, cmp.AllowUnexported(columnJSON{})); diff != "" {
 		t.Errorf("Update() diff (-want +got):\n%s", diff)
 	}
 
@@ -147,7 +147,7 @@ func TestColumn_HappyPath(t *testing.T) {
 	}
 
 	updatedDesc := "Updated column description body"
-	WaitForTimestampTicker(t)
+	waitForTimestampTicker(t)
 	updateDescResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+board.ID+"/columns/"+createdColumn.ID, map[string]string{
 		"description": updatedDesc,
 	})
@@ -198,7 +198,7 @@ func TestColumn_HappyPath(t *testing.T) {
 	if len(listedAfterUpdate) != 1 {
 		t.Fatalf("got %d columns after update, want 1", len(listedAfterUpdate))
 	}
-	if diff := cmp.Diff(updatedDescColumn, listedAfterUpdate[0]); diff != "" {
+	if diff := cmp.Diff(updatedDescColumn, listedAfterUpdate[0], cmp.AllowUnexported(columnJSON{})); diff != "" {
 		t.Errorf("List item after update mismatch (-want +got):\n%s", diff)
 	}
 
@@ -300,9 +300,9 @@ func TestColumn_HappyPath(t *testing.T) {
 	}
 }
 
-func parseColumn(t *testing.T, resp *http.Response) ColumnJSON {
+func parseColumn(t *testing.T, resp *http.Response) columnJSON {
 	t.Helper()
-	var c ColumnJSON
+	var c columnJSON
 	err := json.NewDecoder(resp.Body).Decode(&c)
 	if err != nil {
 		t.Fatalf("Column Decode() error = %v", err)
@@ -310,9 +310,9 @@ func parseColumn(t *testing.T, resp *http.Response) ColumnJSON {
 	return c
 }
 
-func parseColumnsList(t *testing.T, resp *http.Response) []ColumnJSON {
+func parseColumnsList(t *testing.T, resp *http.Response) []columnJSON {
 	t.Helper()
-	var c []ColumnJSON
+	var c []columnJSON
 	err := json.NewDecoder(resp.Body).Decode(&c)
 	if err != nil {
 		t.Fatalf("Columns list Decode() error = %v", err)
@@ -320,9 +320,9 @@ func parseColumnsList(t *testing.T, resp *http.Response) []ColumnJSON {
 	return c
 }
 
-func parseColumnPosition(t *testing.T, resp *http.Response) ColumnPositionJSON {
+func parseColumnPosition(t *testing.T, resp *http.Response) columnPositionJSON {
 	t.Helper()
-	var p ColumnPositionJSON
+	var p columnPositionJSON
 	err := json.NewDecoder(resp.Body).Decode(&p)
 	if err != nil {
 		t.Fatalf("Column position Decode() error = %v", err)

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -25,14 +25,14 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-type PreludeResult struct {
+type preludeResult struct {
 	HTTPClient  *http.Client
 	Server      *httptest.Server
 	Pool        *pgxpool.Pool
 	RedisClient *redis.Client
 }
 
-func Prelude(t *testing.T) PreludeResult {
+func prelude(t *testing.T) preludeResult {
 	t.Helper()
 
 	pool := testutil.SetupPostgres(t, "../migrations")
@@ -64,7 +64,7 @@ func Prelude(t *testing.T) PreludeResult {
 		_ = redisClient.Close()
 	})
 
-	return PreludeResult{
+	return preludeResult{
 		HTTPClient:  ts.Client(),
 		Server:      ts,
 		Pool:        pool,
@@ -72,7 +72,7 @@ func Prelude(t *testing.T) PreludeResult {
 	}
 }
 
-func Register(t *testing.T, c *http.Client, baseURL, email, password string) {
+func register(t *testing.T, c *http.Client, baseURL, email, password string) {
 	t.Helper()
 
 	body, err := json.Marshal(map[string]string{
@@ -96,7 +96,7 @@ func Register(t *testing.T, c *http.Client, baseURL, email, password string) {
 	}
 }
 
-func Login(t *testing.T, c *http.Client, baseURL, email, password string) string {
+func login(t *testing.T, c *http.Client, baseURL, email, password string) string {
 	t.Helper()
 
 	body, err := json.Marshal(map[string]string{
@@ -133,34 +133,34 @@ func Login(t *testing.T, c *http.Client, baseURL, email, password string) string
 	return out.Token
 }
 
-func E2ERegisterAndLogin(t *testing.T, c *http.Client, baseURL, email, password string) string {
+func e2eRegisterAndLogin(t *testing.T, c *http.Client, baseURL, email, password string) string {
 	t.Helper()
-	Register(t, c, baseURL, email, password)
+	register(t, c, baseURL, email, password)
 
-	return Login(t, c, baseURL, email, password)
+	return login(t, c, baseURL, email, password)
 }
 
-type AuthenticatedClient struct {
+type authenticatedClient struct {
 	Client  *http.Client
 	BaseURL string
 	Token   string
 }
 
-func CreateUserAndAuthenticateClient(t *testing.T, client *http.Client, baseURL string) *AuthenticatedClient {
+func createUserAndAuthenticateClient(t *testing.T, client *http.Client, baseURL string) *authenticatedClient {
 	t.Helper()
 
 	email := fmt.Sprintf("e2e-%s@example.com", uuid.NewString())
 	password := testutil.ValidPassword().String()
-	token := E2ERegisterAndLogin(t, client, baseURL, email, password)
+	token := e2eRegisterAndLogin(t, client, baseURL, email, password)
 
-	return &AuthenticatedClient{
+	return &authenticatedClient{
 		Client:  client,
 		BaseURL: baseURL,
 		Token:   token,
 	}
 }
 
-func (c *AuthenticatedClient) Do(t *testing.T, method, path string, body any) *http.Response {
+func (c *authenticatedClient) Do(t *testing.T, method, path string, body any) *http.Response {
 	t.Helper()
 
 	var rdr io.Reader = http.NoBody
@@ -194,7 +194,7 @@ func (c *AuthenticatedClient) Do(t *testing.T, method, path string, body any) *h
 	return resp
 }
 
-func WaitForTimestampTicker(t *testing.T) {
+func waitForTimestampTicker(t *testing.T) {
 	t.Helper()
 	time.Sleep(5 * time.Millisecond)
 }

--- a/tests/task_test.go
+++ b/tests/task_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 )
 
-type TaskJSON struct {
+type taskJSON struct {
 	ID          string `json:"id"`
 	ColumnID    string `json:"columnId"`
 	Name        string `json:"name"`
@@ -24,18 +24,18 @@ type TaskJSON struct {
 	UpdatedAt   string `json:"updatedAt"`
 }
 
-type TaskPositionJSON struct {
+type taskPositionJSON struct {
 	ColumnID string `json:"columnId"`
 	Position int64  `json:"position"`
 }
 
 func TestTask_HappyPath(t *testing.T) {
-	p := Prelude(t)
+	p := prelude(t)
 
 	testutil.TruncateAllTables(t, p.Pool)
 
 	// 1. Register (already done via ac client)
-	ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
+	ac := createUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
 
 	boardName := testutil.ValidBoardName().String()
 	boardDescription := testutil.ValidBoardDescription().String()
@@ -135,14 +135,14 @@ func TestTask_HappyPath(t *testing.T) {
 	if len(listedTasks) != 1 {
 		t.Fatalf("got %d tasks in list, want 1", len(listedTasks))
 	}
-	if diff := cmp.Diff(createdTask, listedTasks[0]); diff != "" {
+	if diff := cmp.Diff(createdTask, listedTasks[0], cmp.AllowUnexported(taskJSON{})); diff != "" {
 		t.Errorf("List item mismatch (-want +got):\n%s", diff)
 	}
 
 	// 5. Update by id with name and description, store response in updatedTask, validate fields, and ensure updatedAt advanced
 	updatedName := "Updated Name"
 	updatedDescription := "Updated description"
-	WaitForTimestampTicker(t)
+	waitForTimestampTicker(t)
 	updateResp := ac.Do(t, http.MethodPatch, "/v1/boards/"+board.ID+"/columns/"+columnA.ID+"/tasks/"+createdTask.ID, map[string]string{
 		"name":        updatedName,
 		"description": updatedDescription,
@@ -161,7 +161,7 @@ func TestTask_HappyPath(t *testing.T) {
 	checkTask.Name = createdTask.Name
 	checkTask.Description = createdTask.Description
 	checkTask.UpdatedAt = createdTask.UpdatedAt
-	if diff := cmp.Diff(createdTask, checkTask); diff != "" {
+	if diff := cmp.Diff(createdTask, checkTask, cmp.AllowUnexported(taskJSON{})); diff != "" {
 		t.Errorf("Update() diff (-want +got):\n%s", diff)
 	}
 
@@ -343,9 +343,9 @@ func TestTask_HappyPath(t *testing.T) {
 	}
 }
 
-func parseTask(t *testing.T, resp *http.Response) TaskJSON {
+func parseTask(t *testing.T, resp *http.Response) taskJSON {
 	t.Helper()
-	var tk TaskJSON
+	var tk taskJSON
 	err := json.NewDecoder(resp.Body).Decode(&tk)
 	if err != nil {
 		t.Fatalf("Task Decode() error = %v", err)
@@ -353,9 +353,9 @@ func parseTask(t *testing.T, resp *http.Response) TaskJSON {
 	return tk
 }
 
-func parseTasksList(t *testing.T, resp *http.Response) []TaskJSON {
+func parseTasksList(t *testing.T, resp *http.Response) []taskJSON {
 	t.Helper()
-	var tasks []TaskJSON
+	var tasks []taskJSON
 	err := json.NewDecoder(resp.Body).Decode(&tasks)
 	if err != nil {
 		t.Fatalf("Tasks list Decode() error = %v", err)
@@ -363,9 +363,9 @@ func parseTasksList(t *testing.T, resp *http.Response) []TaskJSON {
 	return tasks
 }
 
-func parseTaskPosition(t *testing.T, resp *http.Response) TaskPositionJSON {
+func parseTaskPosition(t *testing.T, resp *http.Response) taskPositionJSON {
 	t.Helper()
-	var p TaskPositionJSON
+	var p taskPositionJSON
 	err := json.NewDecoder(resp.Body).Decode(&p)
 	if err != nil {
 		t.Fatalf("Task position Decode() error = %v", err)

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -18,12 +18,12 @@ func TestUser_HappyPath(t *testing.T) {
 
 	t.Setenv("TELEGRAM_API_BASE_URL", mockTelegram.URL())
 
-	p := Prelude(t)
+	p := prelude(t)
 
 	testutil.TruncateAllTables(t, p.Pool)
 	testutil.FlushRedisDB(t, p.RedisClient)
 
-	ac := CreateUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
+	ac := createUserAndAuthenticateClient(t, p.HTTPClient, p.Server.URL)
 
 	// 1. Get Telegram link token.
 	linkResp := ac.Do(t, http.MethodPost, "/v1/users/me/telegram/link", nil)


### PR DESCRIPTION
### Related Issues
Refers to #194 

### Summary
Exported identifiers create noise, so this PR renames them when export is not needed.

### Verification
- [x] Tests are green

### Checklist
- [x] Code follows the style guidelines
- [ ] Unit, E2E, integration tests, load/race tests added or updated
- [x] Documentation updated
- [x] No sensitive data committed
