### PR TITLE
chore: prune unused Docker images daily

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,14 @@ Branch protection rules (GitHub):
 ## CD
 **Highly automated** pipeline below ensures a **secure**, **reproducible**, and **quick** way to get a hardened server with a running app in a few minutes:
 - Get VDS server, generate SSH keys, copy public key (manual)
-- Configure reverse proxy to handle HTTPS and high-level routing
+- Configure reverse proxy to handle HTTPS and high-level routing (manual)
 - Set up config in GitHub secrets (manual)
 - Install required packages
 - Configure unattended upgrades
 - Configure fail2ban
 - Configure log rotation
-- Start Docker service
+- Prune unused Docker images daily
+- Start Docker and Cron services
 - Disable root login and password authentication
 - Close all ports by default, except 443 and 80
 - Create user and app directory

--- a/infra/ansible/server-setup-ubuntu.yml
+++ b/infra/ansible/server-setup-ubuntu.yml
@@ -51,6 +51,7 @@
           - docker-ce-cli
           - containerd.io
           - docker-compose-plugin
+          - cron
         state: present
 
     - name: Configure unattended-upgrades (Daily Schedule)
@@ -97,6 +98,20 @@
           }
         mode: "0644"
       notify: Restart Docker
+
+    - name: Prune unused Docker images daily
+      cron:
+        name: Prune unused Docker images
+        user: root
+        minute: "0"
+        hour: "4"
+        job: '/usr/bin/docker image prune -af'
+
+    - name: Ensure cron is running
+      service:
+        name: cron
+        state: started
+        enabled: yes
 
     - name: Ensure Docker is running
       service:


### PR DESCRIPTION
### Summary
Images become dangling after updates and take a decent amount of space for no reason. To avoid this, the PR adds daily Cron job to prune the images.

### Verification
- [x] Tested after deployment to staging

### Checklist
- [x] Code follows the style guidelines
- [x] Unit, E2E, integration tests, load/race tests added or updated
- [x] Documentation updated
- [x] No sensitive data committed
